### PR TITLE
Update tests to use specific errors

### DIFF
--- a/Sources/StytchCore/StytchClientCommon/Models/StytchError.swift
+++ b/Sources/StytchCore/StytchClientCommon/Models/StytchError.swift
@@ -2,11 +2,6 @@ import Foundation
 
 /// Base class representing an error within the Stytch ecosystem.
 public class StytchError: Error, Equatable {
-    
-    public static func == (lhs: StytchError, rhs: StytchError) -> Bool {
-        return lhs.name == rhs.name && lhs.message == rhs.message
-    }
-    
     public var name: String
     public var message: String
 
@@ -16,6 +11,10 @@ public class StytchError: Error, Equatable {
     ) {
         self.name = name
         self.message = message
+    }
+
+    public static func == (lhs: StytchError, rhs: StytchError) -> Bool {
+        lhs.name == rhs.name && lhs.message == rhs.message
     }
 }
 

--- a/Sources/StytchCore/StytchClientCommon/Models/StytchError.swift
+++ b/Sources/StytchCore/StytchClientCommon/Models/StytchError.swift
@@ -1,7 +1,12 @@
 import Foundation
 
 /// Base class representing an error within the Stytch ecosystem.
-public class StytchError: Error {
+public class StytchError: Error, Equatable {
+    
+    public static func == (lhs: StytchError, rhs: StytchError) -> Bool {
+        return lhs.name == rhs.name && lhs.message == rhs.message
+    }
+    
     public var name: String
     public var message: String
 

--- a/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
@@ -78,7 +78,10 @@ final class B2BMagicLinksTestCase: BaseTestCase {
             sessionDuration: 15
         )
 
-        await XCTAssertThrowsErrorAsync(try await StytchB2BClient.magicLinks.authenticate(parameters: parameters))
+        await XCTAssertThrowsErrorAsync(
+            try await StytchB2BClient.magicLinks.authenticate(parameters: parameters),
+            StytchSDKError.missingPKCE
+        )
 
         try Current.keychainClient.set(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
 
@@ -106,7 +109,10 @@ final class B2BMagicLinksTestCase: BaseTestCase {
 
         let parameters: StytchB2BClient.MagicLinks.DiscoveryAuthenticateParameters = .init(token: "12345")
 
-        await XCTAssertThrowsErrorAsync(try await StytchB2BClient.magicLinks.discoveryAuthenticate(parameters: parameters))
+        await XCTAssertThrowsErrorAsync(
+            try await StytchB2BClient.magicLinks.discoveryAuthenticate(parameters: parameters),
+            StytchSDKError.missingPKCE
+        )
 
         try Current.keychainClient.set(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
 

--- a/Tests/StytchCoreTests/B2BPasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BPasswordsTestCase.swift
@@ -44,7 +44,10 @@ final class B2BPasswordsTestCase: BaseTestCase {
     }
 
     func testResetByEmail() async throws {
-        await XCTAssertThrowsErrorAsync(_ = try await client.resetByEmail(parameters: .init(token: "12345", password: "iAMpasswordHEARmeROAR")))
+        await XCTAssertThrowsErrorAsync(
+            try await client.resetByEmail(parameters: .init(token: "12345", password: "iAMpasswordHEARmeROAR")),
+            StytchSDKError.missingPKCE
+        )
 
         networkInterceptor.responses {
             BasicResponse(requestId: "123", statusCode: 200)

--- a/Tests/StytchCoreTests/B2BSSOTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSSOTestCase.swift
@@ -20,7 +20,10 @@ final class B2BSSOTestCase: BaseTestCase {
 
         let invalidStartParams = createParams(baseUrl)
 
-        await XCTAssertThrowsErrorAsync(try await StytchB2BClient.sso.start(parameters: invalidStartParams))
+        await XCTAssertThrowsErrorAsync(
+            try await StytchB2BClient.sso.start(parameters: invalidStartParams),
+            StytchSDKError.invalidRedirectScheme
+        )
 
         baseUrl = try XCTUnwrap(URL(string: "custom-scheme://blah"))
 
@@ -35,7 +38,10 @@ final class B2BSSOTestCase: BaseTestCase {
         networkInterceptor.responses { B2BAuthenticateResponse.mock }
         Current.timer = { _, _, _ in .init() }
 
-        await XCTAssertThrowsErrorAsync(_ = try await StytchB2BClient.sso.authenticate(parameters: .init(token: "i-am-token", sessionDuration: 12)))
+        await XCTAssertThrowsErrorAsync(
+            try await StytchB2BClient.sso.authenticate(parameters: .init(token: "i-am-token", sessionDuration: 12)),
+            StytchSDKError.missingPKCE
+        )
         _ = try StytchB2BClient.generateAndStorePKCE(keychainItem: .codeVerifierPKCE)
         _ = try await StytchB2BClient.sso.authenticate(parameters: .init(token: "i-am-token", sessionDuration: 12))
 

--- a/Tests/StytchCoreTests/DeeplinkHandlerTestCase.swift
+++ b/Tests/StytchCoreTests/DeeplinkHandlerTestCase.swift
@@ -16,7 +16,10 @@ final class DeeplinkHandlerTestCase: BaseTestCase {
 
         let handledUrl = try XCTUnwrap(URL(string: "https://myapp.com?token=12345&stytch_token_type=magic_links"))
 
-        await XCTAssertThrowsErrorAsync(try await StytchClient.handle(url: handledUrl))
+        await XCTAssertThrowsErrorAsync(
+            try await StytchClient.handle(url: handledUrl),
+            StytchSDKError.missingPKCE
+        )
 
         try Current.keychainClient.set(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
 

--- a/Tests/StytchCoreTests/MagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/MagicLinksTestCase.swift
@@ -116,7 +116,10 @@ final class MagicLinksTestCase: BaseTestCase {
             sessionDuration: 15
         )
 
-        await XCTAssertThrowsErrorAsync(try await StytchClient.magicLinks.authenticate(parameters: parameters))
+        await XCTAssertThrowsErrorAsync(
+            try await StytchClient.magicLinks.authenticate(parameters: parameters),
+            StytchSDKError.missingPKCE
+        )
 
         try Current.keychainClient.set(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
 

--- a/Tests/StytchCoreTests/OAuthTestCase.swift
+++ b/Tests/StytchCoreTests/OAuthTestCase.swift
@@ -30,7 +30,10 @@ final class OAuthTestCase: BaseTestCase {
         networkInterceptor.responses { AuthenticateResponse.mock }
         Current.timer = { _, _, _ in .init() }
 
-        await XCTAssertThrowsErrorAsync(_ = try await StytchClient.oauth.authenticate(parameters: .init(token: "i-am-token", sessionDuration: 12)))
+        await XCTAssertThrowsErrorAsync(
+            try await StytchClient.oauth.authenticate(parameters: .init(token: "i-am-token", sessionDuration: 12)),
+            StytchSDKError.missingPKCE
+        )
         _ = try StytchClient.generateAndStorePKCE(keychainItem: .codeVerifierPKCE)
         _ = try await StytchClient.oauth.authenticate(parameters: .init(token: "i-am-token", sessionDuration: 12))
 
@@ -88,7 +91,10 @@ extension OAuthTestCase {
         let invalidStartParams = createParams(baseUrl)
 
         try await StytchClient.OAuth.ThirdParty.Provider.allCases.asyncForEach { provider in
-            await XCTAssertThrowsErrorAsync(try await provider.interface.start(parameters: invalidStartParams))
+            await XCTAssertThrowsErrorAsync(
+                try await provider.interface.start(parameters: invalidStartParams),
+                StytchSDKError.invalidRedirectScheme
+            )
         }
 
         baseUrl = try XCTUnwrap(URL(string: "custom-scheme://blah"))

--- a/Tests/StytchCoreTests/PasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/PasswordsTestCase.swift
@@ -69,7 +69,10 @@ final class PasswordsTestCase: BaseTestCase {
     }
 
     func testReset() async throws {
-        await XCTAssertThrowsErrorAsync(_ = try await StytchClient.passwords.resetByEmail(parameters: .init(token: "12345", password: "iAMpasswordHEARmeROAR")))
+        await XCTAssertThrowsErrorAsync(
+            try await StytchClient.passwords.resetByEmail(parameters: .init(token: "12345", password: "iAMpasswordHEARmeROAR")),
+            StytchSDKError.missingPKCE
+        )
 
         networkInterceptor.responses {
             BasicResponse(requestId: "123", statusCode: 200)

--- a/Tests/StytchCoreTests/SessionsTestCase.swift
+++ b/Tests/StytchCoreTests/SessionsTestCase.swift
@@ -66,14 +66,20 @@ final class SessionsTestCase: BaseTestCase {
         XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("opaque_all_day"))
         XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("i'm_jwt"))
 
-        await XCTAssertThrowsErrorAsync(_ = try await StytchClient.sessions.revoke())
+        await XCTAssertThrowsErrorAsync(
+            try await StytchClient.sessions.revoke(),
+            StytchError(name: "fake_error", message: "I'm a mock error")
+        )
 
         try XCTAssertRequest(networkInterceptor.requests[0], urlString: "https://web.stytch.com/sdk/v1/sessions/revoke", method: .post([:]))
 
         XCTAssertNotNil(StytchClient.sessions.sessionJwt)
         XCTAssertNotNil(StytchClient.sessions.sessionToken)
 
-        await XCTAssertThrowsErrorAsync(_ = try await StytchClient.sessions.revoke(parameters: .init(forceClear: true)))
+        await XCTAssertThrowsErrorAsync(
+            try await StytchClient.sessions.revoke(parameters: .init(forceClear: true)),
+            StytchError(name: "fake_error", message: "I'm a mock error")
+        )
 
         try XCTAssertRequest(networkInterceptor.requests[1], urlString: "https://web.stytch.com/sdk/v1/sessions/revoke", method: .post([:]))
 

--- a/Tests/StytchCoreTests/XCTestHelpers.swift
+++ b/Tests/StytchCoreTests/XCTestHelpers.swift
@@ -1,18 +1,18 @@
 import StytchCore
 import XCTest
 
-func XCTAssertThrowsErrorAsync<T: Sendable>(
+func XCTAssertThrowsErrorAsync<T, R>(
     _ expression: @autoclosure () async throws -> T,
-    _ message: @autoclosure () -> String = "",
+    _ errorThrown: @autoclosure () -> R,
+    _ message: @autoclosure () -> String = "This method should fail",
     file: StaticString = #filePath,
-    line: UInt = #line,
-    _ errorHandler: (_ error: Error) -> Void = { _ in }
-) async {
+    line: UInt = #line
+) async where T: Sendable, R: Equatable, R: StytchError {
     do {
-        _ = try await expression()
+        let _ = try await expression()
         XCTFail(message(), file: file, line: line)
     } catch {
-        errorHandler(error)
+        XCTAssertEqual(error as? R, errorThrown())
     }
 }
 

--- a/Tests/StytchCoreTests/XCTestHelpers.swift
+++ b/Tests/StytchCoreTests/XCTestHelpers.swift
@@ -9,7 +9,7 @@ func XCTAssertThrowsErrorAsync<T, R>(
     line: UInt = #line
 ) async where T: Sendable, R: Equatable, R: StytchError {
     do {
-        let _ = try await expression()
+        _ = try await expression()
         XCTFail(message(), file: file, line: line)
     } catch {
         XCTAssertEqual(error as? R, errorThrown())


### PR DESCRIPTION
Linear Ticket: [SDK-1315](https://linear.app/stytch/issue/SDK-1315)

## Changes:

1. Updated `XCTAssertThrowsErrorAsync` function to include a StytchError param
2. Updated unit tests using the `XCTAssertThrowsErrorAsync` function to check for specific errors

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A