### PR TITLE
SDK-1589 Enable CNAME domains for OAuth and SSO

### DIFF
--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Bootstrap.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Bootstrap.swift
@@ -6,12 +6,14 @@ extension StytchB2BClient {
         @Dependency(\.captcha) private var captcha
         #endif
         @Dependency(\.networkingClient) private var networkingClient
+        @Dependency(\.localStorage) private var localStorage
 
         public func fetch() async throws {
             guard let publicToken = StytchB2BClient.instance.configuration?.publicToken else {
                 throw StytchSDKError.B2BSDKNotConfigured
             }
             let bootstrapData = try await router.get(route: .fetch(Path(rawValue: publicToken))) as BootstrapResponse
+            localStorage.bootstrapData = bootstrapData.wrapped
             #if os(iOS)
             networkingClient.dfpEnabled = bootstrapData.wrapped.dfpProtectedAuthEnabled
             networkingClient.dfpAuthMode = bootstrapData.wrapped.dfpProtectedAuthMode ?? DFPProtectedAuthMode.observation

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO.swift
@@ -17,6 +17,7 @@ public extension StytchB2BClient {
         let router: NetworkingRouter<SSORoute>
 
         @Dependency(\.keychainClient) private var keychainClient
+        @Dependency(\.localStorage) private var localStorage
 
         @available(tvOS 16.0, *)
         private var webAuthSessionClient: WebAuthenticationSessionClient {
@@ -79,10 +80,11 @@ public extension StytchB2BClient {
                 ("signup_redirect_url", signupRedirectUrl.absoluteString),
             ]
 
-            let subDomain = publicToken.hasPrefix("public-token-test") ? "test" : "api"
+            let cnameDomain = localStorage.bootstrapData?.cnameDomain
+            let stytchDomain = publicToken.hasPrefix("public-token-test") ? "test.stytch.com" : "api.stytch.com"
 
             guard
-                let url = URL(string: "https://\(subDomain).stytch.com/v1/public/sso/start")?.appending(queryParameters: queryParameters)
+                let url = URL(string: "https://\(cnameDomain ?? stytchDomain)/v1/public/sso/start")?.appending(queryParameters: queryParameters)
             else { throw StytchSDKError.invalidStartURL }
 
             return url

--- a/Sources/StytchCore/StytchClient/Bootstrap/StytchClient+Bootstrap.swift
+++ b/Sources/StytchCore/StytchClient/Bootstrap/StytchClient+Bootstrap.swift
@@ -6,12 +6,14 @@ extension StytchClient {
         @Dependency(\.captcha) private var captcha
         #endif
         @Dependency(\.networkingClient) private var networkingClient
+        @Dependency(\.localStorage) private var localStorage
 
         public func fetch() async throws {
             guard let publicToken = StytchClient.instance.configuration?.publicToken else {
                 throw StytchSDKError.consumerSDKNotConfigured
             }
             let bootstrapData = try await router.get(route: .fetch(Path(rawValue: publicToken))) as BootstrapResponse
+            localStorage.bootstrapData = bootstrapData.wrapped
             #if os(iOS)
             networkingClient.dfpEnabled = bootstrapData.wrapped.dfpProtectedAuthEnabled
             networkingClient.dfpAuthMode = bootstrapData.wrapped.dfpProtectedAuthMode ?? DFPProtectedAuthMode.observation

--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
@@ -14,6 +14,7 @@ public extension StytchClient.OAuth {
         let provider: Provider
 
         @Dependency(\.openUrl) private var openUrl
+        @Dependency(\.localStorage) private var localStorage
 
         @available(tvOS 16.0, *)
         private var webAuthSessionClient: WebAuthenticationSessionClient {
@@ -89,11 +90,11 @@ public extension StytchClient.OAuth {
                 guard let value = value else { return }
                 queryParameters.append((name, value))
             }
-
-            let subDomain = publicToken.hasPrefix("public-token-test") ? "test" : "api"
+            let cnameDomain = localStorage.bootstrapData?.cnameDomain
+            let stytchDomain = publicToken.hasPrefix("public-token-test") ? "test.stytch.com" : "api.stytch.com"
 
             guard
-                let url = URL(string: "https://\(subDomain).stytch.com/v1/public/oauth/\(provider.rawValue)/start")?.appending(queryParameters: queryParameters)
+                let url = URL(string: "https://\(cnameDomain ?? stytchDomain)/v1/public/oauth/\(provider.rawValue)/start")?.appending(queryParameters: queryParameters)
             else { throw StytchSDKError.invalidStartURL }
 
             return url


### PR DESCRIPTION
Linear Ticket: [SDK-1589](https://linear.app/stytch/issue/SDK-1589)

## Changes:

1. Persist bootstrap data
2. Use cname if available for oauth and sso

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A