### PR TITLE
Fix expected response from SIWA update user request

### DIFF
--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+Apple.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+Apple.swift
@@ -35,7 +35,7 @@ public extension StytchClient.OAuth {
                 )
             )
             if authenticateResult.name != nil {
-                let _: UserResponse = try await userRouter.put(
+                let _: BasicResponse = try await userRouter.put(
                     to: .index,
                     parameters: StytchClient.UserManagement.UpdateParameters(
                         name: authenticateResult.name


### PR DESCRIPTION
Linear Ticket: [SDK-1535](https://linear.app/stytch/issue/SDK-1535)

## Changes:

1. We were expecting a UserResponse from updating new users, but were instead receiving a nested user response. Since we don't use/care about the response, we can just expect a BasicResponse

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A