### PR TITLE
Re-enable DFP and update with new methods/config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,9 @@ fastlane/test_output
 # Demo
 StytchDemo/*file.lock*
 !StytchDemo/StytchDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
-
+StytchDemo/Client/Shared/StytchConfiguration.plist
+StytchDemo/Client/iOS/iOS.entitlements
+StytchDemo/Client/macOS/macOS.entitlements
 # Dependencies
 .mint/
 .bundle/

--- a/Package.swift
+++ b/Package.swift
@@ -8,9 +8,19 @@ let package = Package(
     products: [
         .library(name: "StytchCore", targets: ["StytchCore"]),
     ],
-    dependencies: [],
+    dependencies: [
+        .package(url: "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk", from: "18.3.0"),
+    ],
     targets: [
-        .target(name: "StytchCore"),
+        .target(
+            name: "StytchCore",
+            dependencies: [
+                .product(name: "RecaptchaEnterprise", package: "recaptcha-enterprise-mobile-sdk", condition: .when(platforms: [.iOS])),
+            ],
+            resources: [
+                .copy("DFPClient/dfp.html"),
+            ]
+        ),
         .testTarget(name: "StytchCoreTests", dependencies: ["StytchCore"]),
     ]
 )

--- a/Sources/StytchCore/DFPClient/CAPTCHA.swift
+++ b/Sources/StytchCore/DFPClient/CAPTCHA.swift
@@ -1,0 +1,45 @@
+#if os(iOS)
+import Foundation
+import RecaptchaEnterprise
+
+internal protocol CaptchaProvider {
+    func setCaptchaClient(siteKey: String) async
+
+    func executeRecaptcha() async -> String
+
+    func isConfigured() -> Bool
+}
+
+final class CaptchaClient: CaptchaProvider {
+    private var recaptchaClient: RecaptchaClient?
+
+    func isConfigured() -> Bool {
+        recaptchaClient != nil
+    }
+
+    func executeRecaptcha() async -> String {
+        guard let recaptchaClient = recaptchaClient else {
+            return ""
+        }
+        do {
+            return try await recaptchaClient.execute(withAction: RecaptchaAction.login)
+        } catch let error as RecaptchaError {
+            print("RecaptchaClient execute error: \(String(describing: error.errorMessage)).")
+            return ""
+        } catch {
+            print("RecaptchaClient execute error: \(String(describing: error)).")
+            return ""
+        }
+    }
+
+    func setCaptchaClient(siteKey: String) async {
+        do {
+            recaptchaClient = try await Recaptcha.getClient(withSiteKey: siteKey)
+        } catch let error as RecaptchaError {
+            print("RecaptchaClient creation error: \(String(describing: error.errorMessage)).")
+        } catch {
+            print("RecaptchaClient creation error: \(String(describing: error))")
+        }
+    }
+}
+#endif

--- a/Sources/StytchCore/DFPClient/DFPClient.swift
+++ b/Sources/StytchCore/DFPClient/DFPClient.swift
@@ -1,0 +1,81 @@
+#if os(iOS)
+import Foundation
+import UIKit
+import WebKit
+
+internal protocol DFPProvider {
+    func getTelemetryId(publicToken: String) async -> String
+}
+
+final class DFPClient: DFPProvider {
+    func getTelemetryId(publicToken: String) async -> String {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                Task {
+                    if let topViewController = UIApplication.shared.topMostViewController {
+                        guard let dfpFileUrl = Bundle.module.url(forResource: "dfp", withExtension: "html") else {
+                            continuation.resume(returning: "Unable to load DFP file")
+                            return
+                        }
+                        let messageHandler = MessageHandler(continuation: continuation)
+                        let userScript = WKUserScript(source: "fetchTelemetryId('\(publicToken)')", injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+                        let userContentController = WKUserContentController()
+                        userContentController.addUserScript(userScript)
+                        userContentController.add(messageHandler, name: "StytchDFP")
+                        let configuration = WKWebViewConfiguration()
+                        configuration.userContentController = userContentController
+                        let webView = WKWebView(frame: CGRect.zero, configuration: configuration)
+                        topViewController.view.addSubview(webView)
+                        webView.loadFileURL(dfpFileUrl, allowingReadAccessTo: dfpFileUrl)
+                    } else {
+                        continuation.resume(returning: "unable to inject telemetry webview")
+                    }
+                }
+            }
+        }
+    }
+}
+
+private final class MessageHandler: NSObject, WKScriptMessageHandler {
+    var continuation: CheckedContinuation<String, Never>
+
+    init(continuation: CheckedContinuation<String, Never>) {
+        self.continuation = continuation
+    }
+
+    func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
+        continuation.resume(returning: message.body as? String ?? "")
+    }
+}
+
+private extension UIViewController {
+    var topMostViewController: UIViewController {
+        if let presented = presentedViewController {
+            return presented.topMostViewController
+        }
+
+        if let navigation = self as? UINavigationController {
+            return navigation.visibleViewController?.topMostViewController ?? navigation
+        }
+
+        if let tab = self as? UITabBarController {
+            return tab.selectedViewController?.topMostViewController ?? tab
+        }
+
+        return self
+    }
+}
+
+private extension UIApplication {
+    var topMostViewController: UIViewController? {
+        let keyWindow = UIApplication.shared.windows.first { $0.isKeyWindow }
+        if var topController = keyWindow?.rootViewController {
+            while let presentedViewController = topController.presentedViewController {
+                topController = presentedViewController
+            }
+            return topController
+        }
+        return nil
+    }
+}
+#endif

--- a/Sources/StytchCore/DFPClient/dfp.html
+++ b/Sources/StytchCore/DFPClient/dfp.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+    <head>
+        <script src="https://elements.stytch.com/telemetry.js"></script>
+    </head>
+    <body>
+        <script>
+            function fetchTelemetryId(publicToken) {
+                window.GetTelemetryID(publicToken)
+                    .then((telemetryId) => window.webkit.messageHandlers.StytchDFP.postMessage(telemetryId))
+                    .catch((error) => window.webkit.messageHandlers.StytchDFP.postMessage(error.message));
+            }
+        </script>
+    </body>
+</html>

--- a/Sources/StytchCore/DFPClient/dfp.html
+++ b/Sources/StytchCore/DFPClient/dfp.html
@@ -6,7 +6,7 @@
     <body>
         <script>
             function fetchTelemetryId(publicToken) {
-                window.GetTelemetryID(publicToken)
+                window.GetTelemetryID({ publicToken: publicToken, platform: "iOS" })
                     .then((telemetryId) => window.webkit.messageHandlers.StytchDFP.postMessage(telemetryId))
                     .catch((error) => window.webkit.messageHandlers.StytchDFP.postMessage(error.message));
             }

--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -51,7 +51,7 @@ struct Environment {
 
     var appleOAuthClient: AppleOAuthClient = .live
 
-    var networkingClient: NetworkingClient = .live
+    var networkingClient: NetworkingClient = .live()
 
     var cryptoClient: CryptoClient = .live
 
@@ -96,7 +96,10 @@ struct Environment {
         set { _passkeysClent = newValue }
     }
     #endif
-
+    #if os(iOS)
+    var dfpClient: DFPProvider = DFPClient()
+    var captcha: CaptchaProvider = CaptchaClient()
+    #endif
     var date: () -> Date = Date.init
 
     var uuid: () -> UUID = UUID.init

--- a/Sources/StytchCore/Generated/StytchB2BClient.DFP.getTelemetryID+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.DFP.getTelemetryID+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchB2BClient.DFP {
+    /// Returns a DFP Telemetry ID
+    func getTelemetryID(completion: @escaping Completion<String>) {
+        Task {
+            do {
+                completion(.success(try await getTelemetryID()))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Returns a DFP Telemetry ID
+    func getTelemetryID() -> AnyPublisher<String, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await getTelemetryID()))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/Generated/StytchClient.DFP.getTelemetryID+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.DFP.getTelemetryID+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchClient.DFP {
+    /// Returns a DFP Telemetry ID
+    func getTelemetryID(completion: @escaping Completion<String>) {
+        Task {
+            do {
+                completion(.success(try await getTelemetryID()))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Returns a DFP Telemetry ID
+    func getTelemetryID() -> AnyPublisher<String, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await getTelemetryID()))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/NetworkingClient/NetworkRequestHandler.swift
+++ b/Sources/StytchCore/NetworkingClient/NetworkRequestHandler.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+internal protocol NetworkRequestHandler {
+    #if os(iOS)
+    func handleDFPDisabled(session: URLSession, request: URLRequest, captcha: CaptchaProvider, requestHandler: (URLSession, URLRequest) async throws -> (Data, HTTPURLResponse)) async throws -> (Data, HTTPURLResponse)
+
+    // swiftlint:disable:next function_parameter_count
+    func handleDFPObservationMode(session: URLSession, request: URLRequest, publicToken: String, captcha: CaptchaProvider, dfp: DFPProvider, requestHandler: (URLSession, URLRequest) async throws -> (Data, HTTPURLResponse)) async throws -> (Data, HTTPURLResponse)
+
+    // swiftlint:disable:next function_parameter_count
+    func handleDFPDecisioningMode(session: URLSession, request: URLRequest, publicToken: String, captcha: CaptchaProvider, dfp: DFPProvider, requestHandler: (URLSession, URLRequest) async throws -> (Data, HTTPURLResponse)) async throws -> (Data, HTTPURLResponse)
+    #endif
+}
+
+internal struct NetworkRequestHandlerImplementation: NetworkRequestHandler {
+    #if os(iOS)
+    func handleDFPDisabled(session: URLSession, request: URLRequest, captcha: CaptchaProvider, requestHandler: (URLSession, URLRequest) async throws -> (Data, HTTPURLResponse)) async throws -> (Data, HTTPURLResponse) {
+        // DISABLED = if captcha client is configured, add a captcha token, else do nothing
+        if captcha.isConfigured() == false {
+            return try await requestHandler(session, request)
+        }
+        var newRequest = request
+        let oldBody = newRequest.httpBody ?? Data("{}".utf8)
+        var newBody = try JSONSerialization.jsonObject(with: oldBody) as? [String: AnyObject] ?? [:]
+        newBody["captcha_token"] = await captcha.executeRecaptcha() as AnyObject
+        newRequest.httpBody = try JSONSerialization.data(withJSONObject: newBody)
+        return try await requestHandler(session, newRequest)
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    func handleDFPObservationMode(session: URLSession, request: URLRequest, publicToken: String, captcha: CaptchaProvider, dfp: DFPProvider, requestHandler: (URLSession, URLRequest) async throws -> (Data, HTTPURLResponse)) async throws -> (Data, HTTPURLResponse) {
+        // OBSERVATION = Always DFP; CAPTCHA if configured
+        var newRequest = request
+        let oldBody = newRequest.httpBody ?? Data("{}".utf8)
+        var newBody = try JSONSerialization.jsonObject(with: oldBody) as? [String: AnyObject] ?? [:]
+        newBody["dfp_telemetry_id"] = await dfp.getTelemetryId(publicToken: publicToken) as AnyObject
+        if captcha.isConfigured() {
+            newBody["captcha_token"] = await captcha.executeRecaptcha() as AnyObject
+        }
+        newRequest.httpBody = try JSONSerialization.data(withJSONObject: newBody)
+        return try await requestHandler(session, newRequest)
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    func handleDFPDecisioningMode(session: URLSession, request: URLRequest, publicToken: String, captcha: CaptchaProvider, dfp: DFPProvider, requestHandler: (URLSession, URLRequest) async throws -> (Data, HTTPURLResponse)) async throws -> (Data, HTTPURLResponse) {
+        // DECISIONING = add DFP Id, proceed; if request 403s, add a captcha token
+        var firstRequest = request
+        let oldBody = firstRequest.httpBody ?? Data("{}".utf8)
+        var firstRequestBody = try JSONSerialization.jsonObject(with: oldBody) as? [String: AnyObject] ?? [:]
+        firstRequestBody["dfp_telemetry_id"] = await dfp.getTelemetryId(publicToken: publicToken) as AnyObject
+        firstRequest.httpBody = try JSONSerialization.data(withJSONObject: firstRequestBody)
+        let (data, response) = try await requestHandler(session, firstRequest)
+        if response.statusCode != 403 {
+            return (data, response)
+        }
+        var secondRequest = request
+        var secondRequestBody = try JSONSerialization.jsonObject(with: oldBody) as? [String: AnyObject] ?? [:]
+        secondRequestBody["dfp_telemetry_id"] = await dfp.getTelemetryId(publicToken: publicToken) as AnyObject
+        secondRequestBody["captcha_token"] = await captcha.executeRecaptcha() as AnyObject
+        secondRequest.httpBody = try JSONSerialization.data(withJSONObject: secondRequestBody)
+        return try await requestHandler(session, secondRequest)
+    }
+    #endif
+}

--- a/Sources/StytchCore/NetworkingClient/NetworkingClient+Live.swift
+++ b/Sources/StytchCore/NetworkingClient/NetworkingClient+Live.swift
@@ -1,9 +1,13 @@
 import Foundation
 
 extension NetworkingClient {
-    static let live: NetworkingClient = {
+    static func live(networkRequestHandler: NetworkRequestHandler = NetworkRequestHandlerImplementation()) -> NetworkingClient {
+        #if os(iOS)
+        @Dependency(\.dfpClient) var dfpClient
+        @Dependency(\.captcha) var captcha
+        #endif
         let session: URLSession = .init(configuration: .default)
-        return .init { request in
+        func defaultRequestHandler(session: URLSession, request: URLRequest) async throws -> (Data, HTTPURLResponse) {
             if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
                 let (data, response) = try await session.data(for: request)
                 guard let response = response as? HTTPURLResponse else { throw NetworkingClient.Error.nonHttpResponse }
@@ -29,5 +33,19 @@ extension NetworkingClient {
                 }
             }
         }
-    }()
+        return .init { request, dfpEnabled, dfpAuthMode, publicToken in
+            #if os(iOS)
+            if !dfpEnabled {
+                return try await networkRequestHandler.handleDFPDisabled(session: session, request: request, captcha: captcha, requestHandler: defaultRequestHandler)
+            }
+            switch dfpAuthMode {
+            case .observation:
+                return try await networkRequestHandler.handleDFPObservationMode(session: session, request: request, publicToken: publicToken, captcha: captcha, dfp: dfpClient, requestHandler: defaultRequestHandler)
+            case .decisioning:
+                return try await networkRequestHandler.handleDFPDecisioningMode(session: session, request: request, publicToken: publicToken, captcha: captcha, dfp: dfpClient, requestHandler: defaultRequestHandler)
+            }
+            #endif
+            return try await defaultRequestHandler(session: session, request: request)
+        }
+    }
 }

--- a/Sources/StytchCore/NetworkingClient/NetworkingClient.swift
+++ b/Sources/StytchCore/NetworkingClient/NetworkingClient.swift
@@ -3,14 +3,20 @@ import Foundation
 final class NetworkingClient {
     var headerProvider: (() -> [String: String])?
 
-    private let handleRequest: (URLRequest) async throws -> (Data, HTTPURLResponse)
+    var dfpEnabled: Bool = false
 
-    init(handleRequest: @escaping (URLRequest) async throws -> (Data, HTTPURLResponse)) {
+    var dfpAuthMode = DFPProtectedAuthMode.observation
+
+    var publicToken: String = ""
+
+    private let handleRequest: (URLRequest, Bool, DFPProtectedAuthMode, String) async throws -> (Data, HTTPURLResponse)
+
+    init(handleRequest: @escaping (URLRequest, Bool, DFPProtectedAuthMode, String) async throws -> (Data, HTTPURLResponse)) {
         self.handleRequest = handleRequest
     }
 
     func performRequest(_ method: Method, url: URL) async throws -> (Data, HTTPURLResponse) {
-        try await handleRequest(urlRequest(url: url, method: method))
+        try await handleRequest(urlRequest(url: url, method: method), dfpEnabled, dfpAuthMode, publicToken)
     }
 
     private func urlRequest(url: URL, method: Method) -> URLRequest {

--- a/Sources/StytchCore/Routing/BaseRoute.swift
+++ b/Sources/StytchCore/Routing/BaseRoute.swift
@@ -9,6 +9,7 @@ extension StytchClient {
         case sessions(SessionsRoute)
         case totp(TOTPRoute)
         case users(UsersRoute)
+        case bootstrap(BootstrapRoute)
 
         var path: Path {
             switch self {
@@ -30,6 +31,8 @@ extension StytchClient {
                 return "totps".appendingPath(route.path)
             case let .users(route):
                 return "users".appendingPath(route.path)
+            case let .bootstrap(route):
+                return "".appendingPath(route.path)
             }
         }
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Bootstrap.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Bootstrap.swift
@@ -1,0 +1,28 @@
+extension StytchB2BClient {
+    struct Bootstrap {
+        let router: NetworkingRouter<BootstrapRoute>
+
+        #if os(iOS)
+        @Dependency(\.captcha) private var captcha
+        #endif
+        @Dependency(\.networkingClient) private var networkingClient
+
+        public func fetch() async throws {
+            guard let publicToken = StytchB2BClient.instance.configuration?.publicToken else { throw StytchError.clientNotConfigured }
+            let bootstrapData = try await router.get(route: .fetch(Path(rawValue: publicToken))) as BootstrapResponse
+            #if os(iOS)
+            networkingClient.dfpEnabled = bootstrapData.wrapped.dfpProtectedAuthEnabled
+            networkingClient.dfpAuthMode = bootstrapData.wrapped.dfpProtectedAuthMode ?? DFPProtectedAuthMode.observation
+            guard let siteKey = bootstrapData.wrapped.captchaSettings.siteKey else {
+                return
+            }
+            await captcha.setCaptchaClient(siteKey: siteKey)
+            #endif
+        }
+    }
+}
+
+internal extension StytchB2BClient {
+    /// The interface for interacting with magic-links products.
+    static var bootstrap: Bootstrap { .init(router: router.scopedRouter { $0.bootstrap }) }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+DFP.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+DFP.swift
@@ -1,0 +1,17 @@
+#if os(iOS)
+public extension StytchB2BClient {
+    struct DFP {
+        @Dependency(\.dfpClient) private var dfpClient
+        // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
+        /// Returns a DFP Telemetry ID
+        public func getTelemetryID() async throws -> String {
+            guard let publicToken = StytchB2BClient.instance.configuration?.publicToken else { throw StytchError.clientNotConfigured }
+            return await dfpClient.getTelemetryId(publicToken: publicToken)
+        }
+    }
+}
+
+public extension StytchB2BClient {
+    static let dfp: DFP = .init()
+}
+#endif

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+DFP.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+DFP.swift
@@ -1,12 +1,17 @@
-#if os(iOS)
 public extension StytchB2BClient {
     struct DFP {
+        #if os(iOS)
         @Dependency(\.dfpClient) private var dfpClient
+        #endif
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Returns a DFP Telemetry ID
         public func getTelemetryID() async throws -> String {
             guard let publicToken = StytchB2BClient.instance.configuration?.publicToken else { throw StytchError.clientNotConfigured }
+            #if os(iOS)
             return await dfpClient.getTelemetryId(publicToken: publicToken)
+            #else
+            return ""
+            #endif
         }
     }
 }
@@ -14,4 +19,3 @@ public extension StytchB2BClient {
 public extension StytchB2BClient {
     static let dfp: DFP = .init()
 }
-#endif

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
@@ -6,6 +6,7 @@ extension StytchB2BClient {
         case passwords(PasswordsRoute)
         case sessions(SessionsRoute)
         case sso(SSORoute)
+        case bootstrap(BootstrapRoute)
 
         var path: Path {
             let (base, next) = routeComponents
@@ -26,6 +27,8 @@ extension StytchB2BClient {
                 return ("sessions", route)
             case let .sso(route):
                 return ("sso", route)
+            case let .bootstrap(route):
+                return ("", route)
             }
         }
     }
@@ -131,6 +134,17 @@ extension StytchB2BClient {
                 return "authenticate"
             case .strengthCheck:
                 return "strength_check"
+            }
+        }
+    }
+
+    enum BootstrapRoute: RouteType {
+        case fetch(Path)
+
+        var path: Path {
+            switch self {
+            case let .fetch(publicToken):
+                return "projects/bootstrap".appendingPath(publicToken)
             }
         }
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -14,6 +14,12 @@ public struct StytchB2BClient: StytchClientType {
     static let router: NetworkingRouter<BaseRoute> = .init { instance.configuration }
 
     private init() {
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
+            // only run this in non-test environments
+            Task {
+                try await Self.bootstrap.fetch()
+            }
+        }
         postInit()
     }
 

--- a/Sources/StytchCore/StytchClient/Bootstrap/BootstrapRoute.swift
+++ b/Sources/StytchCore/StytchClient/Bootstrap/BootstrapRoute.swift
@@ -1,0 +1,10 @@
+enum BootstrapRoute: RouteType {
+    case fetch(Path)
+
+    var path: Path {
+        switch self {
+        case let .fetch(publicToken):
+            return "projects/bootstrap".appendingPath(publicToken)
+        }
+    }
+}

--- a/Sources/StytchCore/StytchClient/Bootstrap/StytchClient+Bootstrap.swift
+++ b/Sources/StytchCore/StytchClient/Bootstrap/StytchClient+Bootstrap.swift
@@ -1,0 +1,28 @@
+extension StytchClient {
+    struct Bootstrap {
+        let router: NetworkingRouter<BootstrapRoute>
+
+        #if os(iOS)
+        @Dependency(\.captcha) private var captcha
+        #endif
+        @Dependency(\.networkingClient) private var networkingClient
+
+        public func fetch() async throws {
+            guard let publicToken = StytchClient.instance.configuration?.publicToken else { throw StytchError.clientNotConfigured }
+            let bootstrapData = try await router.get(route: .fetch(Path(rawValue: publicToken))) as BootstrapResponse
+            #if os(iOS)
+            networkingClient.dfpEnabled = bootstrapData.wrapped.dfpProtectedAuthEnabled
+            networkingClient.dfpAuthMode = bootstrapData.wrapped.dfpProtectedAuthMode ?? DFPProtectedAuthMode.observation
+            guard let siteKey = bootstrapData.wrapped.captchaSettings.siteKey else {
+                return
+            }
+            await captcha.setCaptchaClient(siteKey: siteKey)
+            #endif
+        }
+    }
+}
+
+internal extension StytchClient {
+    /// The interface for interacting with magic-links products.
+    static var bootstrap: Bootstrap { .init(router: router.scopedRouter { $0.bootstrap }) }
+}

--- a/Sources/StytchCore/StytchClient/DFP/StytchClient+DFP.swift
+++ b/Sources/StytchCore/StytchClient/DFP/StytchClient+DFP.swift
@@ -1,12 +1,17 @@
-#if os(iOS)
 public extension StytchClient {
     struct DFP {
+        #if os(iOS)
         @Dependency(\.dfpClient) private var dfpClient
+        #endif
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Returns a DFP Telemetry ID
         public func getTelemetryID() async throws -> String {
             guard let publicToken = StytchClient.instance.configuration?.publicToken else { throw StytchError.clientNotConfigured }
+            #if os(iOS)
             return await dfpClient.getTelemetryId(publicToken: publicToken)
+            #else
+            return ""
+            #endif
         }
     }
 }
@@ -14,4 +19,3 @@ public extension StytchClient {
 public extension StytchClient {
     static let dfp: DFP = .init()
 }
-#endif

--- a/Sources/StytchCore/StytchClient/DFP/StytchClient+DFP.swift
+++ b/Sources/StytchCore/StytchClient/DFP/StytchClient+DFP.swift
@@ -1,0 +1,17 @@
+#if os(iOS)
+public extension StytchClient {
+    struct DFP {
+        @Dependency(\.dfpClient) private var dfpClient
+        // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
+        /// Returns a DFP Telemetry ID
+        public func getTelemetryID() async throws -> String {
+            guard let publicToken = StytchClient.instance.configuration?.publicToken else { throw StytchError.clientNotConfigured }
+            return await dfpClient.getTelemetryId(publicToken: publicToken)
+        }
+    }
+}
+
+public extension StytchClient {
+    static let dfp: DFP = .init()
+}
+#endif

--- a/Sources/StytchCore/StytchClient/LocalStorage+StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/LocalStorage+StytchClient.swift
@@ -19,3 +19,14 @@ extension LocalStorage {
         set { self[SessionStorageKey.self] = newValue }
     }
 }
+
+extension LocalStorage {
+    private enum BootstrapDataStorageKey: LocalStorageKey {
+        typealias Value = BootstrapResponseData
+    }
+
+    var bootstrapData: BootstrapResponseData? {
+        get { self[BootstrapDataStorageKey.self] }
+        set { self[BootstrapDataStorageKey.self] = newValue }
+    }
+}

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -14,6 +14,12 @@ public struct StytchClient: StytchClientType {
     static var router: NetworkingRouter<BaseRoute> = .init { instance.configuration }
 
     private init() {
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
+            // only run this in non-test environments
+            Task {
+                try await Self.bootstrap.fetch()
+            }
+        }
         postInit()
     }
 

--- a/Sources/StytchCore/StytchClientCommon/Models/BootstrapResponse.swift
+++ b/Sources/StytchCore/StytchClientCommon/Models/BootstrapResponse.swift
@@ -1,0 +1,47 @@
+/// The concrete response type for `bootstrap` calls.
+public typealias BootstrapResponse = Response<BootstrapResponseData>
+
+/// Represents the interface of responses for `bootstrap` calls.
+public typealias BootstrapResponseType = BasicResponseType & BootstrapResponseDataType
+
+/// The interface which a data type must conform to for all underlying data in `bootstrap` responses.
+public protocol BootstrapResponseDataType {
+    var disableSdkWatermark: Bool { get }
+    var cnameDomain: String? { get }
+    var emailDomains: [String] { get }
+    var captchaSettings: CaptchaSettings { get }
+    var pkceRequiredForEmailMagicLinks: Bool { get }
+    var pkceRequiredForPasswordResets: Bool { get }
+    var pkceRequiredForOauth: Bool { get }
+    var pkceRequiredForSso: Bool { get }
+    var slugPattern: String? { get }
+    var createOrganizationEnabled: Bool { get }
+    var dfpProtectedAuthEnabled: Bool { get }
+    var dfpProtectedAuthMode: DFPProtectedAuthMode? { get }
+}
+
+/// The underlying data for `bootstrap` calls.
+public struct BootstrapResponseData: Codable, BootstrapResponseDataType {
+    public let disableSdkWatermark: Bool
+    public let cnameDomain: String?
+    public let emailDomains: [String]
+    public let captchaSettings: CaptchaSettings
+    public let pkceRequiredForEmailMagicLinks: Bool
+    public let pkceRequiredForPasswordResets: Bool
+    public let pkceRequiredForOauth: Bool
+    public let pkceRequiredForSso: Bool
+    public let slugPattern: String?
+    public let createOrganizationEnabled: Bool
+    public let dfpProtectedAuthEnabled: Bool
+    public let dfpProtectedAuthMode: DFPProtectedAuthMode?
+}
+
+public struct CaptchaSettings: Codable {
+    public let enabled: Bool
+    public let siteKey: String?
+}
+
+public enum DFPProtectedAuthMode: String, Codable {
+    case observation = "OBSERVATION"
+    case decisioning = "DECISIONING"
+}

--- a/Sources/StytchCore/StytchClientCommon/Models/Configuration.swift
+++ b/Sources/StytchCore/StytchClientCommon/Models/Configuration.swift
@@ -22,6 +22,8 @@ struct Configuration {
         }
         return url
     }
+
+    var bootstrapData: BootstrapResponseData?
 }
 
 extension Configuration: Decodable {

--- a/Sources/StytchCore/StytchClientCommon/Models/Response.swift
+++ b/Sources/StytchCore/StytchClientCommon/Models/Response.swift
@@ -11,13 +11,13 @@ public struct Response<Wrapped: Decodable>: Decodable {
     /// The id for the request.
     public let requestId: String
     /// The HTTP status code of the request.
-    public let statusCode: UInt
+    public let statusCode: UInt?
     let wrapped: Wrapped
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.requestId = try container.decodeIfPresent(String.self, forKey: .requestId) ?? "unknown_request_id"
-        self.statusCode = try container.decode(key: .statusCode)
+        self.statusCode = try container.decodeIfPresent(UInt.self, forKey: .statusCode)
         self.wrapped = try .init(from: decoder)
     }
 
@@ -36,7 +36,7 @@ public struct Response<Wrapped: Decodable>: Decodable {
 /// Represents the interface for basic responses.
 public protocol BasicResponseType {
     var requestId: String { get }
-    var statusCode: UInt { get }
+    var statusCode: UInt? { get }
 }
 
 /// A concrete response type which provides only the `requestId` and `statusCode`.

--- a/Sources/StytchCore/StytchClientCommon/StytchClientType.swift
+++ b/Sources/StytchCore/StytchClientCommon/StytchClientType.swift
@@ -18,7 +18,7 @@ extension StytchClientType {
         get { localStorage.configuration }
         set {
             localStorage.configuration = newValue
-            updateHeaderProvider()
+            updateNetworkingClient()
         }
     }
 
@@ -37,6 +37,10 @@ extension StytchClientType {
     private var clientInfo: ClientInfo { Current.clientInfo }
 
     private var uuid: () -> UUID { Current.uuid }
+    #if os(iOS)
+    private var dfpClient: DFPProvider { Current.dfpClient }
+    private var captchaClient: CaptchaProvider { Current.captcha }
+    #endif
 
     // swiftlint:disable:next identifier_name
     static func _configure(publicToken: String, hostUrl: URL? = nil) {
@@ -70,13 +74,13 @@ extension StytchClientType {
             configuration = try? PropertyListDecoder().decode(Configuration.self, from: data)
         }
 
-        updateHeaderProvider()
+        updateNetworkingClient()
         resetKeychainOnFreshInstall()
         runKeychainMigrations()
     }
 
     // To be called after configuration
-    private func updateHeaderProvider() {
+    private func updateNetworkingClient() {
         let clientInfoString = try? clientInfo.base64EncodedString(encoder: jsonEncoder)
 
         networkingClient.headerProvider = { [weak localStorage, weak sessionStorage] in
@@ -91,6 +95,7 @@ extension StytchClientType {
                 "X-SDK-Client": clientInfoString ?? "",
             ]
         }
+        networkingClient.publicToken = configuration?.publicToken ?? ""
     }
 
     private func resetKeychainOnFreshInstall() {

--- a/StytchDemo/StytchDemo (iOS)-Bridging-Header.h
+++ b/StytchDemo/StytchDemo (iOS)-Bridging-Header.h
@@ -1,0 +1,1 @@
+#import <RecaptchaEnterprise/RecaptchaEnterprise.h>

--- a/StytchDemo/StytchDemo.xcodeproj/project.pbxproj
+++ b/StytchDemo/StytchDemo.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		22E2E06028ECF6AD00327719 /* OAuthAuthenticationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthAuthenticationView.swift; sourceTree = "<group>"; };
 		22E4346A280A133900FB45F0 /* StytchPlayground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; name = StytchPlayground.playground; path = ../StytchPlayground.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		22E4346D280A174100FB45F0 /* Stytch */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Stytch; path = ..; sourceTree = "<group>"; };
