### PR TITLE
SDK-1561 Fix issue with Biometrics registration

### DIFF
--- a/Sources/StytchCore/Extensions/Dictionary+Stytch.swift
+++ b/Sources/StytchCore/Extensions/Dictionary+Stytch.swift
@@ -8,7 +8,7 @@ extension Dictionary where Key == CFString, Value == Any {
 
     func accessibilityAwareMerging(_ other: Self) -> CFDictionary {
         var combined = merging(other) { $1 } as [CFString: Any]
-        if combined[kSecAttrAccessible] != nil && combined[kSecAttrAccessControl] != nil {
+        if combined[kSecAttrAccessible] != nil, combined[kSecAttrAccessControl] != nil {
             // we can't have both, so prefer kSecAttrAccessControl
             combined.removeValue(forKey: kSecAttrAccessible)
         }

--- a/Sources/StytchCore/Extensions/Dictionary+Stytch.swift
+++ b/Sources/StytchCore/Extensions/Dictionary+Stytch.swift
@@ -1,7 +1,17 @@
 import CoreFoundation
+import Foundation
 
 extension Dictionary where Key == CFString, Value == Any {
     func merging(_ other: Self) -> CFDictionary {
         merging(other) { $1 } as CFDictionary
+    }
+
+    func accessibilityAwareMerging(_ other: Self) -> CFDictionary {
+        var combined = merging(other) { $1 } as [CFString: Any]
+        if combined[kSecAttrAccessible] != nil && combined[kSecAttrAccessControl] != nil {
+            // we can't have both, so prefer kSecAttrAccessControl
+            combined.removeValue(forKey: kSecAttrAccessible)
+        }
+        return combined as CFDictionary
     }
 }

--- a/Sources/StytchCore/KeychainClient/KeychainClient+Item.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient+Item.swift
@@ -31,7 +31,7 @@ extension KeychainClient {
         }
 
         func insertQuery(value: Value) -> CFDictionary {
-            baseQuery.merging(updateQuerySegment(for: value))
+            baseQuery.accessibilityAwareMerging(updateQuerySegment(for: value))
         }
 
         func updateQuerySegment(for value: Value) -> [CFString: Any] {


### PR DESCRIPTION
`kSecAttrAccessible` and `kSecAttrAccessControl` are [mutually exclusive](https://developer.apple.com/documentation/security/ksecattraccesscontrol). The first attribute is used to make a keychain item available after the first unlock (which we use so session tokens are available during fetches when the app is backgrounded) and the second one we use to specify that something can only be accessed with a biometric. Seems obvious in hindsight that they wouldn't work together!

Linear Ticket: [SDK-1561](https://linear.app/stytch/issue/SDK-1561)

## Changes:

1. If both `kSecAttrAccessible` and `kSecAttrAccessControl` are requested for the same keychain item, disregard the `kSecAttrAccessible` attribute, preferring `kSecAttrAccessControl`

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A