### PR TITLE
[SDK-1474][B2B] Add methods for b2b member client

### DIFF
--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -63,6 +63,8 @@ struct Environment {
 
     let userStorage: UserStorage = .init()
 
+    let memberStorage: MemberStorage = .init()
+
     var localStorage: LocalStorage = .init()
 
     var cookieClient: CookieClient = .live

--- a/Sources/StytchCore/Generated/StytchB2BClient.Members.deleteFactor+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.Members.deleteFactor+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchB2BClient.Members {
+    /// Deletes, by id, an existing authentication factor associated with the current member.
+    func deleteFactor(_ factor: Member.AuthenticationFactor, completion: @escaping Completion<MemberResponse>) {
+        Task {
+            do {
+                completion(.success(try await deleteFactor(factor)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Deletes, by id, an existing authentication factor associated with the current member.
+    func deleteFactor(_ factor: Member.AuthenticationFactor) -> AnyPublisher<MemberResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await deleteFactor(factor)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/Generated/StytchB2BClient.Members.update+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.Members.update+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchB2BClient.Members {
+    /// Updates the current member.
+    func update(parameters: UpdateParameters, completion: @escaping Completion<MemberResponse>) {
+        Task {
+            do {
+                completion(.success(try await update(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Updates the current member.
+    func update(parameters: UpdateParameters) -> AnyPublisher<MemberResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await update(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/MemberStorage.swift
+++ b/Sources/StytchCore/MemberStorage.swift
@@ -1,0 +1,28 @@
+import Combine
+import Foundation
+
+final class MemberStorage {
+    private(set) var member: Member? {
+        get { localStorage.member }
+        set { localStorage.member = newValue }
+    }
+
+    private(set) lazy var onMemberChange = _onMemberChange
+        .map { [weak self] in self?.member == nil }
+        .removeDuplicates()
+        .map { [weak self] _ in self?.member }
+
+    private let _onMemberChange = PassthroughSubject<Void, Never>()
+
+    @Dependency(\.localStorage) private var localStorage
+
+    func updateMember(_ member: Member) {
+        self.member = member
+        _onMemberChange.send(())
+    }
+
+    func reset() {
+        member = nil
+        _onMemberChange.send(())
+    }
+}

--- a/Sources/StytchCore/StytchB2BClient/Models/Member.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/Member.swift
@@ -12,6 +12,7 @@ public struct Member: Codable {
     public let ssoRegistrations: [SSORegistration]
     public let trustedMetadata: JSON
     public let untrustedMetadata: JSON
+    public let memberPasswordId: String
 
     let memberId: ID
 }
@@ -28,6 +29,13 @@ public extension Member {
             let rawValue = try container.decode(String.self)
             self = .init(rawValue: rawValue) ?? .unknown
         }
+    }
+
+    /// The authentication factors which are able to be managed via member-management calls.
+    enum AuthenticationFactor {
+        case totp
+        case phoneNumber
+        case password(passwordId: String)
     }
 }
 

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Members.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Members.swift
@@ -1,9 +1,22 @@
+import Combine
+
+public extension StytchB2BClient {
+    /// The interface for interacting with member products.
+    static var member: Members { .init(router: organization.router.scopedRouter { $0.members }) }
+}
+
 public extension StytchB2BClient {
     /// The SDK allows you to view the current member's information, such as fetching (or viewing the most recent cached version) of the current member.
     struct Members {
         let router: NetworkingRouter<StytchB2BClient.OrganizationsRoute.MembersRoute>
 
         @Dependency(\.localStorage) private var localStorage
+        @Dependency(\.memberStorage) private var memberStorage
+
+        /// A publisher which emits following a change in member status and returns either the member object or nil. You can use this as an indicator to set up or tear down your UI accordingly.
+        public var onMemberChange: AnyPublisher<Member?, Never> {
+            memberStorage.onMemberChange.eraseToAnyPublisher()
+        }
 
         /// Returns the most-recent cached copy of the member object, if it has already been fetched via another method, else nil.
         public func getSync() -> Member? {
@@ -17,12 +30,37 @@ public extension StytchB2BClient {
             localStorage.member = response.member
             return response
         }
-    }
-}
 
-public extension StytchB2BClient {
-    /// The interface for interacting with member products.
-    static var member: Members { .init(router: organization.router.scopedRouter { $0.members }) }
+        // sourcery: AsyncVariants
+        /// Updates the current member.
+        public func update(parameters: UpdateParameters) async throws -> MemberResponse {
+            try await updatingCachedMember {
+                try await router.put(to: .update, parameters: parameters)
+            }
+        }
+
+        // sourcery: AsyncVariants
+        /// Deletes, by id, an existing authentication factor associated with the current member.
+        public func deleteFactor(_ factor: Member.AuthenticationFactor) async throws -> MemberResponse {
+            let response: MemberResponse
+            switch factor {
+            case .totp:
+                response = try await router.delete(route: .deleteTOTP)
+            case .phoneNumber:
+                response = try await router.delete(route: .deletePhoneNumber)
+            case let .password(passwordId):
+                response = try await router.delete(route: .deletePassword(passwordId: passwordId))
+            }
+            memberStorage.updateMember(response.member)
+            return response
+        }
+
+        private func updatingCachedMember(_ performRequest: () async throws -> MemberResponse) async rethrows -> MemberResponse {
+            let response = try await performRequest()
+            memberStorage.updateMember(response.wrapped.member)
+            return response
+        }
+    }
 }
 
 public extension StytchB2BClient.Members {
@@ -31,7 +69,38 @@ public extension StytchB2BClient.Members {
 
     /// The underlying data for the MemberResponse type.
     struct MemberResponseData: Codable {
+        /// The current member's member id.
+        public let memberId: String?
+
         /// The current member.
         public let member: Member
+
+        /// The current member's organization.
+        public let organization: Organization?
+    }
+}
+
+public extension StytchB2BClient.Members {
+    /// The dedicated parameters type for the update member call.
+    struct UpdateParameters: Codable {
+        let name: String?
+        let untrustedMetadata: JSON?
+        let mfaEnrolled: Bool?
+        let mfaPhoneNumber: String?
+        let defaultMfaMethod: String?
+
+        public init(
+            name: String? = nil,
+            untrustedMetadata: JSON? = nil,
+            mfaEnrolled: Bool? = nil,
+            mfaPhoneNumber: String? = nil,
+            defaultMfaMethod: String? = nil
+        ) {
+            self.name = name
+            self.untrustedMetadata = untrustedMetadata
+            self.mfaEnrolled = mfaEnrolled
+            self.mfaPhoneNumber = mfaPhoneNumber
+            self.defaultMfaMethod = defaultMfaMethod
+        }
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
@@ -111,12 +111,27 @@ extension StytchB2BClient {
             }
         }
 
-        enum MembersRoute: String, RouteType {
+        enum MembersRoute: RouteType {
             // swiftlint:disable:next identifier_name
             case me
+            case update
+            case deletePhoneNumber
+            case deleteTOTP
+            case deletePassword(passwordId: String)
 
             var path: Path {
-                .init(rawValue: rawValue)
+                switch self {
+                case .me:
+                    return Path(rawValue: "me")
+                case .update:
+                    return Path(rawValue: "update")
+                case .deletePhoneNumber:
+                    return Path(rawValue: "deletePhoneNumber")
+                case .deleteTOTP:
+                    return Path(rawValue: "deleteTOTP")
+                case let .deletePassword(passwordId):
+                    return Path(rawValue: "passwords/\(passwordId)")
+                }
             }
         }
     }

--- a/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
@@ -179,6 +179,7 @@ extension Member {
         ssoRegistrations: [],
         trustedMetadata: [:],
         untrustedMetadata: [:],
+        memberPasswordId: "",
         memberId: "member_1234"
     )
 }

--- a/Tests/StytchCoreTests/B2BMembersTestCase.swift
+++ b/Tests/StytchCoreTests/B2BMembersTestCase.swift
@@ -1,7 +1,29 @@
 import XCTest
 @testable import StytchCore
 
+// swiftlint:disable implicitly_unwrapped_optional
 final class B2BMembersTestCase: BaseTestCase {
+    var response: StytchB2BClient.Members.MemberResponse!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        response = StytchB2BClient.Members.MemberResponse(
+            requestId: "123",
+            statusCode: 200,
+            wrapped: .init(
+                memberId: "member_1234",
+                member: .mock,
+                organization: nil
+            )
+        )
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        response = nil
+    }
+
     func testSync() throws {
         XCTAssertNil(StytchB2BClient.member.getSync())
         Current.localStorage.member = .mock
@@ -9,11 +31,78 @@ final class B2BMembersTestCase: BaseTestCase {
     }
 
     func testGet() async throws {
-        networkInterceptor.responses { StytchB2BClient.Members.MemberResponse(requestId: "123", statusCode: 200, wrapped: .init(member: .mock)) }
+        networkInterceptor.responses {
+            response
+        }
         XCTAssertNil(StytchB2BClient.member.getSync())
         let getMemberResponse = try await StytchB2BClient.member.get()
         XCTAssertNotNil(StytchB2BClient.member.getSync())
         XCTAssertEqual(getMemberResponse.member.id, StytchB2BClient.member.getSync()?.id)
-        try XCTAssertRequest(networkInterceptor.requests[0], urlString: "https://web.stytch.com/sdk/v1/b2b/organizations/members/me", method: .get)
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/b2b/organizations/members/me",
+            method: .get
+        )
+    }
+
+    func testUpdate() async throws {
+        networkInterceptor.responses {
+            response
+        }
+        XCTAssertNil(StytchB2BClient.member.getSync())
+        let updateMemberResponse = try await StytchB2BClient.member.update(parameters: .init(name: "foo bar", untrustedMetadata: ["blah": 1]))
+        XCTAssertNotNil(StytchB2BClient.member.getSync())
+        XCTAssertEqual(updateMemberResponse.memberId, StytchB2BClient.member.getSync()?.memberId.rawValue)
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/b2b/organizations/members/update",
+            method: .put(["name": "foo bar", "untrusted_metadata": ["blah": 1]])
+        )
+    }
+
+    func testDeletePhoneNumberFactor() async throws {
+        networkInterceptor.responses {
+            response
+        }
+        Current.localStorage.member = nil
+        XCTAssertNil(StytchB2BClient.member.getSync())
+        _ = try await StytchB2BClient.member.deleteFactor(.phoneNumber)
+        XCTAssertNotNil(StytchB2BClient.member.getSync())
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/b2b/organizations/members/deletePhoneNumber",
+            method: .delete
+        )
+    }
+
+    func testDeleteTotpFactor() async throws {
+        networkInterceptor.responses {
+            response
+        }
+        Current.localStorage.member = nil
+        XCTAssertNil(StytchB2BClient.member.getSync())
+        _ = try await StytchB2BClient.member.deleteFactor(.totp)
+        XCTAssertNotNil(StytchB2BClient.member.getSync())
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/b2b/organizations/members/deleteTOTP",
+            method: .delete
+        )
+    }
+
+    func testDeletePasswordFactor() async throws {
+        networkInterceptor.responses {
+            response
+        }
+        Current.localStorage.member = nil
+        XCTAssertNil(StytchB2BClient.member.getSync())
+        _ = try await StytchB2BClient.member.deleteFactor(.password(passwordId: "passwordId-1234"))
+        XCTAssertNotNil(StytchB2BClient.member.getSync())
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/b2b/organizations/members/passwords/passwordId-1234",
+            method: .delete
+        )
     }
 }


### PR DESCRIPTION
Linear Ticket: Add methods for b2b member client: [SDK-1474](https://linear.app/stytch/issue/SDK-1474)
- onChange
- update
- deleteFactor (deleteMFAPhoneNumber, deletePassword, deleteMFATOTP)

## Notes:

- Much of these changes parodied the way we implemented `User` and `StytchClient+User`.

## Changes:

1. Create `MemberStorage` to cache the current member.
2. Add `memberPasswordId` property to the member object to help with the delete password factor flow.
3. Add `onMemberChange` publisher to `StytchB2BClient+Members` so we can be notified when changes to the member happen.
4. Add `func update(...)` to `StytchB2BClient+Members` so we can update the current member.
5. Add `func deleteFactor(...)` to `StytchB2BClient+Members` for phone number, totp and password.
6. Unify member response with `MemberResponseData` and add missing fields `memberId: String?` and `organization: Organization?`.
7. Update `MemberViewController` in B2B sample app to include new functionality.
8. Update `B2BMembersTestCase` to include tests for new functionality.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A