### PR TITLE
SDK-1093 Conditionally use either consumer or B2B client in WebAuthenticationSessionClient

### DIFF
--- a/Sources/StytchCore/ClientType.swift
+++ b/Sources/StytchCore/ClientType.swift
@@ -1,0 +1,13 @@
+//
+//  File.swift
+//  
+//
+//  Created by Jordan Haven on 7/17/23.
+//
+
+import Foundation
+
+internal enum ClientType {
+    case Consumer
+    case B2B
+}

--- a/Sources/StytchCore/ClientType.swift
+++ b/Sources/StytchCore/ClientType.swift
@@ -1,13 +1,6 @@
-//
-//  File.swift
-//  
-//
-//  Created by Jordan Haven on 7/17/23.
-//
-
 import Foundation
 
 internal enum ClientType {
-    case Consumer
-    case B2B
+    case consumer
+    case b2b
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO.swift
@@ -53,7 +53,8 @@ public extension StytchB2BClient {
             let webClientParams: WebAuthenticationSessionClient.Parameters = .init(
                 url: url,
                 callbackUrlScheme: callbackScheme,
-                presentationContextProvider: parameters.presentationContextProvider ?? WebAuthenticationSessionClient.DefaultPresentationProvider()
+                presentationContextProvider: parameters.presentationContextProvider ?? WebAuthenticationSessionClient.DefaultPresentationProvider(),
+                clientType: ClientType.B2B
             )
             #else
             let webClientParams: WebAuthenticationSessionClient.Parameters = .init(url: url, callbackUrlScheme: callbackScheme)

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO.swift
@@ -54,7 +54,7 @@ public extension StytchB2BClient {
                 url: url,
                 callbackUrlScheme: callbackScheme,
                 presentationContextProvider: parameters.presentationContextProvider ?? WebAuthenticationSessionClient.DefaultPresentationProvider(),
-                clientType: ClientType.B2B
+                clientType: ClientType.b2b
             )
             #else
             let webClientParams: WebAuthenticationSessionClient.Parameters = .init(url: url, callbackUrlScheme: callbackScheme)

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO.swift
@@ -57,7 +57,7 @@ public extension StytchB2BClient {
                 clientType: ClientType.b2b
             )
             #else
-            let webClientParams: WebAuthenticationSessionClient.Parameters = .init(url: url, callbackUrlScheme: callbackScheme)
+            let webClientParams: WebAuthenticationSessionClient.Parameters = .init(url: url, callbackUrlScheme: callbackScheme, clientType: ClientType.b2b)
             #endif
             return try await webAuthSessionClient.initiate(parameters: webClientParams)
         }

--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
@@ -57,7 +57,7 @@ public extension StytchClient.OAuth {
                 clientType: ClientType.consumer
             )
             #else
-            let webClientParams: WebAuthenticationSessionClient.Parameters = .init(url: url, callbackUrlScheme: callbackScheme)
+            let webClientParams: WebAuthenticationSessionClient.Parameters = .init(url: url, callbackUrlScheme: callbackScheme, clientType: ClientType.consumer)
             #endif
             return try await webAuthSessionClient.initiate(parameters: webClientParams)
         }

--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
@@ -54,7 +54,7 @@ public extension StytchClient.OAuth {
                 url: url,
                 callbackUrlScheme: callbackScheme,
                 presentationContextProvider: parameters.presentationContextProvider ?? WebAuthenticationSessionClient.DefaultPresentationProvider(),
-                clientType: ClientType.Consumer
+                clientType: ClientType.consumer
             )
             #else
             let webClientParams: WebAuthenticationSessionClient.Parameters = .init(url: url, callbackUrlScheme: callbackScheme)

--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
@@ -53,7 +53,8 @@ public extension StytchClient.OAuth {
             let webClientParams: WebAuthenticationSessionClient.Parameters = .init(
                 url: url,
                 callbackUrlScheme: callbackScheme,
-                presentationContextProvider: parameters.presentationContextProvider ?? WebAuthenticationSessionClient.DefaultPresentationProvider()
+                presentationContextProvider: parameters.presentationContextProvider ?? WebAuthenticationSessionClient.DefaultPresentationProvider(),
+                clientType: ClientType.Consumer
             )
             #else
             let webClientParams: WebAuthenticationSessionClient.Parameters = .init(url: url, callbackUrlScheme: callbackScheme)

--- a/Sources/StytchCore/WebAuthenticationSessionClient/WebAuthenticationSessionClient+Live.swift
+++ b/Sources/StytchCore/WebAuthenticationSessionClient/WebAuthenticationSessionClient+Live.swift
@@ -15,11 +15,19 @@ extension WebAuthenticationSessionClient {
                     return
                 }
                 do {
-                    guard let token = try StytchClient.tokenValues(for: url)?.1 else {
-                        continuation.resume(throwing: StytchError.missingDeeplinkToken)
-                        return
+                    if (parameters.clientType == ClientType.Consumer) {
+                        guard let token = try StytchClient.tokenValues(for: url)?.1 else {
+                            continuation.resume(throwing: StytchError.missingDeeplinkToken)
+                            return
+                        }
+                        continuation.resume(returning: (token, url))
+                    } else {
+                        guard let token = try StytchB2BClient.tokenValues(for: url)?.1 else {
+                            continuation.resume(throwing: StytchError.missingDeeplinkToken)
+                            return
+                        }
+                        continuation.resume(returning: (token, url))
                     }
-                    continuation.resume(returning: (token, url))
                 } catch {
                     continuation.resume(throwing: error)
                 }

--- a/Sources/StytchCore/WebAuthenticationSessionClient/WebAuthenticationSessionClient+Live.swift
+++ b/Sources/StytchCore/WebAuthenticationSessionClient/WebAuthenticationSessionClient+Live.swift
@@ -15,7 +15,7 @@ extension WebAuthenticationSessionClient {
                     return
                 }
                 do {
-                    if (parameters.clientType == ClientType.Consumer) {
+                    if parameters.clientType == ClientType.consumer {
                         guard let token = try StytchClient.tokenValues(for: url)?.1 else {
                             continuation.resume(throwing: StytchError.missingDeeplinkToken)
                             return

--- a/Sources/StytchCore/WebAuthenticationSessionClient/WebAuthenticationSessionClient.swift
+++ b/Sources/StytchCore/WebAuthenticationSessionClient/WebAuthenticationSessionClient.swift
@@ -25,6 +25,7 @@ extension WebAuthenticationSessionClient {
         #if !os(tvOS)
         let presentationContextProvider: ASWebAuthenticationPresentationContextProviding
         #endif
+        let clientType: ClientType
     }
 }
 #endif


### PR DESCRIPTION
Not sure if this is the Swiftiest way to accomplish this (tried to pass in the instance of the StytchClientType, but ran into compilation issues), but this works in the Workbench app.