### PR TITLE
Add resetByExistingPassword to B2C Passwords client

### DIFF
--- a/Sources/StytchCore/Generated/StytchClient.Passwords.resetByExistingPassword+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.Passwords.resetByExistingPassword+AsyncVariants.generated.swift
@@ -1,0 +1,37 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchClient.Passwords {
+    /// This method resets the user’s password using their existing password. This endpoint checks that the existing password matches the stored value.
+    /// 
+    /// The provided password needs to meet our password strength requirements, which can be checked in advance with the password strength endpoint. If the password and accompanying parameters are accepted, the password is securely stored for future authentication and the user is authenticated.
+    func resetByExistingPassword(parameters: ResetByExistingPasswordParameters, completion: @escaping Completion<AuthenticateResponse>) {
+        Task {
+            do {
+                completion(.success(try await resetByExistingPassword(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// This method resets the user’s password using their existing password. This endpoint checks that the existing password matches the stored value.
+    /// 
+    /// The provided password needs to meet our password strength requirements, which can be checked in advance with the password strength endpoint. If the password and accompanying parameters are accepted, the password is securely stored for future authentication and the user is authenticated.
+    func resetByExistingPassword(parameters: ResetByExistingPasswordParameters) -> AnyPublisher<AuthenticateResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await resetByExistingPassword(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/StytchClient/Passwords/PasswordsRoute.swift
+++ b/Sources/StytchCore/StytchClient/Passwords/PasswordsRoute.swift
@@ -4,6 +4,7 @@ enum PasswordsRoute: RouteType {
     case authenticate
     case strengthCheck
     case resetBySession
+    case resetByExistingPassword
 
     var path: Path {
         switch self {
@@ -17,6 +18,8 @@ enum PasswordsRoute: RouteType {
             return "strength_check"
         case .resetBySession:
             return "session/reset"
+        case .resetByExistingPassword:
+            return "existing_password/reset"
         }
     }
 }

--- a/Sources/StytchCore/StytchClient/Passwords/StytchClient+Passwords.swift
+++ b/Sources/StytchCore/StytchClient/Passwords/StytchClient+Passwords.swift
@@ -7,6 +7,7 @@ public protocol PasswordsProtocol {
     func resetByEmail(parameters: StytchClient.Passwords.ResetByEmailParameters) async throws -> AuthenticateResponse
     func strengthCheck(parameters: StytchClient.Passwords.StrengthCheckParameters) async throws -> StytchClient.Passwords.StrengthCheckResponse
     func resetBySession(parameters: StytchClient.Passwords.ResetBySessionParameters) async throws -> AuthenticateResponse
+    func resetByExistingPassword(parameters: StytchClient.Passwords.ResetByExistingPasswordParameters) async throws -> AuthenticateResponse
 }
 
 public extension StytchClient {
@@ -91,6 +92,14 @@ public extension StytchClient {
         /// The provided password needs to meet our password strength requirements, which can be checked in advance with the password strength endpoint. If the token and password are accepted, the password is securely stored for future authentication and the user is authenticated.
         public func resetBySession(parameters: ResetBySessionParameters) async throws -> AuthenticateResponse {
             try await router.post(to: .resetBySession, parameters: parameters)
+        }
+
+        // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
+        /// This method resets the user’s password using their existing password. This endpoint checks that the existing password matches the stored value.
+        ///
+        /// The provided password needs to meet our password strength requirements, which can be checked in advance with the password strength endpoint. If the password and accompanying parameters are accepted, the password is securely stored for future authentication and the user is authenticated.
+        public func resetByExistingPassword(parameters: ResetByExistingPasswordParameters) async throws -> AuthenticateResponse {
+            try await router.post(to: .resetByExistingPassword, parameters: parameters)
         }
     }
 }
@@ -222,6 +231,40 @@ public extension StytchClient.Passwords {
         ///   - sessionDuration: The duration of the requested session.
         public init(password: String, sessionDuration: Minutes = .defaultSessionDuration) {
             self.password = password
+            self.sessionDuration = sessionDuration
+        }
+    }
+}
+
+public extension StytchClient.Passwords {
+    /// The dedicated parameters type for passwords `resetByExistingPassword` calls.
+    struct ResetByExistingPasswordParameters: Encodable {
+        private enum CodingKeys: String, CodingKey {
+            case email = "emailAddress"
+            case existingPassword
+            case newPassword
+            case sessionDuration = "sessionDurationMinutes"
+        }
+
+        public let email: String
+        public let existingPassword: String
+        public let newPassword: String
+        public let sessionDuration: Minutes
+
+        /// - Parameters:
+        ///   - email: The user's email address.
+        ///   - existingPassword: The user's existing password.
+        ///   - newPassword: The user's new password.
+        ///   - sessionDuration: The duration of the requested session.
+        public init(
+            email: String,
+            existingPassword: String,
+            newPassword: String,
+            sessionDuration: Minutes = .defaultSessionDuration
+        ) {
+            self.email = email
+            self.existingPassword = existingPassword
+            self.newPassword = newPassword
             self.sessionDuration = sessionDuration
         }
     }

--- a/Tests/StytchCoreTests/PasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/PasswordsTestCase.swift
@@ -4,6 +4,7 @@ import XCTest
 final class PasswordsTestCase: BaseTestCase {
     private let passwordParams: StytchClient.Passwords.PasswordParameters = .init(email: "user@stytch.com", password: "password123", sessionDuration: 26)
     private let passwordResetBySessionParams: StytchClient.Passwords.ResetBySessionParameters = .init(password: "password123", sessionDuration: 10)
+    private let passwordResetByExistingPasswordParams: StytchClient.Passwords.ResetByExistingPasswordParameters = .init(email: "user@stytch.com", existingPassword: "password123", newPassword: "password234")
 
     func testCreate() async throws {
         let userId: User.ID = ""
@@ -122,6 +123,24 @@ final class PasswordsTestCase: BaseTestCase {
             method: .post([
                 "session_duration_minutes": 10,
                 "password": "password123",
+            ])
+        )
+    }
+
+    func testResetByExistingPassword() async throws {
+        networkInterceptor.responses { AuthenticateResponse.mock }
+        Current.timer = { _, _, _ in .init() }
+
+        _ = try await StytchClient.passwords.resetByExistingPassword(parameters: passwordResetByExistingPasswordParams)
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/passwords/existing_password/reset",
+            method: .post([
+                "email_address": "user@stytch.com",
+                "existing_password": "password123",
+                "new_password": "password234",
+                "session_duration_minutes": 30,
             ])
         )
     }

--- a/Tests/StytchUIUnitTests/Spies.swift
+++ b/Tests/StytchUIUnitTests/Spies.swift
@@ -11,6 +11,7 @@ enum CalledMethod {
     case passwordsResetByEmail
     case passwordsStrengthCheck
     case passwordsResetBySession
+    case passwordsResetByExistingPassword
 
     case otpLoginOrCreate
     case otpSend
@@ -55,6 +56,11 @@ class PasswordsSpy: PasswordsProtocol {
 
     func resetBySession(parameters _: StytchClient.Passwords.ResetBySessionParameters) async throws -> AuthenticateResponse {
         callback(.passwordsResetBySession)
+        return AuthenticateResponse.mock
+    }
+
+    func resetByExistingPassword(parameters _: StytchClient.Passwords.ResetByExistingPasswordParameters) async throws -> AuthenticateResponse {
+        callback(.passwordsResetByExistingPassword)
         return AuthenticateResponse.mock
     }
 }


### PR DESCRIPTION
Linear Ticket: [SDK-1470](https://linear.app/stytch/issue/SDK-1470)

## Changes:

- Adds `resetByExistingPassword` method to `StytchClient.passwords`

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A