### PR TITLE
DFP: Inject webview and fetch telemetry ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,9 @@ fastlane/test_output
 # Demo
 StytchDemo/*file.lock*
 !StytchDemo/StytchDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
-
+StytchDemo/Client/Shared/StytchConfiguration.plist
+StytchDemo/Client/iOS/iOS.entitlements
+StytchDemo/Client/macOS/macOS.entitlements
 # Dependencies
 .mint/
 .bundle/

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     dependencies: [],
     targets: [
         .target(name: "StytchCore", resources: [
-            .copy("DFPClient/dfp.html")
+            .copy("DFPClient/dfp.html"),
         ]),
         .testTarget(name: "StytchCoreTests", dependencies: ["StytchCore"]),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,9 @@ let package = Package(
     ],
     dependencies: [],
     targets: [
-        .target(name: "StytchCore"),
+        .target(name: "StytchCore", resources: [
+            .copy("DFPClient/dfp.html")
+        ]),
         .testTarget(name: "StytchCoreTests", dependencies: ["StytchCore"]),
     ]
 )

--- a/Sources/StytchCore/DFPClient/DFPClient+live.swift
+++ b/Sources/StytchCore/DFPClient/DFPClient+live.swift
@@ -2,74 +2,75 @@ import Foundation
 import UIKit
 import WebKit
 
-final class MessageHandler : NSObject, WKScriptMessageHandler {
+final class MessageHandler: NSObject, WKScriptMessageHandler {
     var continuation: CheckedContinuation<String, Never>
+
     init(continuation: CheckedContinuation<String, Never>) {
         self.continuation = continuation
     }
-    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+
+    func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
         continuation.resume(returning: message.body as? String ?? "")
     }
 }
 
 extension DFPClient {
-    static let live: Self = .init(
-        getTelemetryId: {
-            guard let publicToken = StytchClient.instance.configuration?.publicToken else { throw StytchError.clientNotConfigured }
-            return await withCheckedContinuation { continuation in
-                DispatchQueue.main.async {
-                    Task {
-                        if let topViewController = UIApplication.shared.topMostViewController {
-                            let messageHandler = MessageHandler(continuation: continuation)
-                            let dfpFileUrl = Bundle.module.url(forResource: "dfp", withExtension: "html")!
-                            let userScript = WKUserScript(source: "fetchTelemetryId('\(publicToken)')", injectionTime: .atDocumentEnd, forMainFrameOnly: true)
-                            let userContentController = WKUserContentController()
-                            userContentController.addUserScript(userScript)
-                            userContentController.add(messageHandler, name: "StytchDFP")
-                            let configuration = WKWebViewConfiguration()
-                            configuration.userContentController = userContentController
-                            let webView = WKWebView(frame: CGRect.zero, configuration: configuration)
-                            topViewController.view.addSubview(webView)
-                            webView.loadFileURL(dfpFileUrl, allowingReadAccessTo: dfpFileUrl)
-                        } else {
-                            continuation.resume(returning: "unable to inject telemetry webview")
+    static let live: Self = .init {
+        guard let publicToken = StytchClient.instance.configuration?.publicToken else { throw StytchError.clientNotConfigured }
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                Task {
+                    if let topViewController = UIApplication.shared.topMostViewController {
+                        guard let dfpFileUrl = Bundle.module.url(forResource: "dfp", withExtension: "html") else {
+                            continuation.resume(returning: "Unable to load DFP file")
+                            return
                         }
+                        let messageHandler = MessageHandler(continuation: continuation)
+                        let userScript = WKUserScript(source: "fetchTelemetryId('\(publicToken)')", injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+                        let userContentController = WKUserContentController()
+                        userContentController.addUserScript(userScript)
+                        userContentController.add(messageHandler, name: "StytchDFP")
+                        let configuration = WKWebViewConfiguration()
+                        configuration.userContentController = userContentController
+                        let webView = WKWebView(frame: CGRect.zero, configuration: configuration)
+                        topViewController.view.addSubview(webView)
+                        webView.loadFileURL(dfpFileUrl, allowingReadAccessTo: dfpFileUrl)
+                    } else {
+                        continuation.resume(returning: "unable to inject telemetry webview")
                     }
                 }
             }
         }
-    )
-    
+    }
 }
 
 extension UIViewController {
-  var topMostViewController : UIViewController {
+    var topMostViewController: UIViewController {
+        if let presented = presentedViewController {
+            return presented.topMostViewController
+        }
 
-    if let presented = self.presentedViewController {
-      return presented.topMostViewController
+        if let navigation = self as? UINavigationController {
+            return navigation.visibleViewController?.topMostViewController ?? navigation
+        }
+
+        if let tab = self as? UITabBarController {
+            return tab.selectedViewController?.topMostViewController ?? tab
+        }
+
+        return self
     }
-
-    if let navigation = self as? UINavigationController {
-      return navigation.visibleViewController?.topMostViewController ?? navigation
-    }
-
-    if let tab = self as? UITabBarController {
-      return tab.selectedViewController?.topMostViewController ?? tab
-    }
-
-    return self
-  }
 }
 
 extension UIApplication {
-  var topMostViewController : UIViewController? {
-      let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
-      if var topController = keyWindow?.rootViewController {
-          while let presentedViewController = topController.presentedViewController {
-              topController = presentedViewController
-          }
-          return topController
-      }
-      return nil
-  }
+    var topMostViewController: UIViewController? {
+        let keyWindow = UIApplication.shared.windows.first { $0.isKeyWindow }
+        if var topController = keyWindow?.rootViewController {
+            while let presentedViewController = topController.presentedViewController {
+                topController = presentedViewController
+            }
+            return topController
+        }
+        return nil
+    }
 }

--- a/Sources/StytchCore/DFPClient/DFPClient+live.swift
+++ b/Sources/StytchCore/DFPClient/DFPClient+live.swift
@@ -1,0 +1,70 @@
+import Foundation
+import UIKit
+import WebKit
+
+final class MessageHandler : NSObject, WKScriptMessageHandler {
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        print(message.body)
+    }
+}
+
+extension DFPClient {
+    static let live: Self = .init(
+        getTelemetryId: {
+            guard let publicToken = StytchClient.instance.configuration?.publicToken else { throw StytchError.clientNotConfigured }
+            DispatchQueue.main.async {
+                Task {
+                    do {
+                        if let topViewController = UIApplication.shared.topMostViewController {
+                            let webConfiguration = WKWebViewConfiguration()
+                            let messageHandler = MessageHandler()
+                            let dfpFileUrl = Bundle.module.url(forResource: "dfp", withExtension: "html")!
+                            let userScript = WKUserScript(source: "fetchTelemetryId('\(publicToken)')", injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+                            let userContentController = WKUserContentController()
+                            userContentController.addUserScript(userScript)
+                            userContentController.add(messageHandler, name: "StytchDFP")
+                            let configuration = WKWebViewConfiguration()
+                            configuration.userContentController = userContentController
+                            let webView = WKWebView(frame: CGRect.zero, configuration: configuration)
+                            topViewController.view.addSubview(webView)
+                            webView.loadFileURL(dfpFileUrl, allowingReadAccessTo: dfpFileUrl)
+                        }
+                    }
+                }
+            }
+            return ""
+        }
+    )
+}
+
+extension UIViewController {
+  var topMostViewController : UIViewController {
+
+    if let presented = self.presentedViewController {
+      return presented.topMostViewController
+    }
+
+    if let navigation = self as? UINavigationController {
+      return navigation.visibleViewController?.topMostViewController ?? navigation
+    }
+
+    if let tab = self as? UITabBarController {
+      return tab.selectedViewController?.topMostViewController ?? tab
+    }
+
+    return self
+  }
+}
+
+extension UIApplication {
+  var topMostViewController : UIViewController? {
+      let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+      if var topController = keyWindow?.rootViewController {
+          while let presentedViewController = topController.presentedViewController {
+              topController = presentedViewController
+          }
+          return topController
+      }
+      return nil
+  }
+}

--- a/Sources/StytchCore/DFPClient/DFPClient+live.swift
+++ b/Sources/StytchCore/DFPClient/DFPClient+live.swift
@@ -1,3 +1,4 @@
+#if os(iOS)
 import Foundation
 import UIKit
 import WebKit
@@ -74,3 +75,4 @@ extension UIApplication {
         return nil
     }
 }
+#endif

--- a/Sources/StytchCore/DFPClient/DFPClient.swift
+++ b/Sources/StytchCore/DFPClient/DFPClient.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 struct DFPClient {
-    var getTelemetryId: () async throws -> String?
-    init(getTelemetryId: @escaping () async throws -> String?) {
+    var getTelemetryId: () async throws -> String
+    init(getTelemetryId: @escaping () async throws -> String) {
         self.getTelemetryId = getTelemetryId
     }
 }

--- a/Sources/StytchCore/DFPClient/DFPClient.swift
+++ b/Sources/StytchCore/DFPClient/DFPClient.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct DFPClient {
+    var getTelemetryId: () async throws -> String?
+    init(getTelemetryId: @escaping () async throws -> String?) {
+        self.getTelemetryId = getTelemetryId
+    }
+}

--- a/Sources/StytchCore/DFPClient/DFPClient.swift
+++ b/Sources/StytchCore/DFPClient/DFPClient.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct DFPClient {
     var getTelemetryId: () async throws -> String
+
     init(getTelemetryId: @escaping () async throws -> String) {
         self.getTelemetryId = getTelemetryId
     }

--- a/Sources/StytchCore/DFPClient/dfp.html
+++ b/Sources/StytchCore/DFPClient/dfp.html
@@ -8,7 +8,7 @@
             function fetchTelemetryId(publicToken) {
                 window.GetTelemetryID(publicToken)
                     .then((telemetryId) => window.webkit.messageHandlers.StytchDFP.postMessage(telemetryId))
-                    .catch(console.error);
+                    .catch((error) => window.webkit.messageHandlers.StytchDFP.postMessage(error.message));
             }
         </script>
     </body>

--- a/Sources/StytchCore/DFPClient/dfp.html
+++ b/Sources/StytchCore/DFPClient/dfp.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+    <head>
+        <script src="https://elements.stytch.com/telemetry_debug.js"></script>
+    </head>
+    <body>
+        <script>
+            function fetchTelemetryId(publicToken) {
+                window.GetTelemetryID(publicToken)
+                    .then((telemetryId) => window.webkit.messageHandlers.StytchDFP.postMessage(telemetryId))
+                    .catch(console.error);
+            }
+        </script>
+    </body>
+</html>

--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -97,6 +97,8 @@ struct Environment {
     }
     #endif
 
+    var dfpClient: DFPClient = .live
+
     var date: () -> Date = Date.init
 
     var uuid: () -> UUID = UUID.init

--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -96,9 +96,9 @@ struct Environment {
         set { _passkeysClent = newValue }
     }
     #endif
-
+    #if os(iOS)
     var dfpClient: DFPClient = .live
-
+    #endif
     var date: () -> Date = Date.init
 
     var uuid: () -> UUID = UUID.init

--- a/Sources/StytchCore/NetworkingClient/NetworkingClient+Live.swift
+++ b/Sources/StytchCore/NetworkingClient/NetworkingClient+Live.swift
@@ -2,11 +2,15 @@ import Foundation
 
 extension NetworkingClient {
     static let live: NetworkingClient = {
+        #if os(iOS)
         @Dependency(\.dfpClient) var dfpClient
+        #endif
         let session: URLSession = .init(configuration: .default)
         return .init { request in
+            #if os(iOS)
             let dfpTelemetryId = try await dfpClient.getTelemetryId()
             print("TELEMETRY ID: \(dfpTelemetryId)")
+            #endif
             if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
                 let (data, response) = try await session.data(for: request)
                 guard let response = response as? HTTPURLResponse else { throw NetworkingClient.Error.nonHttpResponse }

--- a/Sources/StytchCore/NetworkingClient/NetworkingClient+Live.swift
+++ b/Sources/StytchCore/NetworkingClient/NetworkingClient+Live.swift
@@ -2,8 +2,10 @@ import Foundation
 
 extension NetworkingClient {
     static let live: NetworkingClient = {
+        @Dependency(\.dfpClient) var dfpClient
         let session: URLSession = .init(configuration: .default)
         return .init { request in
+            let dfpTelemetryId = try await dfpClient.getTelemetryId()
             if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
                 let (data, response) = try await session.data(for: request)
                 guard let response = response as? HTTPURLResponse else { throw NetworkingClient.Error.nonHttpResponse }

--- a/Sources/StytchCore/NetworkingClient/NetworkingClient+Live.swift
+++ b/Sources/StytchCore/NetworkingClient/NetworkingClient+Live.swift
@@ -6,6 +6,7 @@ extension NetworkingClient {
         let session: URLSession = .init(configuration: .default)
         return .init { request in
             let dfpTelemetryId = try await dfpClient.getTelemetryId()
+            print("TELEMETRY ID: \(dfpTelemetryId)")
             if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
                 let (data, response) = try await session.data(for: request)
                 guard let response = response as? HTTPURLResponse else { throw NetworkingClient.Error.nonHttpResponse }

--- a/Sources/StytchCore/StytchClientCommon/StytchClientType.swift
+++ b/Sources/StytchCore/StytchClientCommon/StytchClientType.swift
@@ -38,6 +38,8 @@ extension StytchClientType {
 
     private var uuid: () -> UUID { Current.uuid }
 
+    private var dfpClient: DFPClient { Current.dfpClient }
+
     // swiftlint:disable:next identifier_name
     static func _configure(publicToken: String, hostUrl: URL? = nil) {
         instance.configuration = .init(publicToken: publicToken, hostUrl: hostUrl)

--- a/Sources/StytchCore/StytchClientCommon/StytchClientType.swift
+++ b/Sources/StytchCore/StytchClientCommon/StytchClientType.swift
@@ -37,9 +37,9 @@ extension StytchClientType {
     private var clientInfo: ClientInfo { Current.clientInfo }
 
     private var uuid: () -> UUID { Current.uuid }
-
+    #if os(iOS)
     private var dfpClient: DFPClient { Current.dfpClient }
-
+    #endif
     // swiftlint:disable:next identifier_name
     static func _configure(publicToken: String, hostUrl: URL? = nil) {
         instance.configuration = .init(publicToken: publicToken, hostUrl: hostUrl)

--- a/StytchDemo/Client/Shared/StytchConfiguration.plist
+++ b/StytchDemo/Client/Shared/StytchConfiguration.plist
@@ -5,6 +5,6 @@
 	<key>StytchHostURL</key>
 	<string>https://example.com</string>
 	<key>StytchPublicToken</key>
-	<string>public-token-test-1944a878-2aa8-47ea-a580-01b22e46c7f4</string>
+	<string>public-token-example</string>
 </dict>
 </plist>

--- a/StytchDemo/Client/Shared/StytchConfiguration.plist
+++ b/StytchDemo/Client/Shared/StytchConfiguration.plist
@@ -5,6 +5,6 @@
 	<key>StytchHostURL</key>
 	<string>https://example.com</string>
 	<key>StytchPublicToken</key>
-	<string>public-token-example</string>
+	<string>public-token-test-1944a878-2aa8-47ea-a580-01b22e46c7f4</string>
 </dict>
 </plist>

--- a/StytchDemo/StytchDemo.xcodeproj/xcshareddata/xcschemes/StytchDemo (iOS).xcscheme
+++ b/StytchDemo/StytchDemo.xcodeproj/xcshareddata/xcschemes/StytchDemo (iOS).xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "229B82172809EA3F007BC3F1"
+               BuildableName = "StytchDemo.app"
+               BlueprintName = "StytchDemo (iOS)"
+               ReferencedContainer = "container:StytchDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "229B82172809EA3F007BC3F1"
+            BuildableName = "StytchDemo.app"
+            BlueprintName = "StytchDemo (iOS)"
+            ReferencedContainer = "container:StytchDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "229B82172809EA3F007BC3F1"
+            BuildableName = "StytchDemo.app"
+            BlueprintName = "StytchDemo (iOS)"
+            ReferencedContainer = "container:StytchDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Linear Ticket: [SDK-1133](https://linear.app/stytch/issue/SDK-1129)

Doing this a little bit out of order, but this is functionality for injecting the webview and awaiting the telemetry ID