### PR TITLE
SDK-1482 Attempt to fix Sign In With Apple name issues

### DIFF
--- a/Sources/StytchCore/AppleOAuthClient/AppleOAuthClient+Live.swift
+++ b/Sources/StytchCore/AppleOAuthClient/AppleOAuthClient+Live.swift
@@ -34,7 +34,7 @@ extension AppleOAuthClient {
             }
             var name: User.Name?
             if credential.fullName?.givenName != nil || credential.fullName?.familyName != nil {
-                name = .init(firstName: credential.fullName?.givenName, lastName: credential.fullName?.givenName)
+                name = .init(firstName: credential.fullName?.givenName, lastName: credential.fullName?.familyName)
             }
             continuation?.resume(returning: .init(idToken: token, name: name))
         }

--- a/Sources/StytchCore/AppleOAuthClient/AppleOAuthClient+Live.swift
+++ b/Sources/StytchCore/AppleOAuthClient/AppleOAuthClient+Live.swift
@@ -32,8 +32,11 @@ extension AppleOAuthClient {
                 continuation?.resume(throwing: StytchSDKError.missingAuthorizationCredentialIDToken)
                 return
             }
-
-            continuation?.resume(returning: .init(idToken: token, name: .init(credential.fullName)))
+            var name: User.Name?
+            if credential.fullName?.givenName != nil || credential.fullName?.familyName != nil {
+                name = .init(firstName: credential.fullName?.givenName, lastName: credential.fullName?.givenName)
+            }
+            continuation?.resume(returning: .init(idToken: token, name: name))
         }
 
         func authorizationController(controller _: ASAuthorizationController, didCompleteWithError error: Error) {

--- a/Sources/StytchCore/AppleOAuthClient/AppleOAuthClient.swift
+++ b/Sources/StytchCore/AppleOAuthClient/AppleOAuthClient.swift
@@ -18,6 +18,6 @@ struct AppleOAuthClient {
 extension AppleOAuthClient {
     struct Result {
         let idToken: String
-        let name: StytchClient.OAuth.Apple.Name
+        let name: User.Name?
     }
 }

--- a/Sources/StytchCore/ClientInfo/ClientInfo+Version.swift
+++ b/Sources/StytchCore/ClientInfo/ClientInfo+Version.swift
@@ -1,3 +1,3 @@
 extension Version {
-    static let current: Self = .init(major: 0, minor: 26, patch: 0)
+    static let current: Self = .init(major: 0, minor: 25, patch: 1)
 }

--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+Apple.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+Apple.swift
@@ -42,6 +42,14 @@ public extension StytchClient.OAuth {
                     )
                 )
             }
+            _ = try await StytchClient.events.logEvent(
+                parameters: .init(
+                    eventName: "apple_oauth_name_found",
+                    details: [
+                        "found": (authenticateResult.name != nil).description,
+                    ]
+                )
+            )
             return authenticateResponse
         }
     }

--- a/Sources/StytchCore/StytchClient/OAuth/StytchClient+OAuth.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/StytchClient+OAuth.swift
@@ -8,6 +8,7 @@ public extension StytchClient {
     /// OAuth allows you to leverage outside identity providers, for which your users may already have an account, to verify their identity. This is a low-friction method your users will be familiar with.
     struct OAuth: OAuthProviderProtocol {
         let router: NetworkingRouter<OAuthRoute>
+        let userRouter: NetworkingRouter<UsersRoute>
 
         @Dependency(\.keychainClient) private var keychainClient
 
@@ -35,12 +36,12 @@ public extension StytchClient {
 
 public extension StytchClient {
     /// The interface for interacting with OAuth products.
-    static var oauth: OAuth { .init(router: router.scopedRouter { $0.oauth }) }
+    static var oauth: OAuth { .init(router: router.scopedRouter { $0.oauth }, userRouter: router.scopedRouter { $0.users }) }
 }
 
 public extension StytchClient.OAuth {
     /// The interface for authenticating a user with Apple.
-    var apple: Apple { .init(router: router.scopedRouter { $0.apple }) }
+    var apple: Apple { .init(router: router.scopedRouter { $0.apple }, userRouter: userRouter) }
 }
 
 #if !os(watchOS)

--- a/Tests/StytchCoreTests/OAuthTestCase.swift
+++ b/Tests/StytchCoreTests/OAuthTestCase.swift
@@ -9,6 +9,7 @@ final class OAuthTestCase: BaseTestCase {
                 statusCode: 200,
                 wrapped: .init(user: .mock(userId: ""), sessionToken: "", sessionJwt: "", session: .mock(userId: ""), userCreated: false)
             )
+            UserResponse(requestId: "", statusCode: 200, wrapped: .mock(userId: ""))
         }
         Current.appleOAuthClient = .init { _, _ in .init(idToken: "id_token_123", name: .init(firstName: "user", lastName: nil)) }
         Current.timer = { _, _, _ in .init() }
@@ -21,6 +22,13 @@ final class OAuthTestCase: BaseTestCase {
                 "session_duration_minutes": 30,
                 "nonce": "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741",
                 "id_token": "id_token_123",
+            ])
+        )
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[1],
+            urlString: "https://web.stytch.com/sdk/v1/users/me",
+            method: .put([
                 "name": ["first_name": "user"],
             ])
         )


### PR DESCRIPTION
Linear Ticket: [SDK-1482](https://linear.app/stytch/issue/SDK-1482)

## Changes:

1. Mimic the fix from RN, where we explicitly make a user update request IF we get a name back from Apple

## Notes:

- 

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A