### PR TITLE
SDK-1449 Bump reCAPTCHA

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/marmelroy/PhoneNumberKit", from: .init(3, 5, 9)),
-        .package(url: "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk", from: "18.3.0"),
+        .package(url: "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk", from: "18.4.0"),
     ],
     targets: [
         .target(

--- a/Sources/StytchCore/NetworkingClient/NetworkingClient+Live.swift
+++ b/Sources/StytchCore/NetworkingClient/NetworkingClient+Live.swift
@@ -37,6 +37,9 @@ extension NetworkingClient {
         }
         return .init { request, dfpEnabled, dfpAuthMode, publicToken in
             #if os(iOS)
+            if request.url?.path.contains("/events") == true {
+                return try await defaultRequestHandler(session: session, request: request)
+            }
             if !dfpEnabled {
                 return try await networkRequestHandler.handleDFPDisabled(session: session, request: request, captcha: captcha, requestHandler: defaultRequestHandler)
             }

--- a/StytchDemo/StytchDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StytchDemo/StytchDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",
         "state": {
           "branch": null,
-          "revision": "5419bb00a3bc81d727423790692f2c538040d00c",
-          "version": "18.3.0"
+          "revision": "30e4e28f2f87236372225c453140774f038302ad",
+          "version": "18.4.0"
         }
       },
       {


### PR DESCRIPTION
Linear Ticket: [SDK-1449](https://linear.app/stytch/issue/SDK-1449)

## Changes:

1. Bumps Google reCAPTCHA version due to a new vulnerability
2. Fixes a bug when sending events with DFP enabled (the fix is to _not_ try to append DFP/CAPTCHA tokens to events)

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A