### PR TITLE
SDK-1361 UI Test OTP screen

### DIFF
--- a/Sources/StytchUI/AuthInputViewController.swift
+++ b/Sources/StytchUI/AuthInputViewController.swift
@@ -21,6 +21,7 @@ final class AuthInputViewController: BaseViewController<AuthInputState, AuthInpu
             animated: false
         )
         segmentedControl.selectedSegmentIndex = 0
+        segmentedControl.accessibilityLabel = "emailTextSegmentedControl"
         return segmentedControl
     }()
 
@@ -35,6 +36,7 @@ final class AuthInputViewController: BaseViewController<AuthInputState, AuthInpu
             self?.didTapContinue()
         }
         button.isEnabled = false
+        button.accessibilityLabel = "continueButton"
         return button
     }()
 

--- a/Sources/StytchUI/Inputs/CodeInput.swift
+++ b/Sources/StytchUI/Inputs/CodeInput.swift
@@ -13,6 +13,7 @@ final class CodeInput: TextInputView<CodeField> {
         }
         textInput.textContentType = .oneTimeCode
         textInput.delegate = self
+        textInput.accessibilityLabel = "otpEntry"
     }
 }
 

--- a/Sources/StytchUI/Inputs/PhoneNumberInput.swift
+++ b/Sources/StytchUI/Inputs/PhoneNumberInput.swift
@@ -70,6 +70,7 @@ final class PhoneNumberInputContainer: UIView, TextInputType {
         let view = UIStackView()
         view.axis = .horizontal
         view.spacing = 8
+        view.accessibilityLabel = "phoneNumberEntry"
         return view
     }()
 

--- a/Sources/StytchUI/OTPCodeViewController.swift
+++ b/Sources/StytchUI/OTPCodeViewController.swift
@@ -3,7 +3,8 @@ import UIKit
 
 final class OTPCodeViewController: BaseViewController<OTPCodeState, OTPCodeViewModel> {
     private let titleLabel: UILabel = .makeTitleLabel(
-        text: NSLocalizedString("stytch.otpTitle", value: "Enter passcode", comment: "")
+        text: NSLocalizedString("stytch.otpTitle", value: "Enter passcode", comment: ""),
+        accessibilityLabel: "otpConfirmationTitle"
     )
 
     private let phoneLabel: UILabel = {
@@ -11,6 +12,7 @@ final class OTPCodeViewController: BaseViewController<OTPCodeState, OTPCodeViewM
         label.numberOfLines = 0
         label.font = .systemFont(ofSize: 18)
         label.textColor = .primaryText
+        label.accessibilityLabel = "phoneLabel"
         return label
     }()
 
@@ -25,6 +27,7 @@ final class OTPCodeViewController: BaseViewController<OTPCodeState, OTPCodeViewM
         button.setTitleColor(.secondaryText, for: .normal)
         button.contentHorizontalAlignment = .leading
         button.titleLabel?.numberOfLines = 0
+        button.accessibilityLabel = "expiryButton"
         return button
     }()
 

