### PR TITLE
[TECH-481] Use prod_cdn updater credentials in publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,5 +24,5 @@ jobs:
     - name: Publish to Carthage
       run: bundle exec Scripts/publish-to-carthage $(Scripts/version show-current)
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.PROD_CDN_UPDATER_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_CDN_UPDATER_AWS_SECRET_ACCESS_KEY_ID }}


### PR DESCRIPTION
Use correct credentials to allow publishing to S3.