### PR TITLE
Fix password reset UI

### DIFF
--- a/Sources/StytchCore/DeeplinkHandledStatus.swift
+++ b/Sources/StytchCore/DeeplinkHandledStatus.swift
@@ -4,7 +4,7 @@
  */
 public enum DeeplinkHandledStatus<AuthenticateResponse, DeeplinkTokenType> {
     /// The handler was successfully able to handle the given item.
-    case handled(AuthenticateResponse)
+    case handled(response: AuthenticateResponse)
     /// The handler was unable to handle the given item.
     case notHandled
     /// The handler recognized the token type, but manual handing is required. This should only be encountered for password reset deeplinks.

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -60,14 +60,14 @@ public struct StytchB2BClient: StytchClientType {
 
         switch tokenType {
         case .discovery:
-            return try await .handled(.discovery(magicLinks.discoveryAuthenticate(parameters: .init(token: token))))
+            return try await .handled(response: .discovery(magicLinks.discoveryAuthenticate(parameters: .init(token: token))))
         case .multiTenantMagicLinks:
-            return try await .handled(.auth(magicLinks.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
+            return try await .handled(response: .auth(magicLinks.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
         case .multiTenantPasswords:
             return .manualHandlingRequired(.multiTenantPasswords, token: token)
         #if !os(watchOS)
         case .sso:
-            return try await .handled(.auth(sso.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
+            return try await .handled(response: .auth(sso.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
         #endif
         }
     }

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -66,9 +66,9 @@ public struct StytchClient: StytchClientType {
 
         switch tokenType {
         case .magicLinks:
-            return try await .handled(magicLinks.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration)))
+            return try await .handled(response: magicLinks.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration)))
         case .oauth:
-            return try await .handled(oauth.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration)))
+            return try await .handled(response: oauth.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration)))
         case .passwordReset:
             return .manualHandlingRequired(tokenType, token: token)
         }

--- a/Sources/StytchUI/PasswordViewModel.swift
+++ b/Sources/StytchUI/PasswordViewModel.swift
@@ -29,7 +29,8 @@ extension PasswordViewModel: PasswordViewModelProtocol {
     }
 
     func signup(email: String, password: String) async throws {
-        _ = try await StytchClient.passwords.create(parameters: .init(email: email, password: password, sessionDuration: sessionDuration))
+        let response = try await StytchClient.passwords.create(parameters: .init(email: email, password: password, sessionDuration: sessionDuration))
+        StytchUIClient.onAuthCallback?(response)
     }
 
     func login(email: String, password: String) async throws {

--- a/StytchDemo/Client/Shared/AuthenticationOptionsView.swift
+++ b/StytchDemo/Client/Shared/AuthenticationOptionsView.swift
@@ -101,13 +101,13 @@ struct AuthenticationOptionsView: View {
                         signupRedirectUrl: .init(string: "stytch-auth://signup")!
                     ),
                     password: .init(
-                        loginURL: redirectUrl,
-                        resetPasswordURL: redirectUrl,
+                        loginURL: .init(string: "stytch-auth://login")!,
+                        resetPasswordURL: .init(string: "stytch-auth://reset")!,
                         resetPasswordExpiration: 120
                     ),
                     magicLink: .init(
-                        loginMagicLinkUrl: redirectUrl,
-                        signupMagicLinkUrl: redirectUrl
+                        loginMagicLinkUrl: .init(string: "stytch-auth://login")!,
+                        signupMagicLinkUrl: .init(string: "stytch-auth://signup")!
                     ),
                     sms: .init()
                 )


### PR DESCRIPTION
Linear Ticket: [SDK-1299](https://linear.app/stytch/issue/SDK-1299)

## Changes:

- fixes UI displaying for redirected password reset flow
- calls `onAuthCallback` after any deeplink handled response

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A