### PR TITLE
SDK-1414 Add profile_picture_url to Provider struct

### DIFF
--- a/Sources/StytchCore/StytchClient/Models/User.swift
+++ b/Sources/StytchCore/StytchClient/Models/User.swift
@@ -110,6 +110,8 @@ public extension User {
         public let providerSubject: String
         /// The type of the provider.
         public let providerType: String
+        /// The profile picture set for the provider
+        public let profilePictureUrl: String?
     }
 
     struct PhoneNumber: Codable {


### PR DESCRIPTION
Linear Ticket: [SDK-1414](https://linear.app/stytch/issue/SDK-1414)

## Changes:

1. Adds profilePictureUrl to Provider struct

## Notes:

- Tested in demo app with GitHub login

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A