### PR TITLE
[SDK-1298] Auth Response Callback

### DIFF
--- a/Sources/StytchUI/AuthRootViewController.swift
+++ b/Sources/StytchUI/AuthRootViewController.swift
@@ -5,40 +5,40 @@ import UIKit
 
 final class AuthRootViewController: UIViewController {
     private let config: StytchUIClient.Configuration
-    
+
     private var navController: UINavigationController?
-    
+
     private let activityIndicator: UIActivityIndicatorView = .init(style: .large)
-    
+
     private var onAuthCallback: AuthCallback?
-    
+
     init(config: StytchUIClient.Configuration, onAuthCallback: AuthCallback? = nil) {
         self.config = config
         self.onAuthCallback = onAuthCallback
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     @available(*, unavailable)
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         view.backgroundColor = .background
-        
+
         StytchClient.configure(publicToken: config.publicToken)
-        
+
         activityIndicator.hidesWhenStopped = true
-        
+
         view.addSubview(activityIndicator)
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor),
         ])
-        
+
         Task { @MainActor in
             defer { activityIndicator.stopAnimating() }
             activityIndicator.startAnimating()
@@ -49,7 +49,7 @@ final class AuthRootViewController: UIViewController {
             }
         }
     }
-    
+
     func handlePasswordReset(token: String, email: String, animated: Bool = true) {
         let controller = PasswordViewController(
             state: .init(
@@ -60,15 +60,15 @@ final class AuthRootViewController: UIViewController {
         ) { .password($0) }
         navController?.pushViewController(controller, animated: animated)
     }
-    
+
     @objc func dismissAuth() {
         presentingViewController?.dismiss(animated: true)
     }
-    
+
     private func handleAuthenticationSuccess(response: AuthenticateResponse) {
         onAuthCallback?(response)
     }
-    
+
     private func render(bootstrap: Bootstrap) {
         let homeController = AuthHomeViewController(state: .init(bootstrap: bootstrap, config: config)) { $0 }
         if let closeButton = config.navigation?.closeButtonStyle {
@@ -86,7 +86,7 @@ final class AuthRootViewController: UIViewController {
         navigationController.navigationBar.tintColor = .primaryText
         navigationController.navigationBar.barTintColor = .background
         navigationController.navigationBar.shadowImage = .init()
-        
+
         addChild(navigationController)
         view.addSubview(navigationController.view)
         navigationController.view.frame = view.bounds
@@ -162,11 +162,11 @@ private extension AuthRootViewController {
             present(navigationController, animated: true)
         }
     }
-    
+
     func handle(oauthAction: OAuthVCAction) async throws {
         guard let oauth = config.oauth else { return }
         let response: AuthenticateResponse
-        
+
         switch oauthAction {
         case let .didTap(provider):
             switch provider {
@@ -181,10 +181,10 @@ private extension AuthRootViewController {
             }
         }
     }
-    
+
     func handle(passwordAction: PasswordVCAction) async throws {
         let response: AuthenticateResponse
-        
+
         switch passwordAction {
         case let .didTapEmailLoginLink(email):
             guard let magicLink = config.magicLink else { return }
@@ -212,10 +212,10 @@ private extension AuthRootViewController {
             navController?.pushViewController(controller, animated: true)
         }
     }
-    
+
     func handle(otpAction: OTPVCAction) async throws {
         let response: AuthenticateResponse
-        
+
         switch otpAction {
         case let .didTapResendCode(phone, controller):
             let expiry = Date().addingTimeInterval(120)
@@ -237,7 +237,7 @@ private extension AuthRootViewController {
             }
         }
     }
-    
+
     func handle(aiAction: AIVCAction) async throws {
         switch aiAction {
         case let .didTapCreatePassword(email):
@@ -258,7 +258,7 @@ private extension AuthRootViewController {
     var sessionDuration: Minutes {
         config.session?.sessionDuration ?? .defaultSessionDuration
     }
-    
+
     func params(email: String, password: StytchUIClient.Configuration.Password) -> StytchClient.Passwords.ResetByEmailStartParameters {
         .init(
             email: email,
@@ -269,7 +269,7 @@ private extension AuthRootViewController {
             resetPasswordTemplateId: password.resetPasswordTemplateId
         )
     }
-    
+
     func params(email: String, magicLink: StytchUIClient.Configuration.MagicLink) -> StytchClient.MagicLinks.Email.Parameters {
         .init(
             email: email,
@@ -351,7 +351,7 @@ private struct UserSearchResponse: Decodable {
         case password
         case passwordless
     }
-    
+
     let userType: UserType
 }
 
@@ -366,7 +366,7 @@ private extension StytchUIClient.Configuration.Navigation.CloseButtonStyle {
             return .done
         }
     }
-    
+
     var position: StytchUIClient.Configuration.Navigation.BarButtonPosition {
         switch self {
         case let .cancel(position), let .close(position), let .done(position):

--- a/Sources/StytchUI/AuthRootViewController.swift
+++ b/Sources/StytchUI/AuthRootViewController.swift
@@ -321,6 +321,8 @@ private extension StytchClient.OAuth.ThirdParty.Provider {
             return StytchClient.oauth.twitch
         case .twitter:
             return StytchClient.oauth.twitter
+        case .yahoo:
+            return StytchClient.oauth.yahoo
         }
     }
 }

--- a/Sources/StytchUI/AuthRootViewController.swift
+++ b/Sources/StytchUI/AuthRootViewController.swift
@@ -66,18 +66,7 @@ final class AuthRootViewController: UIViewController {
     }
     
     private func handleAuthenticationSuccess(response: AuthenticateResponse) {
-        //            // Check if the user is new or returning
-        //            let isNewUser = response.userType == .new
-        
-        // Invoke the callback with the authentication response
         onAuthCallback?(response)
-        
-        //            // You can perform additional actions based on whether the user is new or returning
-        //            if isNewUser {
-        //                print("New user authenticated!")
-        //            } else {
-        //                print("Returning user authenticated!")
-        //            }
     }
     
     private func render(bootstrap: Bootstrap) {

--- a/Sources/StytchUI/StytchUIClient.swift
+++ b/Sources/StytchUI/StytchUIClient.swift
@@ -9,14 +9,14 @@ public typealias AuthCallback = (AuthenticateResponseType) -> Void
 public enum StytchUIClient {
     // Used to store pending reset emails so as to preserve state
     static var pendingResetEmail: String?
-    
+
     // swiftformat:disable modifierOrder
     fileprivate static weak var currentController: AuthRootViewController?
-    
+
     fileprivate static var config: Configuration?
-    
+
     private static var cancellable: AnyCancellable?
-    
+
     /// Presents Stytch's authentication UI, which will self dismiss after successful authentication. Use `StytchClient.sessions.onAuthChange` to observe auth changes.
     public static func presentController(
         with config: Configuration,
@@ -29,7 +29,7 @@ public enum StytchUIClient {
         setUpSessionChangeListener()
         controller.present(rootController, animated: true)
     }
-    
+
     /// Use this function to handle incoming deeplinks for password resets. If presenting from SwiftUI, ensure the sheet is presented before calling this handler. You can use `StytchClient.canHandle(url:)` to determine if you should present the SwiftUI sheet before calling this handler.
     public static func handle(url: URL, from controller: UIViewController? = nil, onAuthCallback: AuthCallback? = nil) -> Bool {
         Task { @MainActor in
@@ -51,7 +51,7 @@ public enum StytchUIClient {
         }
         return StytchClient.canHandle(url: url)
     }
-    
+
     static func setUpSessionChangeListener() {
         cancellable = StytchClient.sessions.onAuthChange
             .compactMap { $0 }
@@ -84,21 +84,21 @@ public extension StytchUIClient {
         let navigation: Navigation?
         let products: Products
         let session: Session?
-        
+
         var inputProductsEnabled: Bool {
             password != nil ||
             magicLink != nil ||
             sms != nil
         }
-        
+
         var oauth: OAuth? { products.oauth }
-        
+
         var password: Password? { products.password }
-        
+
         var magicLink: MagicLink? { products.magicLink }
-        
+
         var sms: OTP? { products.sms }
-        
+
         public init(
             publicToken: String,
             navigation: Navigation? = nil,
@@ -110,13 +110,13 @@ public extension StytchUIClient {
             self.products = products
             self.session = session
         }
-        
+
         public struct Products {
             let oauth: OAuth?
             let password: Password?
             let magicLink: MagicLink?
             let sms: OTP?
-            
+
             public init(
                 oauth: OAuth? = nil,
                 password: Password? = nil,
@@ -129,24 +129,24 @@ public extension StytchUIClient {
                 self.sms = sms
             }
         }
-        
+
         public struct OAuth {
             let providers: [Provider]
             let loginRedirectUrl: URL
             let signupRedirectUrl: URL
-            
+
             public init(providers: [Provider], loginRedirectUrl: URL, signupRedirectUrl: URL) {
                 self.providers = providers
                 self.loginRedirectUrl = loginRedirectUrl
                 self.signupRedirectUrl = signupRedirectUrl
             }
-            
+
             public enum Provider {
                 case apple
                 case thirdParty(StytchClient.OAuth.ThirdParty.Provider)
             }
         }
-        
+
         public struct MagicLink {
             let loginMagicLinkUrl: URL?
             let loginExpiration: Minutes?
@@ -154,7 +154,7 @@ public extension StytchUIClient {
             let signupMagicLinkUrl: URL?
             let signupExpiration: Minutes?
             let signupTemplateId: String?
-            
+
             public init(
                 loginMagicLinkUrl: URL? = nil,
                 loginExpiration: Minutes? = nil,
@@ -171,14 +171,14 @@ public extension StytchUIClient {
                 self.signupTemplateId = signupTemplateId
             }
         }
-        
+
         public struct Password {
             let loginURL: URL?
             let loginExpiration: Minutes?
             let resetPasswordURL: URL?
             let resetPasswordExpiration: Minutes?
             let resetPasswordTemplateId: String?
-            
+
             public init(
                 loginURL: URL? = nil,
                 loginExpiration: Minutes? = nil,
@@ -193,39 +193,39 @@ public extension StytchUIClient {
                 self.resetPasswordTemplateId = resetPasswordTemplateId
             }
         }
-        
+
         public struct OTP {
             let expiration: Minutes?
-            
+
             public init(
                 expiration: Minutes? = nil
             ) {
                 self.expiration = expiration
             }
         }
-        
+
         public struct Session {
             let sessionDuration: Minutes?
-            
+
             public init(sessionDuration: Minutes? = nil) {
                 self.sessionDuration = sessionDuration
             }
         }
-        
+
         public struct Navigation {
             let closeButtonStyle: CloseButtonStyle?
-            
+
             /// - Parameter closeButtonStyle: Determines the type of close button used on the root view as well as its position.
             public init(closeButtonStyle: CloseButtonStyle? = .close(.right)) {
                 self.closeButtonStyle = closeButtonStyle
             }
-            
+
             public enum CloseButtonStyle {
                 case cancel(BarButtonPosition = .right)
                 case close(BarButtonPosition = .right)
                 case done(BarButtonPosition = .right)
             }
-            
+
             public enum BarButtonPosition {
                 case left
                 case right
@@ -236,25 +236,17 @@ public extension StytchUIClient {
 
 struct AuthenticationView: UIViewControllerRepresentable {
     typealias UIViewControllerType = UIViewController
-    
+
     let config: StytchUIClient.Configuration
     let onAuthCallback: AuthCallback?
-    
-    init(
-        config: StytchUIClient.Configuration,
-        onAuthCallback: AuthCallback?
-    ) {
-        self.config = config
-        self.onAuthCallback = onAuthCallback
-    }
-    
+
     func makeUIViewController(context _: Context) -> UIViewController {
         let controller = AuthRootViewController(config: config, onAuthCallback: onAuthCallback)
         StytchUIClient.currentController = controller
         StytchUIClient.setUpSessionChangeListener()
         return controller
     }
-    
+
     func updateUIViewController(_: UIViewController, context _: Context) {}
 }
 

--- a/Sources/StytchUI/StytchUIClient.swift
+++ b/Sources/StytchUI/StytchUIClient.swift
@@ -3,29 +3,35 @@ import StytchCore
 import SwiftUI
 import UIKit
 
+public typealias AuthCallback = (AuthenticateResponseType) -> Void
+
 /// This type serves as the entry point for all usages of the Stytch authentication UI.
 public enum StytchUIClient {
     // Used to store pending reset emails so as to preserve state
     static var pendingResetEmail: String?
-
+    
     // swiftformat:disable modifierOrder
     fileprivate static weak var currentController: AuthRootViewController?
-
+    
     fileprivate static var config: Configuration?
-
+    
     private static var cancellable: AnyCancellable?
-
+    
     /// Presents Stytch's authentication UI, which will self dismiss after successful authentication. Use `StytchClient.sessions.onAuthChange` to observe auth changes.
-    public static func presentController(with config: Configuration, from controller: UIViewController) {
+    public static func presentController(
+        with config: Configuration,
+        from controller: UIViewController,
+        onAuthCallback: AuthCallback? = nil
+    ) {
         Self.config = config
-        let rootController = AuthRootViewController(config: config)
+        let rootController = AuthRootViewController(config: config, onAuthCallback: onAuthCallback)
         currentController = rootController
         setUpSessionChangeListener()
         controller.present(rootController, animated: true)
     }
-
+    
     /// Use this function to handle incoming deeplinks for password resets. If presenting from SwiftUI, ensure the sheet is presented before calling this handler. You can use `StytchClient.canHandle(url:)` to determine if you should present the SwiftUI sheet before calling this handler.
-    public static func handle(url: URL, from controller: UIViewController? = nil) -> Bool {
+    public static func handle(url: URL, from controller: UIViewController? = nil, onAuthCallback: AuthCallback? = nil) -> Bool {
         Task { @MainActor in
             switch try await StytchClient.handle(url: url) {
             case .handled, .notHandled:
@@ -35,7 +41,7 @@ public enum StytchUIClient {
                 if let currentController {
                     currentController.handlePasswordReset(token: token, email: email)
                 } else if let config {
-                    let rootController = AuthRootViewController(config: config)
+                    let rootController = AuthRootViewController(config: config, onAuthCallback: onAuthCallback)
                     currentController = rootController
                     setUpSessionChangeListener()
                     controller?.present(rootController, animated: true)
@@ -45,7 +51,7 @@ public enum StytchUIClient {
         }
         return StytchClient.canHandle(url: url)
     }
-
+    
     static func setUpSessionChangeListener() {
         cancellable = StytchClient.sessions.onAuthChange
             .compactMap { $0 }
@@ -59,10 +65,14 @@ public enum StytchUIClient {
 
 public extension View {
     /// Presents Stytch's authentication UI, which will self dismiss after successful authentication. Use `StytchClient.sessions.onAuthChange` to observe auth changes.
-    func authenticationSheet(isPresented: Binding<Bool>, config: StytchUIClient.Configuration) -> some View {
+    func authenticationSheet(
+        isPresented: Binding<Bool>,
+        config: StytchUIClient.Configuration,
+        onAuthCallback: AuthCallback? = nil
+    ) -> some View {
         sheet(isPresented: isPresented) {
             StytchUIClient.config = config
-            return AuthenticationView(config: config)
+            return AuthenticationView(config: config, onAuthCallback: onAuthCallback)
                 .background(Color(.background).edgesIgnoringSafeArea(.all))
         }
     }
@@ -74,21 +84,21 @@ public extension StytchUIClient {
         let navigation: Navigation?
         let products: Products
         let session: Session?
-
+        
         var inputProductsEnabled: Bool {
             password != nil ||
-                magicLink != nil ||
-                sms != nil
+            magicLink != nil ||
+            sms != nil
         }
-
+        
         var oauth: OAuth? { products.oauth }
-
+        
         var password: Password? { products.password }
-
+        
         var magicLink: MagicLink? { products.magicLink }
-
+        
         var sms: OTP? { products.sms }
-
+        
         public init(
             publicToken: String,
             navigation: Navigation? = nil,
@@ -100,13 +110,13 @@ public extension StytchUIClient {
             self.products = products
             self.session = session
         }
-
+        
         public struct Products {
             let oauth: OAuth?
             let password: Password?
             let magicLink: MagicLink?
             let sms: OTP?
-
+            
             public init(
                 oauth: OAuth? = nil,
                 password: Password? = nil,
@@ -119,24 +129,24 @@ public extension StytchUIClient {
                 self.sms = sms
             }
         }
-
+        
         public struct OAuth {
             let providers: [Provider]
             let loginRedirectUrl: URL
             let signupRedirectUrl: URL
-
+            
             public init(providers: [Provider], loginRedirectUrl: URL, signupRedirectUrl: URL) {
                 self.providers = providers
                 self.loginRedirectUrl = loginRedirectUrl
                 self.signupRedirectUrl = signupRedirectUrl
             }
-
+            
             public enum Provider {
                 case apple
                 case thirdParty(StytchClient.OAuth.ThirdParty.Provider)
             }
         }
-
+        
         public struct MagicLink {
             let loginMagicLinkUrl: URL?
             let loginExpiration: Minutes?
@@ -144,7 +154,7 @@ public extension StytchUIClient {
             let signupMagicLinkUrl: URL?
             let signupExpiration: Minutes?
             let signupTemplateId: String?
-
+            
             public init(
                 loginMagicLinkUrl: URL? = nil,
                 loginExpiration: Minutes? = nil,
@@ -161,14 +171,14 @@ public extension StytchUIClient {
                 self.signupTemplateId = signupTemplateId
             }
         }
-
+        
         public struct Password {
             let loginURL: URL?
             let loginExpiration: Minutes?
             let resetPasswordURL: URL?
             let resetPasswordExpiration: Minutes?
             let resetPasswordTemplateId: String?
-
+            
             public init(
                 loginURL: URL? = nil,
                 loginExpiration: Minutes? = nil,
@@ -183,39 +193,39 @@ public extension StytchUIClient {
                 self.resetPasswordTemplateId = resetPasswordTemplateId
             }
         }
-
+        
         public struct OTP {
             let expiration: Minutes?
-
+            
             public init(
                 expiration: Minutes? = nil
             ) {
                 self.expiration = expiration
             }
         }
-
+        
         public struct Session {
             let sessionDuration: Minutes?
-
+            
             public init(sessionDuration: Minutes? = nil) {
                 self.sessionDuration = sessionDuration
             }
         }
-
+        
         public struct Navigation {
             let closeButtonStyle: CloseButtonStyle?
-
+            
             /// - Parameter closeButtonStyle: Determines the type of close button used on the root view as well as its position.
             public init(closeButtonStyle: CloseButtonStyle? = .close(.right)) {
                 self.closeButtonStyle = closeButtonStyle
             }
-
+            
             public enum CloseButtonStyle {
                 case cancel(BarButtonPosition = .right)
                 case close(BarButtonPosition = .right)
                 case done(BarButtonPosition = .right)
             }
-
+            
             public enum BarButtonPosition {
                 case left
                 case right
@@ -226,20 +236,25 @@ public extension StytchUIClient {
 
 struct AuthenticationView: UIViewControllerRepresentable {
     typealias UIViewControllerType = UIViewController
-
+    
     let config: StytchUIClient.Configuration
-
-    init(config: StytchUIClient.Configuration) {
+    let onAuthCallback: AuthCallback?
+    
+    init(
+        config: StytchUIClient.Configuration,
+        onAuthCallback: AuthCallback?
+    ) {
         self.config = config
+        self.onAuthCallback = onAuthCallback
     }
-
+    
     func makeUIViewController(context _: Context) -> UIViewController {
-        let controller = AuthRootViewController(config: config)
+        let controller = AuthRootViewController(config: config, onAuthCallback: onAuthCallback)
         StytchUIClient.currentController = controller
         StytchUIClient.setUpSessionChangeListener()
         return controller
     }
-
+    
     func updateUIViewController(_: UIViewController, context _: Context) {}
 }
 

--- a/Sources/StytchUI/StytchUIClient.swift
+++ b/Sources/StytchUI/StytchUIClient.swift
@@ -87,8 +87,8 @@ public extension StytchUIClient {
 
         var inputProductsEnabled: Bool {
             password != nil ||
-            magicLink != nil ||
-            sms != nil
+                magicLink != nil ||
+                sms != nil
         }
 
         var oauth: OAuth? { products.oauth }

--- a/StytchDemo/Client/Shared/AuthenticationOptionsView.swift
+++ b/StytchDemo/Client/Shared/AuthenticationOptionsView.swift
@@ -7,19 +7,19 @@ struct AuthenticationOptionsView: View {
     let onAuth: (AuthenticateResponseType) -> Void
     @Environment(\.presentationMode) private var presentationMode
     @State private var authPresented = false
-
+    
     var redirectUrl: URL { configuration.serverUrl }
-
+    
     var body: some View {
         VStack {
             Button("Authenticate with UI") {
                 authPresented = true
             }
             .padding()
-
+            
             NavigationLink("Authenticate with Email") { EmailAuthenticationView() }
                 .padding()
-
+            
             NavigationLink("Authenticate with Password") {
                 PasswordAuthenticationView {
                     onAuth($0)
@@ -27,7 +27,7 @@ struct AuthenticationOptionsView: View {
                 }
             }
             .padding()
-
+            
             if #available(iOS 16.0, macOS 13.0, *) {
                 NavigationLink("Authenticate with Passkeys") {
                     PasskeysAuthenticationView {
@@ -38,7 +38,7 @@ struct AuthenticationOptionsView: View {
                 }
                 .padding()
             }
-
+            
             NavigationLink("Authenticate with OTP") {
                 OTPAuthenticationView(session: session) {
                     onAuth($0)
@@ -46,7 +46,7 @@ struct AuthenticationOptionsView: View {
                 }
             }
             .padding()
-
+            
             NavigationLink("Authenticate with OAuth") {
                 OAuthAuthenticationView {
                     onAuth($0)
@@ -54,7 +54,7 @@ struct AuthenticationOptionsView: View {
                 }
             }
             .padding()
-
+            
             if StytchClient.biometrics.registrationAvailable {
                 Button("Authenticate with Biometrics") {
                     Task {
@@ -80,7 +80,7 @@ struct AuthenticationOptionsView: View {
                 }
                 .padding()
             }
-
+            
             NavigationLink("Authenticate with TOTP") {
                 TOTPAuthenticationView {
                     onAuth($0)
@@ -111,7 +111,8 @@ struct AuthenticationOptionsView: View {
                     ),
                     sms: .init()
                 )
-            )
-        )
+            )) { response in
+                onAuth(response)
+            }
     }
 }

--- a/StytchDemo/Client/Shared/AuthenticationOptionsView.swift
+++ b/StytchDemo/Client/Shared/AuthenticationOptionsView.swift
@@ -7,19 +7,19 @@ struct AuthenticationOptionsView: View {
     let onAuth: (AuthenticateResponseType) -> Void
     @Environment(\.presentationMode) private var presentationMode
     @State private var authPresented = false
-    
+
     var redirectUrl: URL { configuration.serverUrl }
-    
+
     var body: some View {
         VStack {
             Button("Authenticate with UI") {
                 authPresented = true
             }
             .padding()
-            
+
             NavigationLink("Authenticate with Email") { EmailAuthenticationView() }
                 .padding()
-            
+
             NavigationLink("Authenticate with Password") {
                 PasswordAuthenticationView {
                     onAuth($0)
@@ -27,7 +27,7 @@ struct AuthenticationOptionsView: View {
                 }
             }
             .padding()
-            
+
             if #available(iOS 16.0, macOS 13.0, *) {
                 NavigationLink("Authenticate with Passkeys") {
                     PasskeysAuthenticationView {
@@ -38,7 +38,7 @@ struct AuthenticationOptionsView: View {
                 }
                 .padding()
             }
-            
+
             NavigationLink("Authenticate with OTP") {
                 OTPAuthenticationView(session: session) {
                     onAuth($0)
@@ -46,7 +46,7 @@ struct AuthenticationOptionsView: View {
                 }
             }
             .padding()
-            
+
             NavigationLink("Authenticate with OAuth") {
                 OAuthAuthenticationView {
                     onAuth($0)
@@ -54,7 +54,7 @@ struct AuthenticationOptionsView: View {
                 }
             }
             .padding()
-            
+
             if StytchClient.biometrics.registrationAvailable {
                 Button("Authenticate with Biometrics") {
                     Task {
@@ -80,7 +80,7 @@ struct AuthenticationOptionsView: View {
                 }
                 .padding()
             }
-            
+
             NavigationLink("Authenticate with TOTP") {
                 TOTPAuthenticationView {
                     onAuth($0)
@@ -113,6 +113,6 @@ struct AuthenticationOptionsView: View {
                 )
             )) { response in
                 onAuth(response)
-            }
+        }
     }
 }

--- a/StytchDemo/Client/Shared/AuthenticationOptionsView.swift
+++ b/StytchDemo/Client/Shared/AuthenticationOptionsView.swift
@@ -111,8 +111,9 @@ struct AuthenticationOptionsView: View {
                     ),
                     sms: .init()
                 )
-            )) { response in
-                onAuth(response)
+            )
+        ) { response in
+            onAuth(response)
         }
     }
 }


### PR DESCRIPTION
Linear Ticket: [SDK-1298](https://linear.app/stytch/issue/SDK-1298)

## Changes:

- Adds an `onAuthCallback` param that allows a callback with `AuthenticateResponse` after successful authentication

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A