### PR TITLE
[SDK-1473][B2B] Add exchange method to session client

### DIFF
--- a/Sources/StytchCore/Generated/Sessions.exchange+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/Sessions.exchange+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension Sessions {
+    /// Use this endpoint to exchange a Member's existing session for another session in a different Organization.
+    func exchange(parameters: ExchangeParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
+        Task {
+            do {
+                completion(.success(try await exchange(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Use this endpoint to exchange a Member's existing session for another session in a different Organization.
+    func exchange(parameters: ExchangeParameters) -> AnyPublisher<B2BAuthenticateResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await exchange(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Sessions.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Sessions.swift
@@ -2,3 +2,29 @@ public extension StytchB2BClient {
     /// The interface for interacting with sessions products.
     static var sessions: Sessions<B2BAuthenticateResponse> { .init(router: router.scopedRouter { $0.sessions }) }
 }
+
+public extension Sessions {
+    // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
+    /// Use this endpoint to exchange a Member's existing session for another session in a different Organization.
+    func exchange(parameters: ExchangeParameters) async throws -> B2BAuthenticateResponse {
+        try await router.post(to: .exchange, parameters: parameters)
+    }
+}
+
+public extension Sessions {
+    /// The dedicated parameters type for session `exchange` calls.
+    struct ExchangeParameters: Codable {
+        /// The ID of the organization that the new session should belong to.
+        public let organizationID: String
+        /// The duration, in minutes, for the requested session. Defaults to 30 minutes.
+        public let sessionDurationMinutes: Minutes
+        /// The locale will be used if an OTP code is sent to the member's phone number as part of a secondary authentication requirement.
+        public let locale: String?
+
+        public init(organizationID: String, sessionDurationMinutes: Minutes = .defaultSessionDuration, locale: String? = nil) {
+            self.organizationID = organizationID
+            self.sessionDurationMinutes = sessionDurationMinutes
+            self.locale = locale
+        }
+    }
+}

--- a/Sources/StytchCore/StytchClientCommon/Sessions/SessionsRoute.swift
+++ b/Sources/StytchCore/StytchClientCommon/Sessions/SessionsRoute.swift
@@ -1,6 +1,7 @@
 enum SessionsRoute: String, RouteType {
     case authenticate
     case revoke
+    case exchange
 
     var path: Path {
         .init(rawValue: rawValue)

--- a/StytchDemo/B2BWorkbench/AuthMethodControllers/DiscoveryViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthMethodControllers/DiscoveryViewController.swift
@@ -64,8 +64,6 @@ final class DiscoveryViewController: UIViewController {
         })
     }()
 
-    private let defaults: UserDefaults = .standard
-
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/StytchDemo/B2BWorkbench/AuthMethodControllers/MagicLinksViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthMethodControllers/MagicLinksViewController.swift
@@ -66,8 +66,6 @@ final class MagicLinksViewController: UIViewController {
         })
     }()
 
-    private let defaults: UserDefaults = .standard
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -90,9 +88,9 @@ final class MagicLinksViewController: UIViewController {
         stackView.addArrangedSubview(discoverySendButton)
         stackView.addArrangedSubview(inviteSendButton)
 
-        emailTextField.text = defaults.string(forKey: Constants.emailDefaultsKey)
-        orgIdTextField.text = defaults.string(forKey: Constants.orgIdDefaultsKey)
-        redirectUrlTextField.text = defaults.string(forKey: Constants.redirectUrlDefaultsKey) ?? "b2bworkbench://auth"
+        emailTextField.text = UserDefaults.standard.string(forKey: Constants.emailDefaultsKey)
+        orgIdTextField.text = UserDefaults.standard.string(forKey: Constants.orgIdDefaultsKey)
+        redirectUrlTextField.text = UserDefaults.standard.string(forKey: Constants.redirectUrlDefaultsKey) ?? "b2bworkbench://auth"
     }
 
     func submit() {
@@ -100,9 +98,9 @@ final class MagicLinksViewController: UIViewController {
         guard let orgId = orgIdTextField.text, !orgId.isEmpty else { return }
         guard let redirectUrl = redirectUrlTextField.text.map(URL.init(string:)) else { return }
 
-        defaults.set(email, forKey: Constants.emailDefaultsKey)
-        defaults.set(orgId, forKey: Constants.orgIdDefaultsKey)
-        defaults.set(redirectUrl?.absoluteURL, forKey: Constants.redirectUrlDefaultsKey)
+        UserDefaults.standard.set(email, forKey: Constants.emailDefaultsKey)
+        UserDefaults.standard.set(orgId, forKey: Constants.orgIdDefaultsKey)
+        UserDefaults.standard.set(redirectUrl?.absoluteURL, forKey: Constants.redirectUrlDefaultsKey)
 
         Task {
             do {
@@ -126,9 +124,9 @@ final class MagicLinksViewController: UIViewController {
         guard let orgId = orgIdTextField.text, !orgId.isEmpty else { return }
         guard let redirectUrl = redirectUrlTextField.text.map(URL.init(string:)) else { return }
 
-        defaults.set(email, forKey: Constants.emailDefaultsKey)
-        defaults.set(orgId, forKey: Constants.orgIdDefaultsKey)
-        defaults.set(redirectUrl?.absoluteURL, forKey: Constants.redirectUrlDefaultsKey)
+        UserDefaults.standard.set(email, forKey: Constants.emailDefaultsKey)
+        UserDefaults.standard.set(orgId, forKey: Constants.orgIdDefaultsKey)
+        UserDefaults.standard.set(redirectUrl?.absoluteURL, forKey: Constants.redirectUrlDefaultsKey)
 
         Task {
             do {
@@ -150,9 +148,9 @@ final class MagicLinksViewController: UIViewController {
         guard let orgId = orgIdTextField.text, !orgId.isEmpty else { return }
         guard let redirectUrl = redirectUrlTextField.text.map(URL.init(string:)) else { return }
 
-        defaults.set(email, forKey: Constants.emailDefaultsKey)
-        defaults.set(orgId, forKey: Constants.orgIdDefaultsKey)
-        defaults.set(redirectUrl?.absoluteURL, forKey: Constants.redirectUrlDefaultsKey)
+        UserDefaults.standard.set(email, forKey: Constants.emailDefaultsKey)
+        UserDefaults.standard.set(orgId, forKey: Constants.orgIdDefaultsKey)
+        UserDefaults.standard.set(redirectUrl?.absoluteURL, forKey: Constants.redirectUrlDefaultsKey)
 
         Task {
             do {

--- a/StytchDemo/B2BWorkbench/AuthMethodControllers/PasswordsViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthMethodControllers/PasswordsViewController.swift
@@ -93,8 +93,6 @@ final class PasswordsViewController: UIViewController {
         })
     }()
 
-    private let defaults: UserDefaults = .standard
-
     private let passwordClient = StytchB2BClient.passwords
 
     override func viewDidLoad() {
@@ -127,9 +125,9 @@ final class PasswordsViewController: UIViewController {
         stackView.addArrangedSubview(resetByEmailStartButton)
         stackView.addArrangedSubview(resetBySessionButton)
 
-        emailTextField.text = defaults.string(forKey: Constants.emailDefaultsKey)
-        orgIdTextField.text = defaults.string(forKey: Constants.orgIdDefaultsKey)
-        redirectUrlTextField.text = defaults.string(forKey: Constants.redirectUrlDefaultsKey) ?? "b2bworkbench://auth"
+        emailTextField.text = UserDefaults.standard.string(forKey: Constants.emailDefaultsKey)
+        orgIdTextField.text = UserDefaults.standard.string(forKey: Constants.orgIdDefaultsKey)
+        redirectUrlTextField.text = UserDefaults.standard.string(forKey: Constants.redirectUrlDefaultsKey) ?? "b2bworkbench://auth"
 
         if StytchB2BClient.sessions.memberSession == nil {
             resetBySessionButton.isHidden = true
@@ -159,7 +157,7 @@ final class PasswordsViewController: UIViewController {
                         password: values.password
                     )
                 )
-                print("authenticated!")
+                presentAlertWithTitle(alertTitle: "Authenticated!")
             } catch {
                 print("authenticate error: \(error.errorInfo)")
             }
@@ -170,7 +168,7 @@ final class PasswordsViewController: UIViewController {
         guard let password = passwordTextField.text, !password.isEmpty else { return }
 
         if let email = emailTextField.text, !email.isEmpty {
-            defaults.set(email, forKey: Constants.emailDefaultsKey)
+            UserDefaults.standard.set(email, forKey: Constants.emailDefaultsKey)
         }
 
         Task {
@@ -247,17 +245,17 @@ final class PasswordsViewController: UIViewController {
         let redirectUrl = redirectUrlTextField.text.flatMap(URL.init(string:))
 
         if let redirectUrl {
-            defaults.set(redirectUrl.absoluteString, forKey: Constants.redirectUrlDefaultsKey)
+            UserDefaults.standard.set(redirectUrl.absoluteString, forKey: Constants.redirectUrlDefaultsKey)
         }
 
         if let email = emailTextField.text, !email.isEmpty {
-            defaults.set(email, forKey: Constants.emailDefaultsKey)
+            UserDefaults.standard.set(email, forKey: Constants.emailDefaultsKey)
         }
         if let orgId = orgIdTextField.text, !orgId.isEmpty {
-            defaults.set(orgId, forKey: Constants.orgIdDefaultsKey)
+            UserDefaults.standard.set(orgId, forKey: Constants.orgIdDefaultsKey)
         }
 
-        defaults.set(orgId, forKey: Constants.orgIdDefaultsKey)
+        UserDefaults.standard.set(orgId, forKey: Constants.orgIdDefaultsKey)
 
         return (.init(rawValue: orgId), passwordTextField.text ?? "", emailTextField.text ?? "", redirectUrl)
     }

--- a/StytchDemo/B2BWorkbench/AuthMethodControllers/SSOViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthMethodControllers/SSOViewController.swift
@@ -40,8 +40,6 @@ final class SSOViewController: UIViewController {
         return .init(configuration: configuration, primaryAction: startAction)
     }()
 
-    private let defaults: UserDefaults = .standard
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -61,14 +59,14 @@ final class SSOViewController: UIViewController {
         stackView.addArrangedSubview(redirectUrlTextField)
         stackView.addArrangedSubview(startButton)
 
-        redirectUrlTextField.text = defaults.string(forKey: Constants.redirectUrlDefaultsKey) ?? "b2bworkbench://auth"
+        redirectUrlTextField.text = UserDefaults.standard.string(forKey: Constants.redirectUrlDefaultsKey) ?? "b2bworkbench://auth"
     }
 
     private func start() {
         guard let connectionId = connectionIdTextField.text, !connectionId.isEmpty else { return }
         guard let redirectUrl = redirectUrlTextField.text.flatMap(URL.init(string:)) else { return }
 
-        defaults.set(redirectUrl.absoluteURL, forKey: Constants.redirectUrlDefaultsKey)
+        UserDefaults.standard.set(redirectUrl.absoluteURL, forKey: Constants.redirectUrlDefaultsKey)
 
         Task {
             do {

--- a/StytchDemo/B2BWorkbench/RootViewController.swift
+++ b/StytchDemo/B2BWorkbench/RootViewController.swift
@@ -35,8 +35,6 @@ final class RootViewController: UIViewController {
         return view
     }()
 
-    private let defaults: UserDefaults = .standard
-
     private var authChangeCancellable: AnyCancellable?
 
     override func viewDidLoad() {
@@ -59,24 +57,21 @@ final class RootViewController: UIViewController {
         memberIdLabel.preferredMaxLayoutWidth = view.bounds.width - 2 * Constants.padding
         memberIdLabel.isHidden = true
 
-        publicTokenTextField.text = defaults.string(forKey: Constants.publicTokenDefaultsKey)
+        publicTokenTextField.text = UserDefaults.standard.string(forKey: Constants.publicTokenDefaultsKey)
 
         authChangeCancellable = StytchB2BClient.sessions.onAuthChange
             .map { _ in StytchB2BClient.member.getSync() }
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] member in
-                guard let self else { return }
-
-                self.memberIdLabel.isHidden = member == nil
-                self.memberIdLabel.text = member.map { "Welcome, \($0.id.rawValue)!" } ?? "Logged out"
-                self.navigationController?.popToRootViewController(animated: true)
+                self?.memberIdLabel.isHidden = member == nil
+                self?.memberIdLabel.text = member.map { "Welcome, \($0.id.rawValue)!" } ?? "Logged out"
             })
     }
 
     private func submit(token: String?) {
         guard let token = token, !token.isEmpty else { return }
 
-        defaults.set(token, forKey: Constants.publicTokenDefaultsKey)
+        UserDefaults.standard.set(token, forKey: Constants.publicTokenDefaultsKey)
         StytchB2BClient.configure(publicToken: token)
 
         navigationController?.pushViewController(AuthHomeViewController(), animated: true)

--- a/StytchDemo/B2BWorkbench/SceneDelegate.swift
+++ b/StytchDemo/B2BWorkbench/SceneDelegate.swift
@@ -34,10 +34,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                         print("discovery authResponse: \(authResponse)")
                     }
                 case let .manualHandlingRequired(_, token):
-                    guard let controller = window?.rootViewController?.navigationController?.viewControllers.last as? PasswordsViewController else {
-                        fatalError("Passwords controller should still be last")
+                    let appViewController = window?.rootViewController as? AppViewController
+                    if let passwordsViewController = appViewController?.viewControllers.last as? PasswordsViewController {
+                        passwordsViewController.initiatePasswordReset(token: token)
                     }
-                    controller.initiatePasswordReset(token: token)
                 case .notHandled:
                     break
                 }

--- a/Tests/StytchCoreTests/B2BSessionsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSessionsTestCase.swift
@@ -59,4 +59,25 @@ final class B2BSessionsTestCase: BaseTestCase {
         XCTAssertEqual(StytchB2BClient.sessions.sessionToken, .opaque("token"))
         XCTAssertEqual(StytchB2BClient.sessions.sessionJwt, .jwt("jwt"))
     }
+
+    func testSessionExchange() async throws {
+        networkInterceptor.responses {
+            B2BAuthenticateResponse.mock
+        }
+
+        Current.timer = { _, _, _ in .init() }
+
+        let organizationID = "org_123"
+        let parameters = Sessions<B2BAuthenticateResponse>.ExchangeParameters(organizationID: organizationID)
+        _ = try await StytchB2BClient.sessions.exchange(parameters: parameters)
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/b2b/sessions/exchange",
+            method: .post([
+                "organization_id": JSON(stringLiteral: organizationID),
+                "session_duration_minutes": 30,
+            ])
+        )
+    }
 }


### PR DESCRIPTION
Linear Ticket: [SDK-1473: Add exchange method to session client](https://linear.app/stytch/issue/SDK-1473/[ios]-[b2b]-add-method-for-session-client)

## Notes:

- The session exchange function works if there is a user that is authenticated by email magic links or oauth and is a member of multiple organizations. You can then call the session exchange function with the id of the org they wish to authenticate with and it will create and return a new member session.

## Changes:

1. Extend `Sessions` to include an `exchnage` method. And add the `ExchangeParameters` type.
2. In the b2b sample app remove all usage of a defined property for `private let defaults: UserDefaults = .standard` and instead refer directly to `UserDefaults.standard`. I feel that this is confusing and would imply custom usage of user default and not the standard usage.
3. Fix password reset flow in b2b sample app in `SceneDelegate`, wrong logic was being used to parse out the `PasswordsViewController`.
4. Remove logic in b2b sample app `RootViewController` to stop popping to the root view controller every time we got a notification about the session info changing. The `RootViewController` only ever set the project id and that almost never changes. And with the improved reporting throughout the app, we know when the user needs to be authenticated.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A