--- a/StytchDemo/StytchDemo.xcodeproj/project.pbxproj
+++ b/StytchDemo/StytchDemo.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		53E1283F2B50092F00976CAC /* StytchUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StytchUITests.swift; sourceTree = "<group>"; };
 		53E128412B50092F00976CAC /* StytchUILaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StytchUILaunchTests.swift; sourceTree = "<group>"; };
 		53E1284C2B500C7400976CAC /* StytchUIDemo.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = StytchUIDemo.xctestplan; sourceTree = "<group>"; };
+		7763D5AF2B58698F00F00737 /* StytchUIDemo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StytchUIDemo.entitlements; sourceTree = "<group>"; };
 		77AC9C632AA0FF4A004059CF /* StytchDemo (iOS)-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StytchDemo (iOS)-Bridging-Header.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -393,6 +394,7 @@
 		53E128232B50092E00976CAC /* StytchUIDemo */ = {
 			isa = PBXGroup;
 			children = (
+				7763D5AF2B58698F00F00737 /* StytchUIDemo.entitlements */,
 				53E128242B50092E00976CAC /* StytchUIDemoApp.swift */,
 				53E128262B50092E00976CAC /* ContentView.swift */,
 				53E128282B50092F00976CAC /* Assets.xcassets */,
@@ -1155,6 +1157,7 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = StytchUIDemo/StytchUIDemo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"StytchUIDemo/Preview Content\"";
@@ -1193,6 +1196,7 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = StytchUIDemo/StytchUIDemo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"StytchUIDemo/Preview Content\"";

--- a/StytchDemo/StytchUIDemo/ContentView.swift
+++ b/StytchDemo/StytchUIDemo/ContentView.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import StytchUI
+import SwiftUI
 
 struct ContentView: View {
     @State private var authPresented = true

--- a/StytchDemo/StytchUIDemo/StytchUIDemo.entitlements
+++ b/StytchDemo/StytchUIDemo/StytchUIDemo.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/StytchDemo/StytchUIDemo/StytchUIDemoApp.swift
+++ b/StytchDemo/StytchUIDemo/StytchUIDemoApp.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import StytchUI
+import SwiftUI
 
 let configuration: StytchUIDemoApp.Configuration = {
     guard let data = Bundle.main.url(forResource: "StytchUIConfiguration", withExtension: "plist").flatMap({ try? Data(contentsOf: $0) })

--- a/StytchDemo/StytchUITests/StytchUILaunchTests.swift
+++ b/StytchDemo/StytchUITests/StytchUILaunchTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 
 final class StytchUILaunchTests: XCTestCase {
-
     override class var runsForEachTargetApplicationUIConfiguration: Bool {
         true
     }

--- a/StytchDemo/StytchUITests/StytchUITests.swift
+++ b/StytchDemo/StytchUITests/StytchUITests.swift
@@ -44,6 +44,34 @@ final class StytchUITests: XCTestCase {
         XCTAssert(poweredByStytch.exists)
     }
 
+    func testOTPScreen() throws {
+        // UI tests must launch the application that they test.
+        app.launchEnvironment["config"] = "realistic"
+        app.launch()
+        let phoneNumberInput = app.otherElements.element(matching: .any, identifier: "phoneNumberEntry")
+
+        // Default
+        XCTAssert(!phoneNumberInput.exists)
+
+        // Switch to phone input and enter number
+        app.otherElements/*@START_MENU_TOKEN@*/.buttons["Text"]/*[[".segmentedControls[\"emailTextSegmentedControl\"].buttons[\"Text\"]",".buttons[\"Text\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        XCTAssert(phoneNumberInput.exists)
+        let phoneInput = phoneNumberInput.descendants(matching: .textField).element
+        phoneInput.tap()
+        phoneInput.typeText("5005550006")
+        app.otherElements.buttons["continueButton"].tap()
+        // Wait to navigate to OTP screen
+        let otpPageTitle = app.staticTexts.element(matching: .any, identifier: "otpConfirmationTitle")
+        let otpPhoneLabel = app.staticTexts.element(matching: .any, identifier: "phoneLabel")
+        let otpEntry = app.textFields.element(matching: .any, identifier: "otpEntry")
+        let expiryButton = app.buttons.element(matching: .any, identifier: "expiryButton")
+        let _ = otpPageTitle.waitForExistence(timeout: 10)
+        XCTAssert(otpPageTitle.exists)
+        XCTAssert(otpPhoneLabel.exists)
+        XCTAssert(otpEntry.exists)
+        XCTAssert(expiryButton.exists)
+    }
+
     func testLaunchPerformance() throws {
         if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
             // This measures how long it takes to launch your application.
@@ -53,3 +81,4 @@ final class StytchUITests: XCTestCase {
         }
     }
 }
+

--- a/StytchDemo/StytchUITests/StytchUITests.swift
+++ b/StytchDemo/StytchUITests/StytchUITests.swift
@@ -71,6 +71,50 @@ final class StytchUITests: XCTestCase {
         XCTAssert(expiryButton.exists)
     }
 
+    func testOAuthGoogle() throws {
+        app.launchEnvironment["config"] = "realistic"
+        app.launch()
+        let googleButton = app.staticTexts["Continue with Google"]
+        XCTAssert(googleButton.exists)
+        var didDismissPopup = false
+        addUIInterruptionMonitor(withDescription: "Continue with Google popup") { alert in
+            let title = alert.staticTexts["“StytchUIDemo” Wants to Use “stytch.com” to Sign In"]
+            XCTAssert(title.exists)
+            alert.scrollViews.otherElements.buttons["Cancel"].tap()
+            didDismissPopup = true
+            return true
+        }
+        googleButton.tap()
+        // these two lines are the magic that make the interruption handler work
+        sleep(2)
+        app.swipeUp()
+        XCTAssert(didDismissPopup)
+        // Dismiss the expected error alert from canceling Google signin
+        app.alerts["Error"].scrollViews.otherElements.buttons["OK"].tap()
+    }
+
+    func testOAuthApple() throws {
+        app.launchEnvironment["config"] = "realistic"
+        app.launch()
+        let appleButton = app.buttons["Continue with Apple"]
+        XCTAssert(appleButton.exists)
+        var didDismissPopup = false
+        addUIInterruptionMonitor(withDescription: "Continue with Apple popup") { alert in
+            let title = alert.scrollViews.staticTexts["Sign in with your Apple ID"]
+            XCTAssert(title.exists)
+            alert.scrollViews.otherElements.buttons["Close"].tap()
+            didDismissPopup = true
+            return true
+        }
+        appleButton.tap()
+        // these two lines are the magic that make the interruption handler work
+        sleep(2)
+        app.swipeUp()
+        XCTAssert(didDismissPopup)
+        // Dismiss the expected error alert from canceling Apple signin
+        app.alerts["Error"].scrollViews.otherElements.buttons["OK"].tap()
+    }
+
     func testLaunchPerformance() throws {
         if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
             // This measures how long it takes to launch your application.

--- a/StytchDemo/StytchUITests/StytchUITests.swift
+++ b/StytchDemo/StytchUITests/StytchUITests.swift
@@ -1,7 +1,6 @@
 import XCTest
 
 final class StytchUITests: XCTestCase {
-
     let app = XCUIApplication()
 
     lazy var titleLabel = app.staticTexts.element(matching: .any, identifier: "authTitle")
@@ -54,7 +53,7 @@ final class StytchUITests: XCTestCase {
         XCTAssert(!phoneNumberInput.exists)
 
         // Switch to phone input and enter number
-        app.otherElements/*@START_MENU_TOKEN@*/.buttons["Text"]/*[[".segmentedControls[\"emailTextSegmentedControl\"].buttons[\"Text\"]",".buttons[\"Text\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        app.otherElements.segmentedControls["emailTextSegmentedControl"].buttons["Text"].tap()
         XCTAssert(phoneNumberInput.exists)
         let phoneInput = phoneNumberInput.descendants(matching: .textField).element
         phoneInput.tap()
@@ -81,4 +80,3 @@ final class StytchUITests: XCTestCase {
         }
     }
 }
-


### PR DESCRIPTION
Linear Ticket: [SDK-1361](https://linear.app/stytch/issue/SDK-1361)

## Changes:

1. Adds basic test for the OTP confirmation screen

## Notes:

- The phone number we're using is a Twilio test number

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A