### PR TITLE
Changes to Passkeys interface

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Stytch.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Stytch.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "StytchCore"
+               BuildableName = "StytchCore"
+               BlueprintName = "StytchCore"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "StytchCoreTests"
+               BuildableName = "StytchCoreTests"
+               BlueprintName = "StytchCoreTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "StytchCoreTests"
+               BuildableName = "StytchCoreTests"
+               BlueprintName = "StytchCoreTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "229B82172809EA3F007BC3F1"
+            BuildableName = "StytchDemo.app"
+            BlueprintName = "StytchDemo (iOS)"
+            ReferencedContainer = "container:StytchDemo/StytchDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "StytchCore"
+            BuildableName = "StytchCore"
+            BlueprintName = "StytchCore"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/StytchCore/PasskeysClient/PasskeysClient+Live.swift
+++ b/Sources/StytchCore/PasskeysClient/PasskeysClient+Live.swift
@@ -28,7 +28,7 @@ extension PasskeysClient {
 
             return credential
         },
-        assertCredential: { domain, challenge, requestBehavior in
+        assertCredential: { domain, challenge in
             let platformProvider: ASAuthorizationPlatformPublicKeyCredentialProvider = .init(relyingPartyIdentifier: domain)
 
             let request = platformProvider.createCredentialAssertionRequest(challenge: challenge)
@@ -39,17 +39,9 @@ extension PasskeysClient {
 
             let credential: ASAuthorizationCredential = try await withCheckedThrowingContinuation { continuation in
                 delegate.continuation = continuation
-                switch requestBehavior {
                 #if os(iOS)
-                case .autoFill:
-                    controller.performAutoFillAssistedRequests()
-                case let .default(preferLocalCredentials):
-                    controller.performRequests(options: preferLocalCredentials ? .preferImmediatelyAvailableCredentials : [])
-                #else
-                case .default:
-                    controller.performRequests()
+                controller.performRequests()
                 #endif
-                }
             }
 
             guard

--- a/Sources/StytchCore/PasskeysClient/PasskeysClient.swift
+++ b/Sources/StytchCore/PasskeysClient/PasskeysClient.swift
@@ -4,7 +4,7 @@ import AuthenticationServices
 @available(macOS 12.0, iOS 16.0, tvOS 16.0, *)
 struct PasskeysClient {
     var registerCredential: (String, Data, String, User.ID) async throws -> ASAuthorizationPublicKeyCredentialRegistration
-    var assertCredential: (String, Data, StytchClient.Passkeys.AuthenticateParameters.RequestBehavior) async throws -> ASAuthorizationPublicKeyCredentialAssertion
+    var assertCredential: (String, Data) async throws -> ASAuthorizationPublicKeyCredentialAssertion
 
     func registerCredential(domain: String, challenge: Data, username: String, userId: User.ID) async throws -> ASAuthorizationPublicKeyCredentialRegistration {
         try await registerCredential(domain, challenge, username, userId)
@@ -12,10 +12,9 @@ struct PasskeysClient {
 
     func assertCredential(
         domain: String,
-        challenge: Data,
-        requestBehavior: StytchClient.Passkeys.AuthenticateParameters.RequestBehavior
+        challenge: Data
     ) async throws -> ASAuthorizationPublicKeyCredentialAssertion {
-        try await assertCredential(domain, challenge, requestBehavior)
+        try await assertCredential(domain, challenge)
     }
 }
 #endif

--- a/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
+++ b/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
@@ -26,7 +26,7 @@ public extension StytchClient {
             let credential = try await passkeysClient.registerCredential(
                 domain: parameters.domain,
                 challenge: startResp.challenge,
-                username: parameters.username,
+                username: String(), // TODO: get email/phone number
                 userId: startResp.userId
             )
 
@@ -51,13 +51,12 @@ public extension StytchClient {
         public func authenticate(parameters: AuthenticateParameters) async throws -> AuthenticateResponse {
             let startResp: Response<AuthenticateStartResponseData> = try await router.post(
                 to: .authenticateStart,
-                parameters: StartParameters(domain: parameters.domain)
+                parameters: parameters
             )
 
             let credential = try await passkeysClient.assertCredential(
                 domain: parameters.domain,
-                challenge: startResp.challenge,
-                requestBehavior: parameters.requestBehavior
+                challenge: startResp.challenge
             )
 
             return try await router.post(
@@ -71,7 +70,7 @@ public extension StytchClient {
                         signature: credential.signature,
                         userHandle: credential.userID
                     )
-                ).wrapped(sessionDuration: parameters.sessionDuration)
+                ).wrapped()
             )
         }
     }
@@ -89,60 +88,33 @@ public extension StytchClient {
 public extension StytchClient.Passkeys {
     /// A dedicated parameters type for passkeys `register` calls.
     struct RegisterParameters: Encodable {
+        let userId: User.ID
         let domain: String
-        let username: String
+        let userAgent: String?
 
         /// - Parameters:
+        ///   - userId: The user id associated with your passkey registration.
         ///   - domain: The domain for which your passkey is to be registered.
-        ///   - username: The username associated with your user. In the future, it will be required this is a valid email address or phone number.
-        public init(domain: String, username: String) {
+        ///   - userAgent: The user agent associated with your passkey registration.
+        public init(userId: User.ID, domain: String, userAgent: String? = nil) {
+            self.userId = userId
             self.domain = domain
-            self.username = username
+            self.userAgent = userAgent
         }
     }
 
     /// A dedicated parameters type for passkeys `authenticate` calls.
-    struct AuthenticateParameters {
-        // swiftlint:disable duplicate_enum_cases
-        /// A type representing the desired request behavior
-        public enum RequestBehavior {
-            #if os(iOS)
-            /// Uses the default request behavior with a boolean flag to determine whether credentials are limited to those local on device or whether a passkey on a nearby device can be used
-            case `default`(preferLocalCredentials: Bool)
-            /// When a user selects a textfield with the `.username` textContentType, an existing local passkey will be suggested to the user.
-            case autoFill
-            #else
-            /// Uses the default request behavior
-            case `default`
-            #endif
-
-            #if os(iOS)
-            /// The RequestBehavior parameter's default value for this platform — `.default(prefersLocalCredentials: false)`
-            public static let defaultPlatformValue: RequestBehavior = .default(preferLocalCredentials: false)
-            #else
-            /// The RequestBehavior parameter's default value for this platform — `.default`
-            public static let defaultPlatformValue: RequestBehavior = .default
-            #endif
-        }
-
-        // swiftlint:enable duplicate_enum_cases
-
+    struct AuthenticateParameters: Encodable {
         let domain: String
-        let sessionDuration: Minutes
-        let requestBehavior: RequestBehavior
 
         /// - Parameters:
         ///   - domain: The domain for which your passkey is to be registered.
         ///   - sessionDuration: The duration, in minutes, of the requested session. Defaults to 30 minutes.
         ///   - requestBehavior: The  desired behavior of the authentication request. Defaults to a value specific for the platform `RequestBehavior.defaultPlatformValue`
         public init(
-            domain: String,
-            sessionDuration: Minutes = .defaultSessionDuration,
-            requestBehavior: RequestBehavior = .defaultPlatformValue
+            domain: String
         ) {
             self.domain = domain
-            self.sessionDuration = sessionDuration
-            self.requestBehavior = requestBehavior
         }
     }
 }


### PR DESCRIPTION
Linear Ticket: [SDK-1192](https://linear.app/stytch/issue/SDK-1192)

## Changes:

- Updated Passkeys requests to match tech spec params

## Notes:

- We can use a lot of the existing implementation for Passkeys. Noticed there's a `RequestBehavior` param that we might need later, but removed it for now

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A