+		77AC9C632AA0FF4A004059CF /* StytchDemo (iOS)-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StytchDemo (iOS)-Bridging-Header.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -292,6 +293,7 @@
 				22315319299EE16D00BA9126 /* B2BWorkbench */,
 				229B82192809EA3F007BC3F1 /* Products */,
 				22E4345E2809EF2200FB45F0 /* Frameworks */,
+				77AC9C632AA0FF4A004059CF /* StytchDemo (iOS)-Bridging-Header.h */,
 			);
 			sourceTree = "<group>";
 		};
@@ -434,15 +436,19 @@
 				TargetAttributes = {
 					22315317299EE16D00BA9126 = {
 						CreatedOnToolsVersion = 14.2;
+						LastSwiftMigration = 1430;
 					};
 					229B82172809EA3F007BC3F1 = {
 						CreatedOnToolsVersion = 13.3;
+						LastSwiftMigration = 1430;
 					};
 					229B821D2809EA3F007BC3F1 = {
 						CreatedOnToolsVersion = 13.3;
+						LastSwiftMigration = 1430;
 					};
 					22BE99FC2847FFA300E29245 = {
 						CreatedOnToolsVersion = 13.3;
+						LastSwiftMigration = 1430;
 					};
 				};
 			};
@@ -458,6 +464,7 @@
 			packageReferences = (
 				224FC03428486013009C9740 /* XCRemoteSwiftPackageReference "swifter" */,
 				22909075284BE79400ADD3C4 /* XCRemoteSwiftPackageReference "jwt-kit" */,
+				77AC9C5E2AA0FCCD004059CF /* XCRemoteSwiftPackageReference "recaptcha-enterprise-mobile-sdk" */,
 			);
 			productRefGroup = 229B82192809EA3F007BC3F1 /* Products */;
 			projectDirPath = "";
