### PR TITLE
Fix issue when siteKey doesnt exist

### DIFF
--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Bootstrap.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Bootstrap.swift
@@ -11,8 +11,8 @@ extension StytchB2BClient {
             guard let publicToken = StytchB2BClient.instance.configuration?.publicToken else { throw StytchError.clientNotConfigured }
             let bootstrapData = try await router.get(route: .fetch(Path(rawValue: publicToken))) as BootstrapResponse
             #if os(iOS)
-            if !bootstrapData.wrapped.captchaSettings.siteKey.isEmpty {
-                try await captcha.setCaptchaClient(siteKey: bootstrapData.wrapped.captchaSettings.siteKey)
+            if bootstrapData.wrapped.captchaSettings.siteKey != nil {
+                try await captcha.setCaptchaClient(siteKey: bootstrapData.wrapped.captchaSettings.siteKey!)
             }
             networkingClient.dfpEnabled = bootstrapData.wrapped.dfpProtectedAuthEnabled
             #endif

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Bootstrap.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Bootstrap.swift
@@ -11,10 +11,11 @@ extension StytchB2BClient {
             guard let publicToken = StytchB2BClient.instance.configuration?.publicToken else { throw StytchError.clientNotConfigured }
             let bootstrapData = try await router.get(route: .fetch(Path(rawValue: publicToken))) as BootstrapResponse
             #if os(iOS)
-            if bootstrapData.wrapped.captchaSettings.siteKey != nil {
-                try await captcha.setCaptchaClient(siteKey: bootstrapData.wrapped.captchaSettings.siteKey!)
-            }
             networkingClient.dfpEnabled = bootstrapData.wrapped.dfpProtectedAuthEnabled
+            guard let siteKey = bootstrapData.wrapped.captchaSettings.siteKey else {
+                return
+            }
+            try await captcha.setCaptchaClient(siteKey: siteKey)
             #endif
         }
     }

--- a/Sources/StytchCore/StytchClient/Bootstrap/StytchClient+Bootstrap.swift
+++ b/Sources/StytchCore/StytchClient/Bootstrap/StytchClient+Bootstrap.swift
@@ -11,8 +11,8 @@ extension StytchClient {
             guard let publicToken = StytchClient.instance.configuration?.publicToken else { throw StytchError.clientNotConfigured }
             let bootstrapData = try await router.get(route: .fetch(Path(rawValue: publicToken))) as BootstrapResponse
             #if os(iOS)
-            if !bootstrapData.wrapped.captchaSettings.siteKey.isEmpty {
-                try await captcha.setCaptchaClient(siteKey: bootstrapData.wrapped.captchaSettings.siteKey)
+            if bootstrapData.wrapped.captchaSettings.siteKey != nil {
+                try await captcha.setCaptchaClient(siteKey: bootstrapData.wrapped.captchaSettings.siteKey!)
             }
             networkingClient.dfpEnabled = bootstrapData.wrapped.dfpProtectedAuthEnabled
             #endif

--- a/Sources/StytchCore/StytchClient/Bootstrap/StytchClient+Bootstrap.swift
+++ b/Sources/StytchCore/StytchClient/Bootstrap/StytchClient+Bootstrap.swift
@@ -11,10 +11,11 @@ extension StytchClient {
             guard let publicToken = StytchClient.instance.configuration?.publicToken else { throw StytchError.clientNotConfigured }
             let bootstrapData = try await router.get(route: .fetch(Path(rawValue: publicToken))) as BootstrapResponse
             #if os(iOS)
-            if bootstrapData.wrapped.captchaSettings.siteKey != nil {
-                try await captcha.setCaptchaClient(siteKey: bootstrapData.wrapped.captchaSettings.siteKey!)
-            }
             networkingClient.dfpEnabled = bootstrapData.wrapped.dfpProtectedAuthEnabled
+            guard let siteKey = bootstrapData.wrapped.captchaSettings.siteKey else {
+                return
+            }
+            try await captcha.setCaptchaClient(siteKey: siteKey)
             #endif
         }
     }

--- a/Sources/StytchCore/StytchClientCommon/Models/BootstrapResponse.swift
+++ b/Sources/StytchCore/StytchClientCommon/Models/BootstrapResponse.swift
@@ -36,5 +36,5 @@ public struct BootstrapResponseData: Codable, BootstrapResponseDataType {
 
 public struct CaptchaSettings: Codable {
     public let enabled: Bool
-    public let siteKey: String
+    public let siteKey: String?
 }


### PR DESCRIPTION
With the changes to WB, siteKey is not guaranteed to be returned if CAPTCHA is not configured. This was breaking the marshalling of the response to a BoostrapResponse type, so we were not configuring DFP even when it was turned on.