### PR TITLE
Member session polling client should use B2B sessions authenticate

### DIFF
--- a/Sources/StytchCore/PollingClient/PollingClient+Live.swift
+++ b/Sources/StytchCore/PollingClient/PollingClient+Live.swift
@@ -15,7 +15,7 @@ extension PollingClient {
 
     // A polling client which tries to complete every 3 minutes, and will retry w/ exponential backoff upon errors, for up to a total of approximately 124 seconds.
     static let memberSessions: PollingClient = .init(interval: 180, maxRetries: 5, queue: .sessionsPolling) { onSuccess, onFailure in
-        StytchClient.sessions.authenticate(parameters: .init()) { result in
+        StytchB2BClient.sessions.authenticate(parameters: .init()) { result in
             switch result {
             case .success:
                 onSuccess()


### PR DESCRIPTION
Noticed that the polling client for the member sessions "heartbeat" was using the wrong client