### PR TITLE
DFP: Inject telemetry ID and captcha token as necessary

### DIFF
--- a/Sources/StytchCore/NetworkingClient/NetworkingClient+Live.swift
+++ b/Sources/StytchCore/NetworkingClient/NetworkingClient+Live.swift
@@ -8,19 +8,36 @@ extension NetworkingClient {
         #endif
         let session: URLSession = .init(configuration: .default)
         return .init { request, dfpEnabled, publicToken in
+            var newRequest: URLRequest = request
             #if os(iOS)
             if dfpEnabled == true {
-                let dfpTelemetryId = try await dfpClient.getTelemetryId(publicToken)
-                let captchaToken = try await captcha.executeRecaptcha()
+                let oldBody = newRequest.httpBody ?? Data()
+                var newBody = try JSONSerialization.jsonObject(with: oldBody) as! Dictionary<String, AnyObject>
+                newBody["dfp_telemetry_id"] = try await dfpClient.getTelemetryId(publicToken) as AnyObject
+                let bodyWithDfp = try JSONSerialization.data(withJSONObject: newBody)
+                newRequest.httpBody = bodyWithDfp
             }
             #endif
             if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
-                let (data, response) = try await session.data(for: request)
+                let (data, response) = try await session.data(for: newRequest)
                 guard let response = response as? HTTPURLResponse else { throw NetworkingClient.Error.nonHttpResponse }
+                #if os(iOS)
+                if dfpEnabled == true && response.statusCode == 403 {
+                    let oldBody = newRequest.httpBody ?? Data()
+                    var newBody = try JSONSerialization.jsonObject(with: newRequest.httpBody!) as! Dictionary<String, AnyObject>
+                    newBody["dfp_telemetry_id"] = try await dfpClient.getTelemetryId(publicToken) as AnyObject
+                    newBody["captcha_token"] = try await captcha.executeRecaptcha() as AnyObject
+                    let bodyWithDfp = try JSONSerialization.data(withJSONObject: newBody)
+                    newRequest.httpBody = bodyWithDfp
+                    let (captchaData, captchaResponse) = try await session.data(for: newRequest)
+                    guard let captchaResponse = captchaResponse as? HTTPURLResponse else { throw NetworkingClient.Error.nonHttpResponse }
+                    return (data, response)
+                }
+                #endif
                 return (data, response)
             } else {
                 return try await withCheckedThrowingContinuation { continuation in
-                    let task = session.dataTask(with: request) { data, response, error in
+                    let task = session.dataTask(with: newRequest) { data, response, error in
                         if let error = error {
                             continuation.resume(with: .failure(error))
                             return
@@ -33,6 +50,35 @@ extension NetworkingClient {
                             continuation.resume(with: .failure(NetworkingClient.Error.nonHttpResponse))
                             return
                         }
+                        #if os(iOS)
+                        if dfpEnabled == true && response.statusCode == 403 {
+                            Task {
+                                var captchaRequest = newRequest
+                                let oldBody = captchaRequest.httpBody ?? Data()
+                                var newBody = try JSONSerialization.jsonObject(with: oldBody) as! Dictionary<String, AnyObject>
+                                newBody["dfp_telemetry_id"] = try await dfpClient.getTelemetryId(publicToken) as AnyObject
+                                newBody["captcha_token"] = try await captcha.executeRecaptcha() as AnyObject
+                                let bodyWithDfp = try JSONSerialization.data(withJSONObject: newBody)
+                                captchaRequest.httpBody = bodyWithDfp
+                                session.dataTask(with: captchaRequest) { data, response, error in
+                                    if let error = error {
+                                        continuation.resume(with: .failure(error))
+                                        return
+                                    }
+                                    guard let data = data else {
+                                        continuation.resume(with: .failure(NetworkingClient.Error.missingData))
+                                        return
+                                    }
+                                    guard let response = response as? HTTPURLResponse else {
+                                        continuation.resume(with: .failure(NetworkingClient.Error.nonHttpResponse))
+                                        return
+                                    }
+                                    continuation.resume(with: .success((data, response)))
+                                }.resume()
+                            }
+                            return
+                        }
+                        #endif
                         continuation.resume(with: .success((data, response)))
                     }
                     task.resume()


### PR DESCRIPTION
Linear Ticket: [SDK-1134](https://linear.app/stytch/issue/SDK-1134)

- If DFP is enabled, inject dfp_telemetry_id
- If DFP is enabled and response is 403, inject dfp_telemetry_id and captcha_token and rerun the request