### PR TITLE
Refresh session on app foregrounding

### DIFF
--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import UIKit
 
 /**
  The entrypoint for all Stytch B2B-related interaction.
@@ -18,6 +19,11 @@ public struct StytchB2BClient: StytchClientType {
 
     private init() {
         postInit()
+        NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: nil) { _ in
+          Task {
+            try await StytchB2BClient.sessions.authenticate(parameters: .init())
+          }
+        }
     }
 
     /**

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -1,7 +1,8 @@
 import Combine
 import Foundation
+#if os(iOS)
 import UIKit
-
+#endif
 /**
  The entrypoint for all Stytch B2B-related interaction.
 
@@ -19,11 +20,13 @@ public struct StytchB2BClient: StytchClientType {
 
     private init() {
         postInit()
+        #if os(iOS)
         NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: nil) { _ in
             Task {
                 try await Self.sessions.authenticate(parameters: .init())
             }
         }
+        #endif
     }
 
     /**

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -20,9 +20,9 @@ public struct StytchB2BClient: StytchClientType {
     private init() {
         postInit()
         NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: nil) { _ in
-          Task {
-            try await StytchB2BClient.sessions.authenticate(parameters: .init())
-          }
+            Task {
+                try await Self.sessions.authenticate(parameters: .init())
+            }
         }
     }
 

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -26,9 +26,9 @@ public struct StytchClient: StytchClientType {
     private init() {
         postInit()
         NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: nil) { _ in
-          Task {
-            try await StytchClient.sessions.authenticate(parameters: .init())
-          }
+            Task {
+                try await Self.sessions.authenticate(parameters: .init())
+            }
         }
     }
 

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import UIKit
 
 /**
  The entrypoint for all Stytch-related interaction.
@@ -24,6 +25,11 @@ public struct StytchClient: StytchClientType {
 
     private init() {
         postInit()
+        NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: nil) { _ in
+          Task {
+            try await StytchClient.sessions.authenticate(parameters: .init())
+          }
+        }
     }
 
     /**

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -1,6 +1,8 @@
 import Combine
 import Foundation
+#if os(iOS)
 import UIKit
+#endif
 
 /**
  The entrypoint for all Stytch-related interaction.
@@ -25,11 +27,13 @@ public struct StytchClient: StytchClientType {
 
     private init() {
         postInit()
+        #if os(iOS)
         NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: nil) { _ in
             Task {
                 try await Self.sessions.authenticate(parameters: .init())
             }
         }
+        #endif
     }
 
     /**


### PR DESCRIPTION
We check the validity of a persisted session on `StytchClient`/`StytchB2BClient` initialization (and on 3 minute interval while foregrounded), but it's possible for a session to expire/be revoked while the app is backgrounded, and an authentication call immediately following foregrounding would fail with an `Unauthorized credentials` error.

This adds an observer to force check a user's persisted session on app foregrounding to avoid this issue.