@@ -621,6 +628,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 22B584A5Q6;
@@ -641,6 +649,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "B2BWorkbench-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -652,6 +662,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 22B584A5Q6;
@@ -672,6 +683,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "B2BWorkbench-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -732,7 +744,9 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				"OTHER_LDFLAGS[arch=*]" = "-ObjC";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				"SWIFT_OBJC_BRIDGING_HEADER[arch=*]" = "StytchDemo (iOS)-Bridging-Header";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = complete;
 			};
@@ -785,7 +799,9 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				"OTHER_LDFLAGS[arch=*]" = "-ObjC";
 				SWIFT_COMPILATION_MODE = wholemodule;
+				"SWIFT_OBJC_BRIDGING_HEADER[arch=*]" = "StytchDemo/StytchDemo (iOS)-Bridging-Header";
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_STRICT_CONCURRENCY = complete;
 			};
@@ -796,6 +812,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Client/iOS/iOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -818,6 +835,8 @@
 				PRODUCT_NAME = StytchDemo;
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "StytchDemo (iOS)-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -828,6 +847,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Client/iOS/iOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -850,6 +870,7 @@
 				PRODUCT_NAME = StytchDemo;
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "StytchDemo (iOS)-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -861,6 +882,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Client/macOS/macOS.entitlements;
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
@@ -884,6 +906,8 @@
 				PRODUCT_NAME = StytchDemo;
 				SDKROOT = macosx;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "StytchDemo (macOS)-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -893,6 +917,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Client/macOS/macOS.entitlements;
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
@@ -916,6 +941,7 @@
 				PRODUCT_NAME = StytchDemo;
 				SDKROOT = macosx;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "StytchDemo (macOS)-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -923,6 +949,7 @@
 		22BE9A022847FFA300E29245 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
