### PR TITLE
SDK-1174 password reset by session

### DIFF
--- a/Sources/StytchCore/Generated/StytchClient.Passwords.resetBySession+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.Passwords.resetBySession+AsyncVariants.generated.swift
@@ -1,0 +1,37 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchClient.Passwords {
+    /// This method resets the user’s password using their existing session. The endpoint will error if the session does not have a password, email magic link, or email OTP authentication factor that has been issued within the last 5 minutes.
+    /// 
+    /// The provided password needs to meet our password strength requirements, which can be checked in advance with the password strength endpoint. If the token and password are accepted, the password is securely stored for future authentication and the user is authenticated.
+    func resetBySession(parameters: ResetBySessionParameters, completion: @escaping Completion<AuthenticateResponse>) {
+        Task {
+            do {
+                completion(.success(try await resetBySession(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// This method resets the user’s password using their existing session. The endpoint will error if the session does not have a password, email magic link, or email OTP authentication factor that has been issued within the last 5 minutes.
+    /// 
+    /// The provided password needs to meet our password strength requirements, which can be checked in advance with the password strength endpoint. If the token and password are accepted, the password is securely stored for future authentication and the user is authenticated.
+    func resetBySession(parameters: ResetBySessionParameters) -> AnyPublisher<AuthenticateResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await resetBySession(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/StytchClient/Passwords/PasswordsRoute.swift
+++ b/Sources/StytchCore/StytchClient/Passwords/PasswordsRoute.swift
@@ -3,6 +3,7 @@ enum PasswordsRoute: RouteType {
     case resetByEmail(TaskStageRoute)
     case authenticate
     case strengthCheck
+    case resetBySession
 
     var path: Path {
         switch self {
@@ -14,6 +15,8 @@ enum PasswordsRoute: RouteType {
             return "authenticate"
         case .strengthCheck:
             return "strength_check"
+        case .resetBySession:
+            return "session/reset"
         }
     }
 }

--- a/Sources/StytchCore/StytchClient/Passwords/StytchClient+Passwords.swift
+++ b/Sources/StytchCore/StytchClient/Passwords/StytchClient+Passwords.swift
@@ -75,6 +75,14 @@ public extension StytchClient {
         public func strengthCheck(parameters: StrengthCheckParameters) async throws -> StrengthCheckResponse {
             try await router.post(to: .strengthCheck, parameters: parameters)
         }
+
+        // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
+        /// This method resets the user’s password using their existing session. The endpoint will error if the session does not have a password, email magic link, or email OTP authentication factor that has been issued within the last 5 minutes.
+        ///
+        /// The provided password needs to meet our password strength requirements, which can be checked in advance with the password strength endpoint. If the token and password are accepted, the password is securely stored for future authentication and the user is authenticated.
+        public func resetBySession(parameters: ResetBySessionParameters) async throws -> AuthenticateResponse {
+            try await router.post(to: .resetBySession, parameters: parameters)
+        }
     }
 }
 
@@ -174,6 +182,24 @@ public extension StytchClient.Passwords {
         ///   - sessionDuration: The duration of the requested session.
         public init(token: String, password: String, sessionDuration: Minutes = .defaultSessionDuration) {
             self.token = token
+            self.password = password
+            self.sessionDuration = sessionDuration
+        }
+    }
+}
+
+public extension StytchClient.Passwords {
+    /// The dedicated parameters type for passwords `resetBySession` calls
+    struct ResetBySessionParameters: Encodable {
+        private enum CodingKeys: String, CodingKey { case password, sessionDuration = "sessionDurationMinutes" }
+
+        public let password: String
+        public let sessionDuration: Minutes
+
+        /// - Parameters:
+        ///   - password: The user's updated password.
+        ///   - sessionDuration: The duration of the requested session.
+        public init(password: String, sessionDuration: Minutes = .defaultSessionDuration) {
             self.password = password
             self.sessionDuration = sessionDuration
         }

--- a/Tests/StytchCoreTests/PasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/PasswordsTestCase.swift
@@ -3,6 +3,7 @@ import XCTest
 
 final class PasswordsTestCase: BaseTestCase {
     private let passwordParams: StytchClient.Passwords.PasswordParameters = .init(email: "user@stytch.com", password: "password123", sessionDuration: 26)
+    private let passwordResetBySessionParams: StytchClient.Passwords.ResetBySessionParameters = .init(password: "password123", sessionDuration: 10)
 
     func testCreate() async throws {
         let userId: User.ID = ""
@@ -103,6 +104,21 @@ final class PasswordsTestCase: BaseTestCase {
                 "code_verifier": "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741",
                 "session_duration_minutes": 30,
                 "password": "iAMpasswordHEARmeROAR",
+            ])
+        )
+    }
+
+    func testResetBySession() async throws {
+        networkInterceptor.responses { AuthenticateResponse.mock }
+        Current.timer = { _, _, _ in .init() }
+        _ = try await StytchClient.passwords.resetBySession(parameters: passwordResetBySessionParams)
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/passwords/session/reset",
+            method: .post([
+                "session_duration_minutes": 10,
+                "password": "password123",
             ])
         )
     }


### PR DESCRIPTION
Linear Ticket: [SDK-1174](https://linear.app/stytch/issue/SDK-1174)

## Changes:

1. Adds PasswordResetBySession endpoint

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A