### PR TITLE
SDK-1565 Correctly fix biometric key permissions

### DIFF
--- a/Sources/StytchCore/Extensions/Dictionary+Stytch.swift
+++ b/Sources/StytchCore/Extensions/Dictionary+Stytch.swift
@@ -5,13 +5,4 @@ extension Dictionary where Key == CFString, Value == Any {
     func merging(_ other: Self) -> CFDictionary {
         merging(other) { $1 } as CFDictionary
     }
-
-    func accessibilityAwareMerging(_ other: Self) -> CFDictionary {
-        var combined = merging(other) { $1 } as [CFString: Any]
-        if combined[kSecAttrAccessible] != nil, combined[kSecAttrAccessControl] != nil {
-            // we can't have both, so prefer kSecAttrAccessControl
-            combined.removeValue(forKey: kSecAttrAccessible)
-        }
-        return combined as CFDictionary
-    }
 }

--- a/Sources/StytchCore/KeychainClient/KeychainClient+Item.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient+Item.swift
@@ -16,7 +16,6 @@ extension KeychainClient {
                 kSecClass: kSecClassGenericPassword,
                 kSecAttrService: name,
                 kSecUseDataProtectionKeychain: true,
-                kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock,
             ]
         }
 
@@ -31,7 +30,7 @@ extension KeychainClient {
         }
 
         func insertQuery(value: Value) -> CFDictionary {
-            baseQuery.accessibilityAwareMerging(updateQuerySegment(for: value))
+            baseQuery.merging(updateQuerySegment(for: value))
         }
 
         func updateQuerySegment(for value: Value) -> [CFString: Any] {
@@ -49,6 +48,9 @@ extension KeychainClient {
             }
             if let accessControl = try? value.accessPolicy?.accessControl {
                 querySegment[kSecAttrAccessControl] = accessControl
+            }
+            if kind == .token {
+                querySegment[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlock
             }
             return querySegment
         }
@@ -115,7 +117,7 @@ private extension KeychainClient.Item.AccessPolicy {
             guard
                 let accessControl = SecAccessControlCreateWithFlags(
                     nil,
-                    kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+                    kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
                     flags,
                     &error
                 )

--- a/Sources/StytchCore/KeychainClient/KeychainMigration.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainMigration.swift
@@ -7,5 +7,6 @@ extension KeychainClient {
     static let migrations: [KeychainMigration.Type] = [
         Migration1.self,
         Migration2.self,
+        Migration3.self,
     ]
 }

--- a/Sources/StytchCore/KeychainClient/Migrations/Migration3.swift
+++ b/Sources/StytchCore/KeychainClient/Migrations/Migration3.swift
@@ -1,0 +1,41 @@
+import Security
+
+extension KeychainClient {
+    struct Migration3: KeychainMigration {
+        static func run() throws {
+            try [
+                KeychainClient.Item.privateKeyRegistration,
+            ]
+            .forEach { item in
+                var error: Unmanaged<CFError>?
+                defer { error?.release() }
+                #if os(macOS)
+                let flags: SecAccessControlCreateFlags = [.biometryCurrentSet, .or, .watch]
+                #else
+                let flags: SecAccessControlCreateFlags = [.biometryCurrentSet]
+                #endif
+                let accessControl = SecAccessControlCreateWithFlags(
+                    nil,
+                    kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+                    flags,
+                    &error
+                )
+
+                var status = SecItemUpdate(
+                    [kSecAttrService: item.name as CFString, kSecClass: kSecClassGenericPassword] as CFDictionary,
+                    [kSecAttrAccessible: kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly] as CFDictionary
+                )
+                guard [errSecSuccess, errSecItemNotFound].contains(status) else {
+                    throw KeychainError.unhandledError(status: status)
+                }
+                status = SecItemUpdate(
+                    [kSecAttrService: item.name as CFString, kSecClass: kSecClassGenericPassword] as CFDictionary,
+                    [kSecAttrAccessControl: accessControl] as CFDictionary
+                )
+                guard [errSecSuccess, errSecItemNotFound].contains(status) else {
+                    throw KeychainError.unhandledError(status: status)
+                }
+            }
+        }
+    }
+}

--- a/StytchDemo/Client/iOS/iOS.entitlements
+++ b/StytchDemo/Client/iOS/iOS.entitlements
@@ -8,7 +8,7 @@
 	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>webcredentials:jordan.ngrok.dev?mode=developer</string>
+		<string>webcredentials:stytch-passkey-app-association.vercel.app</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
In 0.16.0, I introduced some changes to make keychain items (sessionToken, sessionJWT, etc) available after the first unlock, but unfortunately this was too broad, and affected biometric registrations, too. However, the mutually-exclusive `kSecAttrAccessible` and `kSecAttrAccessControl` flags meant that biometric registrations were _not_ being persisted (biometrics was broken).

0.28.0 attempted to fix this by ignoring the `kSecAttrAccessible` when `kSecAttrAccessControl` was set, which worked, and allowed biometric registrations to be persisted, BUT, it maintained the incorrect/too-broad accessibility flag, which meant registrations were NOT actually protected by biometrics, just by device lock status. As such, biometrics on 0.28.0 should be considered insecure (no bueno!).

This PR ensures that `token` registrations are still available after unlock, that keychain items with `accessControl` flags are correctly applied, and that existing biometric registrations are updated to be correctly locked behind biometrics.

Linear Ticket: [SDK-1565](https://linear.app/stytch/issue/SDK-1565)

## Changes:

1. Add migration for existing biometric registrations
2. Ensure we're still setting accessibleAfterUnlock for tokens (only)
3. Correctly assign access flags for biometric registrations
4. Remove unnecessary merge method

## Notes:

- This has been tested on device

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A