### PR TITLE
[SDK-1733] Create separate session clients for B2B and B2C.

### DIFF
--- a/Sources/StytchCore/Generated/StytchB2BClientSessions.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClientSessions.authenticate+AsyncVariants.generated.swift
@@ -3,9 +3,9 @@
 import Combine
 import Foundation
 
-public extension Sessions {
+public extension StytchB2BClientSessions {
     /// Wraps Stytch's [authenticate](https://stytch.com/docs/api/session-auth) Session endpoint and validates that the session issued to the user is still valid, returning both an opaque sessionToken and sessionJwt for this session. The sessionJwt will have a fixed lifetime of five minutes regardless of the underlying session duration, though it will be refreshed automatically in the background after a successful authentication.
-    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<AuthResponseType>) {
+    func authenticate(parameters: Sessions.AuthenticateParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
         Task {
             do {
                 completion(.success(try await authenticate(parameters: parameters)))
@@ -16,7 +16,7 @@ public extension Sessions {
     }
 
     /// Wraps Stytch's [authenticate](https://stytch.com/docs/api/session-auth) Session endpoint and validates that the session issued to the user is still valid, returning both an opaque sessionToken and sessionJwt for this session. The sessionJwt will have a fixed lifetime of five minutes regardless of the underlying session duration, though it will be refreshed automatically in the background after a successful authentication.
-    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<AuthResponseType, Error> {
+    func authenticate(parameters: Sessions.AuthenticateParameters) -> AnyPublisher<B2BAuthenticateResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/Generated/StytchB2BClientSessions.exchange+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClientSessions.exchange+AsyncVariants.generated.swift
@@ -3,7 +3,7 @@
 import Combine
 import Foundation
 
-public extension Sessions {
+public extension StytchB2BClientSessions {
     /// Use this endpoint to exchange a Member's existing session for another session in a different Organization.
     func exchange(parameters: ExchangeParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
         Task {

--- a/Sources/StytchCore/Generated/StytchB2BClientSessions.revoke+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClientSessions.revoke+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchB2BClientSessions {
+    /// Wraps Stytch's [revoke](https://stytch.com/docs/api/session-revoke) Session endpoint and revokes the user's current session. This method should be used to log out a user. A successful revocation will terminate session-refresh polling.
+    func revoke(parameters: Sessions.RevokeParameters = .init(), completion: @escaping Completion<BasicResponse>) {
+        Task {
+            do {
+                completion(.success(try await revoke(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Wraps Stytch's [revoke](https://stytch.com/docs/api/session-revoke) Session endpoint and revokes the user's current session. This method should be used to log out a user. A successful revocation will terminate session-refresh polling.
+    func revoke(parameters: Sessions.RevokeParameters = .init()) -> AnyPublisher<BasicResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await revoke(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/Generated/StytchClientSessions.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClientSessions.authenticate+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchClientSessions {
+    /// Wraps Stytch's [authenticate](https://stytch.com/docs/api/session-auth) Session endpoint and validates that the session issued to the user is still valid, returning both an opaque sessionToken and sessionJwt for this session. The sessionJwt will have a fixed lifetime of five minutes regardless of the underlying session duration, though it will be refreshed automatically in the background after a successful authentication.
+    func authenticate(parameters: Sessions.AuthenticateParameters, completion: @escaping Completion<AuthenticateResponse>) {
+        Task {
+            do {
+                completion(.success(try await authenticate(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Wraps Stytch's [authenticate](https://stytch.com/docs/api/session-auth) Session endpoint and validates that the session issued to the user is still valid, returning both an opaque sessionToken and sessionJwt for this session. The sessionJwt will have a fixed lifetime of five minutes regardless of the underlying session duration, though it will be refreshed automatically in the background after a successful authentication.
+    func authenticate(parameters: Sessions.AuthenticateParameters) -> AnyPublisher<AuthenticateResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await authenticate(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/Generated/StytchClientSessions.revoke+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClientSessions.revoke+AsyncVariants.generated.swift
@@ -3,9 +3,9 @@
 import Combine
 import Foundation
 
-public extension Sessions {
+public extension StytchClientSessions {
     /// Wraps Stytch's [revoke](https://stytch.com/docs/api/session-revoke) Session endpoint and revokes the user's current session. This method should be used to log out a user. A successful revocation will terminate session-refresh polling.
-    func revoke(parameters: RevokeParameters = .init(), completion: @escaping Completion<BasicResponse>) {
+    func revoke(parameters: Sessions.RevokeParameters = .init(), completion: @escaping Completion<BasicResponse>) {
         Task {
             do {
                 completion(.success(try await revoke(parameters: parameters)))
@@ -16,7 +16,7 @@ public extension Sessions {
     }
 
     /// Wraps Stytch's [revoke](https://stytch.com/docs/api/session-revoke) Session endpoint and revokes the user's current session. This method should be used to log out a user. A successful revocation will terminate session-refresh polling.
-    func revoke(parameters: RevokeParameters = .init()) -> AnyPublisher<BasicResponse, Error> {
+    func revoke(parameters: Sessions.RevokeParameters = .init()) -> AnyPublisher<BasicResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
@@ -4,7 +4,7 @@ extension StytchB2BClient {
         case magicLinks(MagicLinksRoute)
         case organizations(OrganizationsRoute)
         case passwords(PasswordsRoute)
-        case sessions(SessionsRoute)
+        case sessions(B2BSessionsRoute)
         case sso(SSORoute)
         case events(EventsRoute)
         case bootstrap(BootstrapRoute)
@@ -167,6 +167,16 @@ extension StytchB2BClient {
             case let .fetch(publicToken):
                 return "projects/bootstrap".appendingPath(publicToken)
             }
+        }
+    }
+
+    enum B2BSessionsRoute: String, RouteType {
+        case authenticate
+        case revoke
+        case exchange
+
+        var path: Path {
+            .init(rawValue: rawValue)
         }
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Sessions.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Sessions.swift
@@ -1,17 +1,76 @@
+import Combine
+
 public extension StytchB2BClient {
     /// The interface for interacting with sessions products.
-    static var sessions: Sessions<B2BAuthenticateResponse> { .init(router: router.scopedRouter { $0.sessions }) }
+    static var sessions: StytchB2BClientSessions {
+        .init(router: router.scopedRouter { $0.sessions })
+    }
 }
 
-public extension Sessions {
+/// The SDK may be used to check whether a user has a cached session, view the current session, refresh the session, and revoke the session. To authenticate a session on your backend, you must use either the Stytch API or a Stytch server-side library. **NOTE**: - After a successful authentication, the session will be automatically refreshed in the background to ensure the sessionJwt remains valid (it expires after 5 minutes.) Session polling will be stopped after a session is revoked or after an unauthenticated error response is received.
+public struct StytchB2BClientSessions {
+    let router: NetworkingRouter<StytchB2BClient.B2BSessionsRoute>
+    @Dependency(\.sessionStorage) var sessionStorage
+    @Dependency(\.localStorage) var localStorage
+
+    public var memberSession: MemberSession? {
+        get {
+            localStorage.memberSession
+        }
+        set {
+            localStorage.memberSession = newValue
+        }
+    }
+
+    /// An opaque token representing your session, which your servers can check with Stytch's servers to verify your session status.
+    public var sessionToken: SessionToken? {
+        sessionStorage.sessionToken
+    }
+
+    /// A session JWT (JSON Web Token), which your servers can check locally to verify your session status.
+    public var sessionJwt: SessionToken? {
+        sessionStorage.sessionJwt
+    }
+
+    /// A publisher which emits following a change in authentication status and returns either the opaque session token or nil. You can use this as an indicator to set up or tear down your UI accordingly.
+    public var onAuthChange: AnyPublisher<String?, Never> {
+        sessionStorage.onAuthChange.eraseToAnyPublisher()
+    }
+
+    // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
+    /// Wraps Stytch's [authenticate](https://stytch.com/docs/api/session-auth) Session endpoint and validates that the session issued to the user is still valid, returning both an opaque sessionToken and sessionJwt for this session. The sessionJwt will have a fixed lifetime of five minutes regardless of the underlying session duration, though it will be refreshed automatically in the background after a successful authentication.
+    public func authenticate(parameters: Sessions.AuthenticateParameters) async throws -> B2BAuthenticateResponse {
+        try await router.post(to: .authenticate, parameters: parameters)
+    }
+
+    /// If your app has cookies disabled or simply receives updated session tokens from your backend via means other than
+    /// `Set-Cookie` headers, you must call this method after receiving the updated tokens to ensure the `StytchClient`
+    /// and persistent storage are kept up-to-date. You should include both the opaque token and the jwt.
+    public func update(sessionTokens tokens: [SessionToken]) {
+        tokens.forEach(sessionStorage.updatePersistentStorage)
+    }
+
+    // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
+    /// Wraps Stytch's [revoke](https://stytch.com/docs/api/session-revoke) Session endpoint and revokes the user's current session. This method should be used to log out a user. A successful revocation will terminate session-refresh polling.
+    public func revoke(parameters: Sessions.RevokeParameters = .init()) async throws -> BasicResponse {
+        do {
+            let response: BasicResponse = try await router.post(to: .revoke, parameters: EmptyCodable())
+            sessionStorage.reset()
+            return response
+        } catch {
+            if parameters.forceClear { sessionStorage.reset() }
+            throw error
+        }
+    }
+
     // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
     /// Use this endpoint to exchange a Member's existing session for another session in a different Organization.
-    func exchange(parameters: ExchangeParameters) async throws -> B2BAuthenticateResponse {
+    public func exchange(parameters: ExchangeParameters) async throws -> B2BAuthenticateResponse {
         try await router.post(to: .exchange, parameters: parameters)
     }
 }
 
-public extension Sessions {
+public extension StytchB2BClientSessions {
     /// The dedicated parameters type for session `exchange` calls.
     struct ExchangeParameters: Codable {
         /// The ID of the organization that the new session should belong to.

--- a/Sources/StytchCore/StytchClient/StytchClient+Sessions.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient+Sessions.swift
@@ -1,4 +1,75 @@
+import Combine
+
 public extension StytchClient {
     /// The interface for interacting with sessions products.
-    static var sessions: Sessions<AuthenticateResponse> { .init(router: router.scopedRouter { $0.sessions }) }
+    static var sessions: StytchClientSessions {
+        .init(router: router.scopedRouter { $0.sessions })
+    }
+}
+
+enum SessionsRoute: String, RouteType {
+    case authenticate
+    case revoke
+
+    var path: Path {
+        .init(rawValue: rawValue)
+    }
+}
+
+/// The SDK may be used to check whether a user has a cached session, view the current session, refresh the session, and revoke the session. To authenticate a session on your backend, you must use either the Stytch API or a Stytch server-side library. **NOTE**: - After a successful authentication, the session will be automatically refreshed in the background to ensure the sessionJwt remains valid (it expires after 5 minutes.) Session polling will be stopped after a session is revoked or after an unauthenticated error response is received.
+public struct StytchClientSessions {
+    let router: NetworkingRouter<SessionsRoute>
+    @Dependency(\.sessionStorage) var sessionStorage
+    @Dependency(\.localStorage) var localStorage
+
+    /// If logged in, returns the cached session object.
+    public var session: Session? {
+        get {
+            localStorage.session
+        }
+        set {
+            localStorage.session = newValue
+        }
+    }
+
+    /// An opaque token representing your session, which your servers can check with Stytch's servers to verify your session status.
+    public var sessionToken: SessionToken? {
+        sessionStorage.sessionToken
+    }
+
+    /// A session JWT (JSON Web Token), which your servers can check locally to verify your session status.
+    public var sessionJwt: SessionToken? {
+        sessionStorage.sessionJwt
+    }
+
+    /// A publisher which emits following a change in authentication status and returns either the opaque session token or nil. You can use this as an indicator to set up or tear down your UI accordingly.
+    public var onAuthChange: AnyPublisher<String?, Never> {
+        sessionStorage.onAuthChange.eraseToAnyPublisher()
+    }
+
+    // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
+    /// Wraps Stytch's [authenticate](https://stytch.com/docs/api/session-auth) Session endpoint and validates that the session issued to the user is still valid, returning both an opaque sessionToken and sessionJwt for this session. The sessionJwt will have a fixed lifetime of five minutes regardless of the underlying session duration, though it will be refreshed automatically in the background after a successful authentication.
+    public func authenticate(parameters: Sessions.AuthenticateParameters) async throws -> AuthenticateResponse {
+        try await router.post(to: .authenticate, parameters: parameters)
+    }
+
+    /// If your app has cookies disabled or simply receives updated session tokens from your backend via means other than
+    /// `Set-Cookie` headers, you must call this method after receiving the updated tokens to ensure the `StytchClient`
+    /// and persistent storage are kept up-to-date. You should include both the opaque token and the jwt.
+    public func update(sessionTokens tokens: [SessionToken]) {
+        tokens.forEach(sessionStorage.updatePersistentStorage)
+    }
+
+    // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
+    /// Wraps Stytch's [revoke](https://stytch.com/docs/api/session-revoke) Session endpoint and revokes the user's current session. This method should be used to log out a user. A successful revocation will terminate session-refresh polling.
+    public func revoke(parameters: Sessions.RevokeParameters = .init()) async throws -> BasicResponse {
+        do {
+            let response: BasicResponse = try await router.post(to: .revoke, parameters: EmptyCodable())
+            sessionStorage.reset()
+            return response
+        } catch {
+            if parameters.forceClear { sessionStorage.reset() }
+            throw error
+        }
+    }
 }

--- a/Sources/StytchCore/StytchClientCommon/Sessions/Sessions.swift
+++ b/Sources/StytchCore/StytchClientCommon/Sessions/Sessions.swift
@@ -1,68 +1,9 @@
-import Combine
-
-/// The SDK may be used to check whether a user has a cached session, view the current session, refresh the session, and revoke the session. To authenticate a session on your backend, you must use either the Stytch API or a Stytch server-side library. **NOTE**: - After a successful authentication, the session will be automatically refreshed in the background to ensure the sessionJwt remains valid (it expires after 5 minutes.) Session polling will be stopped after a session is revoked or after an unauthenticated error response is received.
-public struct Sessions<AuthResponseType: Decodable> {
-    let router: NetworkingRouter<SessionsRoute>
-
-    @Dependency(\.sessionStorage) private var sessionStorage
-
-    @Dependency(\.localStorage) private var localStorage
-
-    /// An opaque token representing your session, which your servers can check with Stytch's servers to verify your session status.
-    public var sessionToken: SessionToken? { sessionStorage.sessionToken }
-
-    /// A session JWT (JSON Web Token), which your servers can check locally to verify your session status.
-    public var sessionJwt: SessionToken? { sessionStorage.sessionJwt }
-
-    /// A publisher which emits following a change in authentication status and returns either the opaque session token or nil. You can use this as an indicator to set up or tear down your UI accordingly.
-    public var onAuthChange: AnyPublisher<String?, Never> { sessionStorage.onAuthChange.eraseToAnyPublisher() }
-
-    /// If your app has cookies disabled or simply receives updated session tokens from your backend via means other than
-    /// `Set-Cookie` headers, you must call this method after receiving the updated tokens to ensure the `StytchClient`
-    /// and persistent storage are kept up-to-date. You should include both the opaque token and the jwt.
-    public func update(sessionTokens tokens: [SessionToken]) {
-        tokens.forEach(sessionStorage.updatePersistentStorage)
-    }
-
-    // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
-    /// Wraps Stytch's [authenticate](https://stytch.com/docs/api/session-auth) Session endpoint and validates that the session issued to the user is still valid, returning both an opaque sessionToken and sessionJwt for this session. The sessionJwt will have a fixed lifetime of five minutes regardless of the underlying session duration, though it will be refreshed automatically in the background after a successful authentication.
-    public func authenticate(parameters: AuthenticateParameters) async throws -> AuthResponseType {
-        try await router.post(to: .authenticate, parameters: parameters)
-    }
-
-    // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
-    /// Wraps Stytch's [revoke](https://stytch.com/docs/api/session-revoke) Session endpoint and revokes the user's current session. This method should be used to log out a user. A successful revocation will terminate session-refresh polling.
-    public func revoke(parameters: RevokeParameters = .init()) async throws -> BasicResponse {
-        do {
-            let response: BasicResponse = try await router.post(to: .revoke, parameters: EmptyCodable())
-            sessionStorage.reset()
-            return response
-        } catch {
-            if parameters.forceClear { sessionStorage.reset() }
-            throw error
-        }
-    }
-}
-
-public extension Sessions where AuthResponseType == B2BAuthenticateResponse {
-    internal(set) var memberSession: MemberSession? {
-        get { localStorage.memberSession }
-        set { localStorage.memberSession = newValue }
-    }
-}
-
-public extension Sessions where AuthResponseType == AuthenticateResponse {
-    /// If logged in, returns the cached session object.
-    internal(set) var session: Session? {
-        get { localStorage.session }
-        set { localStorage.session = newValue }
-    }
-}
-
-public extension Sessions {
+public enum Sessions {
     /// The dedicated parameters type for sessions `authenticate` calls.
-    struct AuthenticateParameters: Encodable {
-        private enum CodingKeys: String, CodingKey { case sessionDuration = "sessionDurationMinutes" }
+    public struct AuthenticateParameters: Encodable {
+        private enum CodingKeys: String, CodingKey {
+            case sessionDuration = "sessionDurationMinutes"
+        }
 
         let sessionDuration: Minutes?
 
@@ -73,7 +14,7 @@ public extension Sessions {
     }
 
     /// The dedicated parameters type for session `revoke` calls.
-    struct RevokeParameters {
+    public struct RevokeParameters {
         let forceClear: Bool
 
         /// - Parameter forceClear: In the event of an error received from the network, setting this value to true will ensure the local session state is cleared.

--- a/Sources/StytchCore/StytchClientCommon/Sessions/SessionsRoute.swift
+++ b/Sources/StytchCore/StytchClientCommon/Sessions/SessionsRoute.swift
@@ -1,9 +1,0 @@
-enum SessionsRoute: String, RouteType {
-    case authenticate
-    case revoke
-    case exchange
-
-    var path: Path {
-        .init(rawValue: rawValue)
-    }
-}

--- a/StytchDemo/B2BWorkbench/AuthMethodControllers/SessionsViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthMethodControllers/SessionsViewController.swift
@@ -68,7 +68,7 @@ final class SessionsViewController: UIViewController {
         }
         Task {
             do {
-                let parameters = Sessions<B2BAuthenticateResponse>.ExchangeParameters(organizationID: organizationID)
+                let parameters = StytchB2BClientSessions.ExchangeParameters(organizationID: organizationID)
                 let response = try await StytchB2BClient.sessions.exchange(parameters: parameters)
                 UserDefaults.standard.set(organizationID, forKey: Constants.orgIdDefaultsKey)
                 orgIdTextField.text = ""

--- a/Tests/StytchCoreTests/B2BSessionsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSessionsTestCase.swift
@@ -4,7 +4,7 @@ import XCTest
 final class B2BSessionsTestCase: BaseTestCase {
     func testSessionsAuthenticate() async throws {
         networkInterceptor.responses { B2BAuthenticateResponse.mock }
-        let parameters: Sessions<B2BAuthenticateResponse>.AuthenticateParameters = .init(sessionDuration: 15)
+        let parameters: Sessions.AuthenticateParameters = .init(sessionDuration: 15)
 
         Current.timer = { _, _, _ in .init() }
 
@@ -68,7 +68,7 @@ final class B2BSessionsTestCase: BaseTestCase {
         Current.timer = { _, _, _ in .init() }
 
         let organizationID = "org_123"
-        let parameters = Sessions<B2BAuthenticateResponse>.ExchangeParameters(organizationID: organizationID)
+        let parameters = StytchB2BClientSessions.ExchangeParameters(organizationID: organizationID)
         _ = try await StytchB2BClient.sessions.exchange(parameters: parameters)
 
         try XCTAssertRequest(

--- a/Tests/StytchCoreTests/SessionsTestCase.swift
+++ b/Tests/StytchCoreTests/SessionsTestCase.swift
@@ -4,7 +4,7 @@ import XCTest
 final class SessionsTestCase: BaseTestCase {
     func testSessionsAuthenticate() async throws {
         networkInterceptor.responses { AuthenticateResponse.mock }
-        let parameters: Sessions<AuthenticateResponse>.AuthenticateParameters = .init(sessionDuration: 15)
+        let parameters: Sessions.AuthenticateParameters = .init(sessionDuration: 15)
 
         Current.timer = { _, _, _ in .init() }
 


### PR DESCRIPTION
Linear Ticket: [SDK-1733](https://linear.app/stytch/issue/SDK-1733/[ios][b2b]-create-separate-session-clients-for-b2b-and-b2c)

## Changes:

1. Remove the generics usage of the `Sessions` object and split into 2 separate objects. `StytchClientSessions` and `StytchB2BClientSessions`.
2. @jhaven-stytch and I had decided to do this after the [pr for adding the exchange method](https://github.com/stytchauth/stytch-ios/pull/233) to the b2b client and that he had already done this on Android. 
3. We felt that this was better so that the exchange method was not available for usage on the b2c client which it had been previously and that any additional changes that needed to be scoped for the session object on either b2c or b2b remained in their respective sandbox.
4. All functionality not needed to make public was able to be shared in the `SessionsBase` protocol.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A