### PR TITLE
SDK-1401 quick win metrics

### DIFF
--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Events.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Events.swift
@@ -1,10 +1,10 @@
 import Foundation
-public protocol StytchClientEventsProtocol {
-    func logEvent(parameters: StytchClient.Events.Parameters) async throws
+public protocol StytchB2BClientEventsProtocol {
+    func logEvent(parameters: StytchB2BClient.Events.Parameters) async throws
 }
 
-public extension StytchClient {
-    struct Events: StytchClientEventsProtocol {
+public extension StytchB2BClient {
+    struct Events: StytchB2BClientEventsProtocol {
         let router: NetworkingRouter<EventsRoute>
 
         @Dependency(\.clientInfo) private var clientInfo
@@ -36,8 +36,7 @@ public extension StytchClient {
                 event: .init(
                     publicToken: networkingClient.publicToken,
                     eventName: parameters.eventName,
-                    details: parameters.details,
-                    error: parameters.error
+                    details: parameters.details
                 )
             )
             try await router.post(to: .logEvents, parameters: [params])
@@ -108,13 +107,11 @@ public extension StytchClient {
             let publicToken: String
             let eventName: String
             let details: [String: String]?
-            let errorDescription: String?
 
-            public init(publicToken: String, eventName: String, details: [String: String]? = nil, error: Error? = nil) {
+            public init(publicToken: String, eventName: String, details: [String: String]? = nil) {
                 self.publicToken = publicToken
                 self.eventName = eventName
                 self.details = details
-                self.errorDescription = error?.localizedDescription
             }
         }
 
@@ -125,20 +122,18 @@ public extension StytchClient {
     }
 }
 
-public extension StytchClient {
+public extension StytchB2BClient {
     static var events: Events { .init(router: router.scopedRouter { $0.events }, appSessionId: appSessionId) }
 }
 
-public extension StytchClient.Events {
+public extension StytchB2BClient.Events {
     struct Parameters {
         let eventName: String
         let details: [String: String]?
-        let error: Error?
 
-        public init(eventName: String, details: [String: String]? = nil, error: Error? = nil) {
+        public init(eventName: String, details: [String: String]? = nil) {
             self.eventName = eventName
             self.details = details
-            self.error = error
         }
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
@@ -6,6 +6,7 @@ extension StytchB2BClient {
         case passwords(PasswordsRoute)
         case sessions(SessionsRoute)
         case sso(SSORoute)
+        case events(EventsRoute)
         case bootstrap(BootstrapRoute)
 
         var path: Path {
@@ -28,6 +29,8 @@ extension StytchB2BClient {
             case let .sso(route):
                 return ("sso", route)
             case let .bootstrap(route):
+                return ("", route)
+            case let .events(route):
                 return ("", route)
             }
         }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -52,47 +52,32 @@ public struct StytchB2BClient: StytchClientType {
     ///    - sessionDuration: The duration, in minutes, of the requested session. Defaults to 30 minutes.
     public static func handle(url: URL, sessionDuration: Minutes) async throws -> DeeplinkHandledStatus<DeeplinkResponse, DeeplinkTokenType> {
         guard let (tokenType, token) = try tokenValues(for: url) else {
-            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
-                // only run this in non-test environments
-                Task {
-                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_failure", details: ["token_type": "UNKNOWN"]))
-                }
+            Task {
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_failure", details: ["token_type": "UNKNOWN"]))
             }
             return .notHandled
         }
 
         switch tokenType {
         case .discovery:
-            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
-                // only run this in non-test environments
-                Task {
-                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
-                }
+            Task {
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
             return try await .handled(response: .discovery(magicLinks.discoveryAuthenticate(parameters: .init(token: token))))
         case .multiTenantMagicLinks:
-            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
-                // only run this in non-test environments
-                Task {
-                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
-                }
+            Task {
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
             return try await .handled(response: .auth(magicLinks.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
         case .multiTenantPasswords:
-            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
-                // only run this in non-test environments
-                Task {
-                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
-                }
+            Task {
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
             return .manualHandlingRequired(.multiTenantPasswords, token: token)
         #if !os(watchOS)
         case .sso:
-            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
-                // only run this in non-test environments
-                Task {
-                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
-                }
+            Task {
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
             return try await .handled(response: .auth(sso.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
         #endif

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -14,6 +14,8 @@ public struct StytchB2BClient: StytchClientType {
     static let router: NetworkingRouter<BaseRoute> = .init { instance.configuration }
     public static var isInitialized: AnyPublisher<Bool, Never> { instance.initializationState.isInitialized }
 
+    static let appSessionId: String = UUID().uuidString
+
     private init() {
         postInit()
     }
@@ -50,18 +52,33 @@ public struct StytchB2BClient: StytchClientType {
     ///    - sessionDuration: The duration, in minutes, of the requested session. Defaults to 30 minutes.
     public static func handle(url: URL, sessionDuration: Minutes) async throws -> DeeplinkHandledStatus<DeeplinkResponse, DeeplinkTokenType> {
         guard let (tokenType, token) = try tokenValues(for: url) else {
+            Task {
+                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_failure", details: ["token_type" : "UNKNOWN"]))
+            }
             return .notHandled
         }
 
         switch tokenType {
         case .discovery:
+            Task {
+                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type" : tokenType.rawValue]))
+            }
             return try await .handled(response: .discovery(magicLinks.discoveryAuthenticate(parameters: .init(token: token))))
         case .multiTenantMagicLinks:
+            Task {
+                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type" : tokenType.rawValue]))
+            }
             return try await .handled(response: .auth(magicLinks.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
         case .multiTenantPasswords:
+            Task {
+                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type" : tokenType.rawValue]))
+            }
             return .manualHandlingRequired(.multiTenantPasswords, token: token)
         #if !os(watchOS)
         case .sso:
+            Task {
+                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type" : tokenType.rawValue]))
+            }
             return try await .handled(response: .auth(sso.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
         #endif
         }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -52,32 +52,47 @@ public struct StytchB2BClient: StytchClientType {
     ///    - sessionDuration: The duration, in minutes, of the requested session. Defaults to 30 minutes.
     public static func handle(url: URL, sessionDuration: Minutes) async throws -> DeeplinkHandledStatus<DeeplinkResponse, DeeplinkTokenType> {
         guard let (tokenType, token) = try tokenValues(for: url) else {
-            Task {
-                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_failure", details: ["token_type": "UNKNOWN"]))
+            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
+                // only run this in non-test environments
+                Task {
+                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_failure", details: ["token_type": "UNKNOWN"]))
+                }
             }
             return .notHandled
         }
 
         switch tokenType {
         case .discovery:
-            Task {
-                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
+                // only run this in non-test environments
+                Task {
+                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+                }
             }
             return try await .handled(response: .discovery(magicLinks.discoveryAuthenticate(parameters: .init(token: token))))
         case .multiTenantMagicLinks:
-            Task {
-                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
+                // only run this in non-test environments
+                Task {
+                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+                }
             }
             return try await .handled(response: .auth(magicLinks.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
         case .multiTenantPasswords:
-            Task {
-                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
+                // only run this in non-test environments
+                Task {
+                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+                }
             }
             return .manualHandlingRequired(.multiTenantPasswords, token: token)
         #if !os(watchOS)
         case .sso:
-            Task {
-                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
+                // only run this in non-test environments
+                Task {
+                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+                }
             }
             return try await .handled(response: .auth(sso.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
         #endif

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -53,7 +53,7 @@ public struct StytchB2BClient: StytchClientType {
     public static func handle(url: URL, sessionDuration: Minutes) async throws -> DeeplinkHandledStatus<DeeplinkResponse, DeeplinkTokenType> {
         guard let (tokenType, token) = try tokenValues(for: url) else {
             Task {
-                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_failure", details: ["token_type" : "UNKNOWN"]))
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_failure", details: ["token_type": "UNKNOWN"]))
             }
             return .notHandled
         }
@@ -61,23 +61,23 @@ public struct StytchB2BClient: StytchClientType {
         switch tokenType {
         case .discovery:
             Task {
-                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type" : tokenType.rawValue]))
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
             return try await .handled(response: .discovery(magicLinks.discoveryAuthenticate(parameters: .init(token: token))))
         case .multiTenantMagicLinks:
             Task {
-                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type" : tokenType.rawValue]))
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
             return try await .handled(response: .auth(magicLinks.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
         case .multiTenantPasswords:
             Task {
-                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type" : tokenType.rawValue]))
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
             return .manualHandlingRequired(.multiTenantPasswords, token: token)
         #if !os(watchOS)
         case .sso:
             Task {
-                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type" : tokenType.rawValue]))
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
             return try await .handled(response: .auth(sso.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
         #endif

--- a/Sources/StytchCore/StytchClient/Events/StytchClient+Events.swift
+++ b/Sources/StytchCore/StytchClient/Events/StytchClient+Events.swift
@@ -114,7 +114,7 @@ public extension StytchClient {
                 self.publicToken = publicToken
                 self.eventName = eventName
                 self.details = details
-                self.errorDescription = error?.localizedDescription
+                errorDescription = error?.localizedDescription
             }
         }
 

--- a/Sources/StytchCore/StytchClient/OAuth/StytchClient+OAuth.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/StytchClient+OAuth.swift
@@ -25,7 +25,7 @@ public extension StytchClient {
                 ) as AuthenticateResponse
                 try? await StytchClient.events.logEvent(parameters: .init(eventName: "oauth_success"))
                 return result
-            } catch let error {
+            } catch {
                 try? await StytchClient.events.logEvent(parameters: .init(eventName: "oauth_failure", error: error))
                 throw error
             }

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -57,38 +57,26 @@ public struct StytchClient: StytchClientType {
         sessionDuration: Minutes = .defaultSessionDuration
     ) async throws -> DeeplinkHandledStatus<AuthenticateResponse, DeeplinkTokenType> {
         guard let (tokenType, token) = try tokenValues(for: url) else {
-            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
-                // only run this in non-test environments
-                Task {
-                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_failure", details: ["token_type": "UNKNOWN"]))
-                }
+            Task {
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_failure", details: ["token_type": "UNKNOWN"]))
             }
             return .notHandled
         }
 
         switch tokenType {
         case .magicLinks:
-            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
-                // only run this in non-test environments
-                Task {
-                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
-                }
+            Task {
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
             return try await .handled(response: magicLinks.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration)))
         case .oauth:
-            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
-                // only run this in non-test environments
-                Task {
-                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
-                }
+            Task {
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
             return try await .handled(response: oauth.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration)))
         case .passwordReset:
-            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
-                // only run this in non-test environments
-                Task {
-                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
-                }
+            Task {
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
             return .manualHandlingRequired(tokenType, token: token)
         }

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -57,26 +57,38 @@ public struct StytchClient: StytchClientType {
         sessionDuration: Minutes = .defaultSessionDuration
     ) async throws -> DeeplinkHandledStatus<AuthenticateResponse, DeeplinkTokenType> {
         guard let (tokenType, token) = try tokenValues(for: url) else {
-            Task {
-                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_failure", details: ["token_type": "UNKNOWN"]))
+            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
+                // only run this in non-test environments
+                Task {
+                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_failure", details: ["token_type": "UNKNOWN"]))
+                }
             }
             return .notHandled
         }
 
         switch tokenType {
         case .magicLinks:
-            Task {
-                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
+                // only run this in non-test environments
+                Task {
+                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+                }
             }
             return try await .handled(response: magicLinks.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration)))
         case .oauth:
-            Task {
-                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
+                // only run this in non-test environments
+                Task {
+                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+                }
             }
             return try await .handled(response: oauth.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration)))
         case .passwordReset:
-            Task {
-                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
+                // only run this in non-test environments
+                Task {
+                    try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+                }
             }
             return .manualHandlingRequired(tokenType, token: token)
         }

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -58,7 +58,7 @@ public struct StytchClient: StytchClientType {
     ) async throws -> DeeplinkHandledStatus<AuthenticateResponse, DeeplinkTokenType> {
         guard let (tokenType, token) = try tokenValues(for: url) else {
             Task {
-                try? await StytchClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_failure", details: ["token_type" : "UNKNOWN"]))
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_failure", details: ["token_type": "UNKNOWN"]))
             }
             return .notHandled
         }
@@ -66,17 +66,17 @@ public struct StytchClient: StytchClientType {
         switch tokenType {
         case .magicLinks:
             Task {
-                try? await StytchClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type" : tokenType.rawValue]))
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
             return try await .handled(response: magicLinks.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration)))
         case .oauth:
             Task {
-                try? await StytchClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type" : tokenType.rawValue]))
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
             return try await .handled(response: oauth.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration)))
         case .passwordReset:
             Task {
-                try? await StytchClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type" : tokenType.rawValue]))
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
             return .manualHandlingRequired(tokenType, token: token)
         }

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -57,15 +57,27 @@ public struct StytchClient: StytchClientType {
         sessionDuration: Minutes = .defaultSessionDuration
     ) async throws -> DeeplinkHandledStatus<AuthenticateResponse, DeeplinkTokenType> {
         guard let (tokenType, token) = try tokenValues(for: url) else {
+            Task {
+                try? await StytchClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_failure", details: ["token_type" : "UNKNOWN"]))
+            }
             return .notHandled
         }
 
         switch tokenType {
         case .magicLinks:
+            Task {
+                try? await StytchClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type" : tokenType.rawValue]))
+            }
             return try await .handled(response: magicLinks.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration)))
         case .oauth:
+            Task {
+                try? await StytchClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type" : tokenType.rawValue]))
+            }
             return try await .handled(response: oauth.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration)))
         case .passwordReset:
+            Task {
+                try? await StytchClient.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type" : tokenType.rawValue]))
+            }
             return .manualHandlingRequired(tokenType, token: token)
         }
     }

--- a/Sources/StytchCore/StytchClientCommon/StytchClientType.swift
+++ b/Sources/StytchCore/StytchClientCommon/StytchClientType.swift
@@ -97,11 +97,13 @@ extension StytchClientType {
                 if hasSession {
                     _ = try? await StytchClient.sessions.authenticate(parameters: .init(sessionDuration: nil))
                 }
+                try? await StytchClient.events.logEvent(parameters: .init(eventName: "client_initialization_success"))
             } else {
                 try? await StytchB2BClient.bootstrap.fetch()
                 if hasSession {
                     _ = try? await StytchB2BClient.sessions.authenticate(parameters: .init(sessionDuration: nil))
                 }
+                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "client_initialization_success"))
             }
             initializationState.setInitializationState(state: true)
         }

--- a/Sources/StytchUI/AuthHomeViewModel.swift
+++ b/Sources/StytchUI/AuthHomeViewModel.swift
@@ -22,7 +22,7 @@ extension AuthHomeViewModel: AuthHomeViewModelProtocol {
     func logRenderScreen() async throws {
         try await eventsClient.logEvent(
             parameters: .init(
-                eventName: "render-login-screen",
+                eventName: "render_login_screen",
                 details: ["options": String(data: JSONEncoder().encode(state.config), encoding: .utf8) ?? ""]
             )
         )

--- a/Sources/StytchUI/AuthHomeViewModel.swift
+++ b/Sources/StytchUI/AuthHomeViewModel.swift
@@ -7,11 +7,11 @@ protocol AuthHomeViewModelProtocol {
 
 final class AuthHomeViewModel {
     let state: AuthHomeState
-    let eventsClient: EventsProtocol
+    let eventsClient: StytchClientEventsProtocol
 
     init(
         state: AuthHomeState,
-        eventsClient: EventsProtocol = StytchClient.events
+        eventsClient: StytchClientEventsProtocol = StytchClient.events
     ) {
         self.state = state
         self.eventsClient = eventsClient

--- a/Sources/StytchUI/OAuthViewController.swift
+++ b/Sources/StytchUI/OAuthViewController.swift
@@ -32,6 +32,7 @@ final class OAuthViewController: BaseViewController<OAuthState, OAuthViewModel> 
             do {
                 try await viewModel.startOAuth(provider: provider)
             } catch {
+                try? await StytchClient.events.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
                 presentAlert(error: error)
             }
         }

--- a/Sources/StytchUI/OTPCodeViewController.swift
+++ b/Sources/StytchUI/OTPCodeViewController.swift
@@ -42,6 +42,7 @@ final class OTPCodeViewController: BaseViewController<OTPCodeState, OTPCodeViewM
         super.init(viewModel: OTPCodeViewModel(state: state))
     }
 
+    // swiftlint:disable:next function_body_length
     override func configureView() {
         super.configureView()
 

--- a/Sources/StytchUI/OTPCodeViewController.swift
+++ b/Sources/StytchUI/OTPCodeViewController.swift
@@ -71,6 +71,7 @@ final class OTPCodeViewController: BaseViewController<OTPCodeState, OTPCodeViewM
                         self.showInvalidCode()
                     }
                 } catch {
+                    try? await StytchClient.events.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
                     self.presentAlert(error: error)
                 }
             }

--- a/Sources/StytchUI/PasswordViewController.swift
+++ b/Sources/StytchUI/PasswordViewController.swift
@@ -1,5 +1,5 @@
-import UIKit
 import StytchCore
+import UIKit
 
 // swiftlint:disable type_body_length
 final class PasswordViewController: BaseViewController<PasswordState, PasswordViewModel> {

--- a/Sources/StytchUI/PasswordViewController.swift
+++ b/Sources/StytchUI/PasswordViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import StytchCore
 
 // swiftlint:disable type_body_length
 final class PasswordViewController: BaseViewController<PasswordState, PasswordViewModel> {
@@ -242,6 +243,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                 do {
                     try await viewModel.setPassword(token: token, password: password)
                 } catch {
+                    try? await StytchClient.events.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
                     presentAlert(error: error)
                 }
             }
@@ -250,6 +252,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                 do {
                     try await viewModel.login(email: email, password: password)
                 } catch {
+                    try? await StytchClient.events.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
                     presentAlert(error: error)
                 }
             }
@@ -258,6 +261,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                 do {
                     try await viewModel.signup(email: email, password: password)
                 } catch {
+                    try? await StytchClient.events.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
                     presentAlert(error: error)
                 }
             }

--- a/Sources/StytchUI/StytchUIClient.swift
+++ b/Sources/StytchUI/StytchUIClient.swift
@@ -26,7 +26,12 @@ public enum StytchUIClient {
         onAuthCallback: AuthCallback? = nil
     ) {
         Self.config = config
-        Self.onAuthCallback = onAuthCallback
+        Self.onAuthCallback = { response in
+            Task {
+                try? await StytchClient.events.logEvent(parameters: .init(eventName: "ui_authentication_success"))
+            }
+            onAuthCallback?(response)
+        }
         let rootController = AuthRootViewController(config: config)
         currentController = rootController
         setUpSessionChangeListener()
@@ -77,7 +82,12 @@ public extension View {
     ) -> some View {
         sheet(isPresented: isPresented) {
             StytchUIClient.config = config
-            StytchUIClient.onAuthCallback = onAuthCallback
+            StytchUIClient.onAuthCallback = { response in
+                Task {
+                    try? await StytchClient.events.logEvent(parameters: .init(eventName: "ui_authentication_success"))
+                }
+                onAuthCallback?(response)
+            }
             return AuthenticationView(config: config)
                 .background(Color(.background).edgesIgnoringSafeArea(.all))
         }

--- a/StytchDemo/Client/Shared/StytchConfiguration.plist
+++ b/StytchDemo/Client/Shared/StytchConfiguration.plist
@@ -5,6 +5,6 @@
 	<key>StytchHostURL</key>
 	<string>http://example.com</string>
 	<key>StytchPublicToken</key>
-	<string>public-token-example</string>
+	<string>public-token-test-5110e67c-f7a1-4ed7-9f85-604e0f6447d3</string>
 </dict>
 </plist>

--- a/StytchDemo/Client/Shared/StytchConfiguration.plist
+++ b/StytchDemo/Client/Shared/StytchConfiguration.plist
@@ -5,6 +5,6 @@
 	<key>StytchHostURL</key>
 	<string>http://example.com</string>
 	<key>StytchPublicToken</key>
-	<string>public-token-test-5110e67c-f7a1-4ed7-9f85-604e0f6447d3</string>
+	<string>public-token-example</string>
 </dict>
 </plist>

--- a/Tests/StytchCoreTests/NetworkingClientInterceptor.swift
+++ b/Tests/StytchCoreTests/NetworkingClientInterceptor.swift
@@ -12,6 +12,9 @@ final class NetworkingClientInterceptor {
     }
 
     func handleRequest(request: URLRequest, _: Bool, _: DFPProtectedAuthMode, _: String) async throws -> (Data, HTTPURLResponse) {
+        if request.url?.absoluteString.contains("/v1/events") != nil {
+            responses.append(.success(try Current.jsonEncoder.encode(AuthenticateResponse.mock)).map { $0.surroundInDataJSONContainer() })
+        }
         requests.append(request)
 
         switch responses.removeFirst() {

--- a/Tests/StytchCoreTests/OAuthTestCase.swift
+++ b/Tests/StytchCoreTests/OAuthTestCase.swift
@@ -38,7 +38,7 @@ final class OAuthTestCase: BaseTestCase {
         _ = try await StytchClient.oauth.authenticate(parameters: .init(token: "i-am-token", sessionDuration: 12))
 
         try XCTAssertRequest(
-            networkInterceptor.requests[0],
+            networkInterceptor.requests[1],
             urlString: "https://web.stytch.com/sdk/v1/oauth/authenticate",
             method: .post([
                 "session_duration_minutes": 12,


### PR DESCRIPTION
Linear Ticket: [SDK-1401](https://linear.app/stytch/issue/SDK-1401)

## Changes:

1. Fixes the name of the render_login_screen event (underscores, not dashes)
2. Adds event support to B2B client
3. Adds _most_ of the desired events

## Notes:

- The one event that is missing is `client_initialization_failure`, because I can't figure out a way to catch that
- I spent a good few hours trying to figure out how to get the details for the `render_login_screen` event to send as JSON instead of a string (something I just fixed in Android), but can't figure that out, either. I think it's fine for now, the important thing is really the event firing

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A