@@ -931,6 +958,8 @@
 				MACOSX_DEPLOYMENT_TARGET = 12.2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "StytchDemo (Server)-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -938,6 +967,7 @@
 		22BE9A032847FFA300E29245 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
@@ -946,6 +976,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 12.2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "StytchDemo (Server)-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -1015,6 +1046,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 4.0.0;
+			};
+		};
+		77AC9C5E2AA0FCCD004059CF /* XCRemoteSwiftPackageReference "recaptcha-enterprise-mobile-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 18.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/StytchDemo/StytchDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StytchDemo/StytchDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,30 @@
   "object": {
     "pins": [
       {
+        "package": "InteropForGoogle",
+        "repositoryURL": "https://github.com/google/interop-ios-for-google-sdks.git",
+        "state": {
+          "branch": null,
+          "revision": "2d12673670417654f08f5f90fdd62926dc3a2648",
+          "version": "100.0.0"
+        }
+      },
+      {
         "package": "jwt-kit",
         "repositoryURL": "https://github.com/vapor/jwt-kit.git",
         "state": {
           "branch": null,
           "revision": "87ce13a1df913ba4d51cf00606df7ef24d455571",
           "version": "4.7.0"
+        }
+      },
+      {
+        "package": "RecaptchaEnterprise",
+        "repositoryURL": "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",
+        "state": {
+          "branch": null,
+          "revision": "5419bb00a3bc81d727423790692f2c538040d00c",
+          "version": "18.3.0"
         }
       },
       {

--- a/StytchDemo/StytchDemo.xcodeproj/xcshareddata/xcschemes/StytchDemo (iOS).xcscheme
+++ b/StytchDemo/StytchDemo.xcodeproj/xcshareddata/xcschemes/StytchDemo (iOS).xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "229B82172809EA3F007BC3F1"
+               BuildableName = "StytchDemo.app"
+               BlueprintName = "StytchDemo (iOS)"
+               ReferencedContainer = "container:StytchDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "229B82172809EA3F007BC3F1"
+            BuildableName = "StytchDemo.app"
+            BlueprintName = "StytchDemo (iOS)"
+            ReferencedContainer = "container:StytchDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "229B82172809EA3F007BC3F1"
+            BuildableName = "StytchDemo.app"
+            BlueprintName = "StytchDemo (iOS)"
+            ReferencedContainer = "container:StytchDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/StytchCoreTests/BaseTestCase.swift
+++ b/Tests/StytchCoreTests/BaseTestCase.swift
@@ -8,7 +8,7 @@ class BaseTestCase: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        Current.networkingClient = .init(handleRequest: networkInterceptor.handleRequest(request:))
+        Current.networkingClient = .init(handleRequest: networkInterceptor.handleRequest)
         Current.sessionsPollingClient = .failing
         Current.cookieClient = .mock()
         Current.keychainClient = .mock()

--- a/Tests/StytchCoreTests/NetworkRequestHandlerTestCase.swift
+++ b/Tests/StytchCoreTests/NetworkRequestHandlerTestCase.swift
@@ -1,0 +1,138 @@
+#if os(iOS)
+import Foundation
+import XCTest
+@testable import StytchCore
+
+private struct UnconfiguredRecaptchaProviderMock: CaptchaProvider {
+    func setCaptchaClient(siteKey _: String) async {}
+
+    func executeRecaptcha() async -> String {
+        ""
+    }
+
+    func isConfigured() -> Bool {
+        false
+    }
+}
+
+private struct ConfiguredRecaptchaProviderMock: CaptchaProvider {
+    func setCaptchaClient(siteKey _: String) async {}
+
+    func executeRecaptcha() async -> String {
+        "captcha-token"
+    }
+
+    func isConfigured() -> Bool {
+        true
+    }
+}
+
+private struct DFPProviderMock: DFPProvider {
+    func getTelemetryId(publicToken _: String) async -> String {
+        "dfp-telemetry-id"
+    }
+}
+
+private extension URLRequest {
+    func bodyContainsKey(key: String) throws -> Bool {
+        let body: Data = httpBody ?? Data()
+        if body.isEmpty {
+            return false
+        }
+        let bodyJSON = try JSONSerialization.jsonObject(with: body) as? [String: AnyObject] ?? [:]
+        return bodyJSON[key] != nil
+    }
+}
+
+// These tests are admittedly a little weird, but basically, I'm just returning either a "good" response or a "bad" response, depending on the test parameters
+final class NetworkRequestHandlerTestCase: XCTestCase {
+    private let handler = NetworkRequestHandlerImplementation()
+    private let dfpClient = DFPProviderMock()
+
+    func testHandleDFPDisabledNoCaptcha() async throws {
+        // do nothing to the request
+        let captcha = UnconfiguredRecaptchaProviderMock()
+        let url = try XCTUnwrap(URL(string: "https://www.stytch.com"))
+
+        func requestHandler(session _: URLSession, request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+            let hasCaptcha = try request.bodyContainsKey(key: "captcha_token")
+            let hasDfp = try request.bodyContainsKey(key: "dfp_telemetry_id")
+            XCTAssert(!hasDfp)
+            XCTAssert(!hasCaptcha)
+            return (Data(), HTTPURLResponse())
+        }
+        try await handler.handleDFPDisabled(session: URLSession(), request: URLRequest(url: url), captcha: captcha, requestHandler: requestHandler)
+    }
+
+    func testHandleDFPDisabledWithCaptcha() async throws {
+        // add a captcha token to the request
+        let captcha = ConfiguredRecaptchaProviderMock()
+        let url = try XCTUnwrap(URL(string: "https://www.stytch.com"))
+
+        func requestHandler(session _: URLSession, request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+            let hasCaptcha = try request.bodyContainsKey(key: "captcha_token")
+            let hasDfp = try request.bodyContainsKey(key: "dfp_telemetry_id")
+            XCTAssert(!hasDfp)
+            XCTAssert(hasCaptcha)
+            return (Data(), HTTPURLResponse())
+        }
+        try await handler.handleDFPDisabled(session: URLSession(), request: URLRequest(url: url), captcha: captcha, requestHandler: requestHandler)
+    }
+
+    func testHandleDFPObservationModeNoCaptcha() async throws {
+        // add DFP, no captcha token
+        let captcha = UnconfiguredRecaptchaProviderMock()
+        let url = try XCTUnwrap(URL(string: "https://www.stytch.com"))
+
+        func requestHandler(session _: URLSession, request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+            let hasCaptcha = try request.bodyContainsKey(key: "captcha_token")
+            let hasDfp = try request.bodyContainsKey(key: "dfp_telemetry_id")
+            XCTAssert(hasDfp)
+            XCTAssert(!hasCaptcha)
+            return (Data(), HTTPURLResponse())
+        }
+        try await handler.handleDFPObservationMode(session: URLSession(), request: URLRequest(url: url), publicToken: "", captcha: captcha, dfp: dfpClient, requestHandler: requestHandler)
+    }
+
+    func testHandleDFPObservationModeWithCaptcha() async throws {
+        // add dfp and captcha token
+        let captcha = ConfiguredRecaptchaProviderMock()
+        let url = try XCTUnwrap(URL(string: "https://www.stytch.com"))
+
+        func requestHandler(session _: URLSession, request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+            let hasCaptcha = try request.bodyContainsKey(key: "captcha_token")
+            let hasDfp = try request.bodyContainsKey(key: "dfp_telemetry_id")
+            XCTAssert(hasDfp)
+            XCTAssert(hasCaptcha)
+            return (Data(), HTTPURLResponse())
+        }
+        try await handler.handleDFPObservationMode(session: URLSession(), request: URLRequest(url: url), publicToken: "", captcha: captcha, dfp: dfpClient, requestHandler: requestHandler)
+    }
+
+    func testHandleDFPDecisioningMode() async throws {
+        // add DFP Id, proceed; if request 403s, add a captcha token
+        let captcha = ConfiguredRecaptchaProviderMock()
+        let url = try XCTUnwrap(URL(string: "https://www.stytch.com"))
+        var requestNumber = 0
+
+        func requestHandler(session _: URLSession, request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+            requestNumber += 1
+            let hasCaptcha = try request.bodyContainsKey(key: "captcha_token")
+            let hasDfp = try request.bodyContainsKey(key: "dfp_telemetry_id")
+            if requestNumber == 1 {
+                // assert that it has dfp and no captcha
+                XCTAssert(hasDfp)
+                XCTAssert(!hasCaptcha)
+                // force return a 403
+                // swiftlint:disable:next force_unwrapping
+                return (Data(), HTTPURLResponse(url: url, statusCode: 403, httpVersion: "1.1", headerFields: nil)!)
+            } else {
+                XCTAssert(hasDfp)
+                XCTAssert(hasCaptcha)
+                return (Data(), HTTPURLResponse())
+            }
+        }
+        try await handler.handleDFPDecisioningMode(session: URLSession(), request: URLRequest(url: url), publicToken: "", captcha: captcha, dfp: dfpClient, requestHandler: requestHandler)
+    }
+}
+#endif

--- a/Tests/StytchCoreTests/NetworkingClient+LiveTestCase.swift
+++ b/Tests/StytchCoreTests/NetworkingClient+LiveTestCase.swift
@@ -1,0 +1,66 @@
+import Foundation
+import XCTest
+@testable import StytchCore
+
+private class NetworkRequestHandlerMock: NetworkRequestHandler {
+    private(set) var methodCalled: String?
+    #if os(iOS)
+    func handleDFPDisabled(session _: URLSession, request _: URLRequest, captcha _: CaptchaProvider, requestHandler _: (URLSession, URLRequest) async throws -> (Data, HTTPURLResponse)) async throws -> (Data, HTTPURLResponse) {
+        methodCalled = "handleDfpDisabled"
+        return (Data(), HTTPURLResponse())
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    func handleDFPObservationMode(session _: URLSession, request _: URLRequest, publicToken _: String, captcha _: CaptchaProvider, dfp _: DFPProvider, requestHandler _: (URLSession, URLRequest) async throws -> (Data, HTTPURLResponse)) async throws -> (Data, HTTPURLResponse) {
+        methodCalled = "handleDFPObservationMode"
+        return (Data(), HTTPURLResponse())
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    func handleDFPDecisioningMode(session _: URLSession, request _: URLRequest, publicToken _: String, captcha _: CaptchaProvider, dfp _: DFPProvider, requestHandler _: (URLSession, URLRequest) async throws -> (Data, HTTPURLResponse)) async throws -> (Data, HTTPURLResponse) {
+        methodCalled = "handleDFPDecisioningMode"
+        return (Data(), HTTPURLResponse())
+    }
+    #endif
+}
+
+final class NetworkingClientLiveTestCase: XCTestCase {
+    func testDFPDisabled() async throws {
+        let handler = NetworkRequestHandlerMock()
+        let client = NetworkingClient.live(networkRequestHandler: handler)
+        client.dfpEnabled = false
+        client.dfpAuthMode = DFPProtectedAuthMode.observation
+        try await client.performRequest(.get, url: XCTUnwrap(URL(string: "https://www.stytch.com")))
+        #if !os(iOS)
+        XCTAssert(handler.methodCalled == nil)
+        #else
+        XCTAssert(handler.methodCalled == "handleDfpDisabled")
+        #endif
+    }
+
+    func testDFPObservation() async throws {
+        let handler = NetworkRequestHandlerMock()
+        let client = NetworkingClient.live(networkRequestHandler: handler)
+        client.dfpEnabled = true
+        client.dfpAuthMode = DFPProtectedAuthMode.observation
+        try await client.performRequest(.get, url: XCTUnwrap(URL(string: "https://www.stytch.com")))
+        #if !os(iOS)
+        XCTAssert(handler.methodCalled == nil)
+        #else
+        XCTAssert(handler.methodCalled == "handleDFPObservationMode")
+        #endif
+    }
+
+    func testDFPDecisioning() async throws {
+        let handler = NetworkRequestHandlerMock()
+        let client = NetworkingClient.live(networkRequestHandler: handler)
+        client.dfpEnabled = true
+        client.dfpAuthMode = DFPProtectedAuthMode.decisioning
+        try await client.performRequest(.get, url: XCTUnwrap(URL(string: "https://www.stytch.com")))
+        #if !os(iOS)
+        XCTAssert(handler.methodCalled == nil)
+        #else
+        XCTAssert(handler.methodCalled == "handleDFPDecisioningMode")
+        #endif
+    }
+}

--- a/Tests/StytchCoreTests/NetworkingClientInterceptor.swift
+++ b/Tests/StytchCoreTests/NetworkingClientInterceptor.swift
@@ -11,7 +11,7 @@ final class NetworkingClientInterceptor {
         responses = []
     }
 
-    func handleRequest(request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+    func handleRequest(request: URLRequest, _: Bool, _: DFPProtectedAuthMode, _: String) async throws -> (Data, HTTPURLResponse) {
         requests.append(request)
 
         switch responses.removeFirst() {

--- a/Tests/StytchCoreTests/NetworkingClientTestCase.swift
+++ b/Tests/StytchCoreTests/NetworkingClientTestCase.swift
@@ -54,7 +54,7 @@ final class NetworkingClientTestCase: XCTestCase {
         onClientCreate: ((NetworkingClient) -> Void)? = nil,
         onPerformRequest: @escaping (_ request: URLRequest, _ line: UInt) -> Void
     ) async throws {
-        let networkingClient: NetworkingClient = .init { request in
+        let networkingClient: NetworkingClient = .init { request, _, _, _ in
             onPerformRequest(request, line)
             return (.init(), .init())
         }


### PR DESCRIPTION
Linear Ticket:
[SDK-1225](https://linear.app/stytch/issue/SDK-1225)
[SDK-1226](https://linear.app/stytch/issue/SDK-1226)

## Changes:

1. Reverts the commit that removed DFP
2. Updates the GetTelemetryID call to pass an object with the platform
3. Adds a top-level DFP object that exposes a getTelemetryId method that delegates to the existing DFPProvider

## Notes:

- fc011a814d2da3e2607c33cc1ef6e550ce3057b6 and ee387ff83f1b8ece7d4eb9f6c2588d04c166452e are the only real relevant commits

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A