### PR TITLE
Update iOS User headless client

### DIFF
--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -61,6 +61,8 @@ struct Environment {
 
     let sessionStorage: SessionStorage = .init()
 
+    let userStorage: UserStorage = .init()
+
     var localStorage: LocalStorage = .init()
 
     var cookieClient: CookieClient = .live

--- a/Sources/StytchCore/Routing/NetworkingRouter.swift
+++ b/Sources/StytchCore/Routing/NetworkingRouter.swift
@@ -17,6 +17,8 @@ public struct NetworkingRouter<Route: RouteType> {
 
     @Dependency(\.sessionStorage) private var sessionStorage
 
+    @Dependency(\.userStorage) private var userStorage
+
     @Dependency(\.localStorage) private var localStorage
 
     private init(_ pathForRoute: @escaping (Route) -> Path, getConfiguration: @escaping () -> Configuration?) {
@@ -111,7 +113,7 @@ public extension NetworkingRouter {
                     ],
                     hostUrl: configuration.hostUrl
                 )
-                localStorage.user = sessionResponse.user
+                userStorage.updateUser(sessionResponse.user)
             } else if let sessionResponse = dataContainer.data as? B2BAuthenticateResponseType {
                 sessionStorage.updateSession(
                     .member(sessionResponse.memberSession),

--- a/Sources/StytchCore/SessionStorage.swift
+++ b/Sources/StytchCore/SessionStorage.swift
@@ -53,12 +53,7 @@ final class SessionStorage {
         set { localStorage.memberSession = newValue }
     }
 
-    private(set) lazy var onUserChange = _onUserChange
-        .map { [weak self] in self?.session == nil }
-        .removeDuplicates()
-        .map { [weak self] _ in self?.session?.userId }
-
-    private let _onUserChange = PassthroughSubject<Void, Never>()
+    @Dependency(\.userStorage) private var userStorage
 
     @Dependency(\.localStorage) private var localStorage
 
@@ -123,7 +118,7 @@ final class SessionStorage {
         sessionToken = nil
         sessionJwt = nil
 
-        localStorage.user = nil
+        userStorage.reset()
         localStorage.organization = nil
         localStorage.member = nil
 

--- a/Sources/StytchCore/SessionStorage.swift
+++ b/Sources/StytchCore/SessionStorage.swift
@@ -53,6 +53,13 @@ final class SessionStorage {
         set { localStorage.memberSession = newValue }
     }
 
+    private(set) lazy var onUserChange = _onUserChange
+        .map { [weak self] in self?.session == nil }
+        .removeDuplicates()
+        .map { [weak self] _ in self?.session?.userId }
+
+    private let _onUserChange = PassthroughSubject<Void, Never>()
+
     @Dependency(\.localStorage) private var localStorage
 
     @Dependency(\.cookieClient) private var cookieClient

--- a/Sources/StytchCore/StytchClient/Models/User.swift
+++ b/Sources/StytchCore/StytchClient/Models/User.swift
@@ -106,12 +106,16 @@ public extension User {
     }
 
     struct Provider: Codable {
+        public typealias ID = Identifier<Self, String>
         /// The subject of the provider.
         public let providerSubject: String
         /// The type of the provider.
         public let providerType: String
         /// The profile picture set for the provider
         public let profilePictureUrl: String?
+        /// The id of the registration.
+        public var id: ID { oauthUserRegistrationId }
+        let oauthUserRegistrationId: ID
     }
 
     struct PhoneNumber: Codable {

--- a/Sources/StytchCore/StytchClient/User/StytchClient+User.swift
+++ b/Sources/StytchCore/StytchClient/User/StytchClient+User.swift
@@ -42,6 +42,8 @@ public extension StytchClient {
                     return try await router.delete(route: .factors(.webAuthNRegistrations(id: id)))
                 case let .totp(id):
                     return try await router.delete(route: .factors(.totp(id: id)))
+                case let .oauth(id):
+                    return try await router.delete(route: .factors(.oauth(id: id)))
                 }
             }
         }
@@ -71,6 +73,7 @@ public extension StytchClient.UserManagement {
         case phoneNumber(id: User.PhoneNumber.ID)
         case webAuthnRegistration(id: User.WebAuthNRegistration.ID)
         case totp(id: User.TOTP.ID)
+        case oauth(id: User.Provider.ID)
     }
 
     struct UpdateParameters: Encodable {

--- a/Sources/StytchCore/StytchClient/User/StytchClient+User.swift
+++ b/Sources/StytchCore/StytchClient/User/StytchClient+User.swift
@@ -1,3 +1,5 @@
+import Combine
+
 public extension StytchClient {
     /// The SDK allows you to manage the current user's information, such as fetching the user, viewing the most recent cached version of the user, or deleting existing authentication factors associated with this user.
     struct UserManagement {
@@ -5,10 +7,15 @@ public extension StytchClient {
 
         @Dependency(\.localStorage) private var localStorage
 
+        @Dependency(\.sessionStorage) private var sessionStorage
+
         /// Returns the most-recent cached copy of the user object, if it has already been fetched via another method, else nil.
         public func getSync() -> User? {
             localStorage.user
         }
+
+        /// A publisher which emits following a change in user status and returns either the user ID or nil. You can use this as an indicator to set up or tear down your UI accordingly.
+        public var onChange: AnyPublisher<User.ID?, Never> { sessionStorage.onUserChange.eraseToAnyPublisher() }
 
         // sourcery: AsyncVariants
         /// Fetches the most up-to-date version of the current user.

--- a/Sources/StytchCore/StytchClient/User/StytchClient+User.swift
+++ b/Sources/StytchCore/StytchClient/User/StytchClient+User.swift
@@ -40,6 +40,8 @@ public extension StytchClient {
                     return try await router.delete(route: .factors(.phoneNumbers(id: id)))
                 case let .webAuthnRegistration(id):
                     return try await router.delete(route: .factors(.webAuthNRegistrations(id: id)))
+                case let .totp(id):
+                    return try await router.delete(route: .factors(.totp(id: id)))
                 }
             }
         }
@@ -68,6 +70,7 @@ public extension StytchClient.UserManagement {
         case email(id: User.Email.ID)
         case phoneNumber(id: User.PhoneNumber.ID)
         case webAuthnRegistration(id: User.WebAuthNRegistration.ID)
+        case totp(id: User.TOTP.ID)
     }
 
     struct UpdateParameters: Encodable {

--- a/Sources/StytchCore/StytchClient/User/StytchClient+User.swift
+++ b/Sources/StytchCore/StytchClient/User/StytchClient+User.swift
@@ -9,13 +9,15 @@ public extension StytchClient {
 
         @Dependency(\.sessionStorage) private var sessionStorage
 
+        @Dependency(\.userStorage) private var userStorage
+
         /// Returns the most-recent cached copy of the user object, if it has already been fetched via another method, else nil.
         public func getSync() -> User? {
-            localStorage.user
+            userStorage.user
         }
 
-        /// A publisher which emits following a change in user status and returns either the user ID or nil. You can use this as an indicator to set up or tear down your UI accordingly.
-        public var onChange: AnyPublisher<User.ID?, Never> { sessionStorage.onUserChange.eraseToAnyPublisher() }
+        /// A publisher which emits following a change in user status and returns either the user object or nil. You can use this as an indicator to set up or tear down your UI accordingly.
+        public var onChange: AnyPublisher<User?, Never> { userStorage.onUserChange.eraseToAnyPublisher() }
 
         // sourcery: AsyncVariants
         /// Fetches the most up-to-date version of the current user.
@@ -57,7 +59,7 @@ public extension StytchClient {
 
         private func updatingCachedUser(_ performRequest: () async throws -> UserResponse) async rethrows -> UserResponse {
             let response = try await performRequest()
-            localStorage.user = response.wrapped
+            userStorage.updateUser(response.wrapped)
             return response
         }
     }

--- a/Sources/StytchCore/StytchClient/User/UsersRoute.swift
+++ b/Sources/StytchCore/StytchClient/User/UsersRoute.swift
@@ -20,6 +20,7 @@ extension UsersRoute {
         case phoneNumbers(id: User.PhoneNumber.ID)
         case webAuthNRegistrations(id: User.WebAuthNRegistration.ID)
         case totp(id: User.TOTP.ID)
+        case oauth(id: User.Provider.ID)
 
         var path: Path {
             let joinedPath: (Path, String) -> Path = { $0.appendingPath(.init(rawValue: $1)) }
@@ -36,6 +37,8 @@ extension UsersRoute {
                 return joinedPath("webauthn_registrations", id.rawValue)
             case let .totp(id):
                 return joinedPath("totps", id.rawValue)
+            case let .oauth(id):
+                return joinedPath("oauth", id.rawValue)
             }
         }
     }

--- a/Sources/StytchCore/StytchClient/User/UsersRoute.swift
+++ b/Sources/StytchCore/StytchClient/User/UsersRoute.swift
@@ -19,6 +19,7 @@ extension UsersRoute {
         case emails(id: User.Email.ID)
         case phoneNumbers(id: User.PhoneNumber.ID)
         case webAuthNRegistrations(id: User.WebAuthNRegistration.ID)
+        case totp(id: User.TOTP.ID)
 
         var path: Path {
             let joinedPath: (Path, String) -> Path = { $0.appendingPath(.init(rawValue: $1)) }
@@ -33,6 +34,8 @@ extension UsersRoute {
                 return joinedPath("phone_numbers", id.rawValue)
             case let .webAuthNRegistrations(id):
                 return joinedPath("webauthn_registrations", id.rawValue)
+            case let .totp(id):
+                return joinedPath("totps", id.rawValue)
             }
         }
     }

--- a/Sources/StytchCore/UserStorage.swift
+++ b/Sources/StytchCore/UserStorage.swift
@@ -1,0 +1,28 @@
+import Combine
+import Foundation
+
+final class UserStorage {
+    private(set) var user: User? {
+        get { localStorage.user }
+        set { localStorage.user = newValue }
+    }
+
+    private(set) lazy var onUserChange = _onUserChange
+        .map { [weak self] in self?.user == nil }
+        .removeDuplicates()
+        .map { [weak self] _ in self?.user }
+
+    private let _onUserChange = PassthroughSubject<Void, Never>()
+
+    @Dependency(\.localStorage) private var localStorage
+
+    func updateUser(_ user: User) {
+        self.user = user
+        _onUserChange.send(())
+    }
+
+    func reset() {
+        user = nil
+        _onUserChange.send(())
+    }
+}

--- a/Tests/StytchCoreTests/UserManagementTestCase.swift
+++ b/Tests/StytchCoreTests/UserManagementTestCase.swift
@@ -49,7 +49,7 @@ final class UserManagementTestCase: BaseTestCase {
             (.phoneNumber(id: .init(rawValue: "phone_123983")), "phone_numbers", "phone_123983"),
             (.webAuthnRegistration(id: .init(rawValue: "web_123983")), "webauthn_registrations", "web_123983"),
             (.totp(id: .init(rawValue: "totp_123983")), "totps", "totp_123983"),
-            (.oauth(id: .init(rawValue: "oauth_123983")), "oauth", "oauth_123983")
+            (.oauth(id: .init(rawValue: "oauth_123983")), "oauth", "oauth_123983"),
         ]
 
         try await factors.enumerated().asyncForEach { index, values in

--- a/Tests/StytchCoreTests/UserManagementTestCase.swift
+++ b/Tests/StytchCoreTests/UserManagementTestCase.swift
@@ -39,6 +39,7 @@ final class UserManagementTestCase: BaseTestCase {
             response
             response
             response
+            response
         }
 
         let factors: [(factor: StytchClient.UserManagement.AuthenticationFactor, pathComponent: String, id: String)] = [
@@ -47,7 +48,8 @@ final class UserManagementTestCase: BaseTestCase {
             (.biometricRegistration(id: .init(rawValue: "bio_123983")), "biometric_registrations", "bio_123983"),
             (.phoneNumber(id: .init(rawValue: "phone_123983")), "phone_numbers", "phone_123983"),
             (.webAuthnRegistration(id: .init(rawValue: "web_123983")), "webauthn_registrations", "web_123983"),
-            (.totp(id: .init(rawValue: "totp_123983")), "totps", "totp_123983")
+            (.totp(id: .init(rawValue: "totp_123983")), "totps", "totp_123983"),
+            (.oauth(id: .init(rawValue: "oauth_123983")), "oauth", "oauth_123983")
         ]
 
         try await factors.enumerated().asyncForEach { index, values in

--- a/Tests/StytchCoreTests/UserManagementTestCase.swift
+++ b/Tests/StytchCoreTests/UserManagementTestCase.swift
@@ -38,6 +38,7 @@ final class UserManagementTestCase: BaseTestCase {
             response
             response
             response
+            response
         }
 
         let factors: [(factor: StytchClient.UserManagement.AuthenticationFactor, pathComponent: String, id: String)] = [
@@ -46,6 +47,7 @@ final class UserManagementTestCase: BaseTestCase {
             (.biometricRegistration(id: .init(rawValue: "bio_123983")), "biometric_registrations", "bio_123983"),
             (.phoneNumber(id: .init(rawValue: "phone_123983")), "phone_numbers", "phone_123983"),
             (.webAuthnRegistration(id: .init(rawValue: "web_123983")), "webauthn_registrations", "web_123983"),
+            (.totp(id: .init(rawValue: "totp_123983")), "totps", "totp_123983")
         ]
 
         try await factors.enumerated().asyncForEach { index, values in


### PR DESCRIPTION
Linear Ticket: [SDK-1471](https://linear.app/stytch/issue/SDK-1471)

## Changes:

Adds the following methods to the user management client:

- `onChange`
- `deleteFactor` for TOTP and OAuth registrations

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A