### PR TITLE
iOS B2C Crypto Wallets client

### DIFF
--- a/Sources/StytchCore/Generated/StytchClient.CryptoWallets.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.CryptoWallets.authenticate+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchClient.CryptoWallets {
+    /// Wraps Stytch's Crypto wallet [authenticate](https://stytch.com/docs/api/crypto-wallet-authenticate) endpoint. Call this method after the user signs the challenge to validate the signature.
+    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<AuthenticateResponse>) {
+        Task {
+            do {
+                completion(.success(try await authenticate(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Wraps Stytch's Crypto wallet [authenticate](https://stytch.com/docs/api/crypto-wallet-authenticate) endpoint. Call this method after the user signs the challenge to validate the signature.
+    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<AuthenticateResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await authenticate(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/Generated/StytchClient.CryptoWallets.authenticateStart+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.CryptoWallets.authenticateStart+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchClient.CryptoWallets {
+    /// Wraps Stytch's Crypto wallet [authenticate_start](https://stytch.com/docs/api/crypto-wallet-authenticate-start) endpoint. Call this method to load the challenge data. Pass this challenge to your user's wallet for signing.
+    func authenticateStart(parameters: AuthenticateStartParameters, completion: @escaping Completion<AuthenticateStartResponse>) {
+        Task {
+            do {
+                completion(.success(try await authenticateStart(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Wraps Stytch's Crypto wallet [authenticate_start](https://stytch.com/docs/api/crypto-wallet-authenticate-start) endpoint. Call this method to load the challenge data. Pass this challenge to your user's wallet for signing.
+    func authenticateStart(parameters: AuthenticateStartParameters) -> AnyPublisher<AuthenticateStartResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await authenticateStart(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/Routing/BaseRoute.swift
+++ b/Sources/StytchCore/Routing/BaseRoute.swift
@@ -1,6 +1,7 @@
 extension StytchClient {
     enum BaseRoute: BaseRouteType {
         case biometrics(BiometricsRoute)
+        case cryptoWallets(CryptoWalletsRoute)
         case events(EventsRoute)
         case magicLinks(MagicLinksRoute)
         case oauth(OAuthRoute)
@@ -18,6 +19,8 @@ extension StytchClient {
             switch self {
             case let .biometrics(route):
                 return "biometrics".appendingPath(route.path)
+            case let .cryptoWallets(route):
+                return "crypto_wallets".appendingPath(route.path)
             case let .events(route):
                 return "".appendingPath(route.path)
             case let .magicLinks(route):

--- a/Sources/StytchCore/StytchClient/CryptoWallets/CryptoWalletsRoute.swift
+++ b/Sources/StytchCore/StytchClient/CryptoWallets/CryptoWalletsRoute.swift
@@ -5,7 +5,7 @@ enum CryptoWalletsRoute: RouteType {
     var path: Path {
         switch self {
         case .authenticateStart:
-            return "authenticateStart"
+            return "authenticate/start/primary"
         case .authenticate:
             return "authenticate"
         }

--- a/Sources/StytchCore/StytchClient/CryptoWallets/CryptoWalletsRoute.swift
+++ b/Sources/StytchCore/StytchClient/CryptoWallets/CryptoWalletsRoute.swift
@@ -1,11 +1,14 @@
 enum CryptoWalletsRoute: RouteType {
-    case authenticateStart
+    case authenticateStartPrimary
+    case authenticateStartSecondary
     case authenticate
 
     var path: Path {
         switch self {
-        case .authenticateStart:
+        case .authenticateStartPrimary:
             return "authenticate/start/primary"
+        case .authenticateStartSecondary:
+            return "authenticate/start/secondary"
         case .authenticate:
             return "authenticate"
         }

--- a/Sources/StytchCore/StytchClient/CryptoWallets/CryptoWalletsRoute.swift
+++ b/Sources/StytchCore/StytchClient/CryptoWallets/CryptoWalletsRoute.swift
@@ -1,0 +1,13 @@
+enum CryptoWalletsRoute: RouteType {
+    case authenticateStart
+    case authenticate
+
+    var path: Path {
+        switch self {
+        case .authenticateStart:
+            return "authenticateStart"
+        case .authenticate:
+            return "authenticate"
+        }
+    }
+}

--- a/Sources/StytchCore/StytchClient/CryptoWallets/StytchClient+CryptoWallets.swift
+++ b/Sources/StytchCore/StytchClient/CryptoWallets/StytchClient+CryptoWallets.swift
@@ -86,6 +86,7 @@ public extension StytchClient.CryptoWallets {
         private enum CodingKeys: String, CodingKey {
             case challenge
         }
+
         /// A challenge string to be signed by the wallet in order to prove ownership.
         public let challenge: String
 

--- a/Sources/StytchCore/StytchClient/CryptoWallets/StytchClient+CryptoWallets.swift
+++ b/Sources/StytchCore/StytchClient/CryptoWallets/StytchClient+CryptoWallets.swift
@@ -26,7 +26,7 @@ public extension StytchClient {
 
 public extension StytchClient.CryptoWallets {
     /// The type of crypto wallet. Currently `ethereum` and `solana` are supported. Wallets for any EVM-compatible chains (such as Polygon or BSC) are also supported and are grouped under the `ethereum` type.
-    enum WalletType: Encodable {
+    enum WalletType: String, Codable {
         case ethereum
         case solana
     }
@@ -79,12 +79,16 @@ public extension StytchClient.CryptoWallets {
     typealias AuthenticateStartResponse = Response<CryptoWalletsAuthenticateResponseData>
 
     /// The underlying data for crypto wallets `authenticateStart` calls.
-    struct CryptoWalletsAuthenticateResponseData: Decodable {
+    struct CryptoWalletsAuthenticateResponseData: Codable {
         private enum CodingKeys: String, CodingKey {
             case challenge
         }
         /// A challenge string to be signed by the wallet in order to prove ownership.
         public let challenge: String
+
+        public init(challenge: String) {
+            self.challenge = challenge
+        }
     }
 }
 

--- a/Sources/StytchCore/StytchClient/CryptoWallets/StytchClient+CryptoWallets.swift
+++ b/Sources/StytchCore/StytchClient/CryptoWallets/StytchClient+CryptoWallets.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+public protocol CryptoWalletsProtocol {
+    func authenticateStart(parameters: StytchClient.CryptoWallets.AuthenticateStartParameters) async throws -> StytchClient.CryptoWallets.AuthenticateStartResponse
+    func authenticate(parameters: StytchClient.CryptoWallets.AuthenticateParameters) async throws -> AuthenticateResponse
+}
+
+public extension StytchClient {
+    /// The SDK provides methods that can be used to authenticate a user via their crypto wallet.
+    struct CryptoWallets: CryptoWalletsProtocol {
+        let router: NetworkingRouter<CryptoWalletsRoute>
+
+        // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
+        /// Wraps Stytch's Crypto wallet [authenticate_start](https://stytch.com/docs/api/crypto-wallet-authenticate-start) endpoint. Call this method to load the challenge data. Pass this challenge to your user's wallet for signing.
+        public func authenticateStart(parameters: AuthenticateStartParameters) async throws -> AuthenticateStartResponse {
+            try await router.post(to: .authenticateStart, parameters: parameters)
+        }
+
+        // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
+        /// Wraps Stytch's Crypto wallet [authenticate](https://stytch.com/docs/api/crypto-wallet-authenticate) endpoint. Call this method after the user signs the challenge to validate the signature.
+        public func authenticate(parameters: AuthenticateParameters) async throws -> AuthenticateResponse {
+            try await router.post(to: .authenticate, parameters: parameters)
+        }
+    }
+}
+
+public extension StytchClient.CryptoWallets {
+    /// The type of crypto wallet. Currently `ethereum` and `solana` are supported. Wallets for any EVM-compatible chains (such as Polygon or BSC) are also supported and are grouped under the `ethereum` type.
+    enum WalletType: Encodable {
+        case ethereum
+        case solana
+    }
+
+    /// The dedicated parameters type for crypto wallets `authenticateStart` calls.
+    struct AuthenticateStartParameters: Encodable {
+        private enum CodingKeys: String, CodingKey {
+            case cryptoWalletType
+            case cryptoWalletAddress
+        }
+
+        let cryptoWalletType: WalletType
+        let cryptoWalletAddress: String
+
+        /// - Parameters:
+        ///   - cryptoWalletType: The type of wallet to authenticate.
+        ///   - cryptoWalletAddress: The crypto wallet address to authenticate.
+        public init(cryptoWalletType: WalletType, cryptoWalletAddress: String) {
+            self.cryptoWalletType = cryptoWalletType
+            self.cryptoWalletAddress = cryptoWalletAddress
+        }
+    }
+
+    /// The dedicated parameters type for crypto wallets `authenticate` calls.
+    struct AuthenticateParameters: Encodable {
+        private enum CodingKeys: String, CodingKey {
+            case cryptoWalletType
+            case cryptoWalletAddress
+            case signature
+        }
+
+        let cryptoWalletType: WalletType
+        let cryptoWalletAddress: String
+        let signature: String
+
+        /// - Parameters:
+        ///   - cryptoWalletType: The type of wallet to authenticate.
+        ///   - cryptoWalletAddress: The crypto wallet address to authenticate.
+        ///   - signature: The signature from the message challenge.
+        public init(cryptoWalletType: WalletType, cryptoWalletAddress: String, signature: String) {
+            self.cryptoWalletType = cryptoWalletType
+            self.cryptoWalletAddress = cryptoWalletAddress
+            self.signature = signature
+        }
+    }
+}
+
+public extension StytchClient.CryptoWallets {
+    /// The concrete response type for crypto wallets `authenticateStart` calls.
+    typealias AuthenticateStartResponse = Response<CryptoWalletsAuthenticateResponseData>
+
+    /// The underlying data for crypto wallets `authenticateStart` calls.
+    struct CryptoWalletsAuthenticateResponseData: Decodable {
+        private enum CodingKeys: String, CodingKey {
+            case challenge
+        }
+        /// A challenge string to be signed by the wallet in order to prove ownership.
+        public let challenge: String
+    }
+}
+
+public extension StytchClient {
+    /// The interface for interacting with crypto wallet products.
+    static var cryptoWallets: CryptoWallets { .init(router: router.scopedRouter { $0.cryptoWallets }) }
+}

--- a/Sources/StytchCore/StytchClient/CryptoWallets/StytchClient+CryptoWallets.swift
+++ b/Sources/StytchCore/StytchClient/CryptoWallets/StytchClient+CryptoWallets.swift
@@ -10,10 +10,13 @@ public extension StytchClient {
     struct CryptoWallets: CryptoWalletsProtocol {
         let router: NetworkingRouter<CryptoWalletsRoute>
 
+        @Dependency(\.sessionStorage.persistedSessionIdentifiersExist) private var activeSessionExists
+
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's Crypto wallet [authenticate_start](https://stytch.com/docs/api/crypto-wallet-authenticate-start) endpoint. Call this method to load the challenge data. Pass this challenge to your user's wallet for signing.
         public func authenticateStart(parameters: AuthenticateStartParameters) async throws -> AuthenticateStartResponse {
-            try await router.post(to: .authenticateStart, parameters: parameters)
+            let route: CryptoWalletsRoute = activeSessionExists ? .authenticateStartSecondary : .authenticateStartPrimary
+            return try await router.post(to: route, parameters: parameters)
         }
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)

--- a/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
+++ b/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
@@ -2,11 +2,13 @@ import XCTest
 @testable import StytchCore
 
 final class CryptoWalletsTestCase: BaseTestCase {
-    func testAuthenticateStart() async throws {
+    func testAuthenticateStartWithNoSession() async throws {
         networkInterceptor.responses {
             StytchClient.CryptoWallets.AuthenticateStartResponse(requestId: "mock-request-id", statusCode: 200, wrapped: .init(challenge: "mock-challenge"))
         }
-        Current.timer = { _, _, _ in .init() }
+
+        XCTAssertFalse(Current.sessionStorage.persistedSessionIdentifiersExist)
+
         _ = try await StytchClient.cryptoWallets.authenticateStart(parameters: .init(cryptoWalletType: .ethereum, cryptoWalletAddress: "mock-crypto-address"))
 
         try XCTAssertRequest(
@@ -17,12 +19,44 @@ final class CryptoWalletsTestCase: BaseTestCase {
                 "crypto_wallet_address": "mock-crypto-address",
             ])
         )
+
+        XCTAssertNil(StytchClient.sessions.sessionJwt)
+        XCTAssertNil(StytchClient.sessions.sessionToken)
+    }
+
+    func testAuthenticateStartWithActiveSession() async throws {
+        networkInterceptor.responses {
+            StytchClient.CryptoWallets.AuthenticateStartResponse(requestId: "mock-request-id", statusCode: 200, wrapped: .init(challenge: "mock-challenge"))
+        }
+
+        try Current.keychainClient.set("123", for: .sessionToken)
+
+        XCTAssertTrue(Current.sessionStorage.persistedSessionIdentifiersExist)
+
+        _ = try await StytchClient.cryptoWallets.authenticateStart(parameters: .init(cryptoWalletType: .ethereum, cryptoWalletAddress: "mock-crypto-address"))
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/crypto_wallets/authenticate/start/secondary",
+            method: .post([
+                "crypto_wallet_type": "ethereum",
+                "crypto_wallet_address": "mock-crypto-address",
+            ])
+        )
     }
 
     func testAuthenticate() async throws {
         networkInterceptor.responses { AuthenticateResponse.mock }
+
+        XCTAssertNil(StytchClient.sessions.sessionToken)
+        XCTAssertNil(StytchClient.sessions.sessionJwt)
+
         Current.timer = { _, _, _ in .init() }
+        
         _ = try await StytchClient.cryptoWallets.authenticate(parameters: .init(cryptoWalletType: .solana, cryptoWalletAddress: "mock-crypto-address", signature: "mock-signature"))
+
+        XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("hello_session"))
+        XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("jwt_for_me"))
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],

--- a/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
+++ b/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import StytchCore
+
+final class CryptoWalletsTestCase: BaseTestCase {
+    func testAuthenticateStart() async throws {
+        networkInterceptor.responses {
+            StytchClient.CryptoWallets.AuthenticateStartResponse(requestId: "mock-request-id", statusCode: 200, wrapped: .init(challenge: "mock-challenge"))
+        }
+        Current.timer = { _, _, _ in .init() }
+        _ = try await StytchClient.cryptoWallets.authenticateStart(parameters: .init(cryptoWalletType: .ethereum, cryptoWalletAddress: "mock-crypto-address"))
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/crypto_wallets/authenticate/start/primary",
+            method: .post([
+                "crypto_wallet_type": "ethereum",
+                "crypto_wallet_address": "mock-crypto-address",
+            ])
+        )
+    }
+
+    func testAuthenticate() async throws {
+        networkInterceptor.responses { AuthenticateResponse.mock }
+        Current.timer = { _, _, _ in .init() }
+        _ = try await StytchClient.cryptoWallets.authenticate(parameters: .init(cryptoWalletType: .solana, cryptoWalletAddress: "mock-crypto-address", signature: "mock-signature"))
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/crypto_wallets/authenticate",
+            method: .post([
+                "crypto_wallet_type": "solana",
+                "crypto_wallet_address": "mock-crypto-address",
+                "signature": "mock-signature",
+            ])
+        )
+    }
+}

--- a/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
+++ b/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
@@ -52,7 +52,7 @@ final class CryptoWalletsTestCase: BaseTestCase {
         XCTAssertNil(StytchClient.sessions.sessionJwt)
 
         Current.timer = { _, _, _ in .init() }
-        
+
         _ = try await StytchClient.cryptoWallets.authenticate(parameters: .init(cryptoWalletType: .solana, cryptoWalletAddress: "mock-crypto-address", signature: "mock-signature"))
 
         XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("hello_session"))


### PR DESCRIPTION
Linear Ticket: [SDK-1469](https://linear.app/stytch/issue/SDK-1469)

## Changes:

Adds `stytch.cryptoWallets` with the following methods:
- `authenticateStart`
- `authenticate`

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A