### PR TITLE
[SDK-1549] Create SearchManager and add search member and org functions

### DIFF
--- a/Sources/StytchCore/Generated/StytchB2BClient.SearchManager.searchMember+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.SearchManager.searchMember+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchB2BClient.SearchManager {
+    /// Search for a member of any organization by their email and organization id
+    func searchMember(searchMemberParameters: SearchMemberParameters, completion: @escaping Completion<SearchMemberResponse>) {
+        Task {
+            do {
+                completion(.success(try await searchMember(searchMemberParameters: searchMemberParameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Search for a member of any organization by their email and organization id
+    func searchMember(searchMemberParameters: SearchMemberParameters) -> AnyPublisher<SearchMemberResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await searchMember(searchMemberParameters: searchMemberParameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/Generated/StytchB2BClient.SearchManager.searchOrganization+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.SearchManager.searchOrganization+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchB2BClient.SearchManager {
+    /// Search for an organization by its slug
+    func searchOrganization(searchOrganizationParameters: SearchOrganizationParameters, completion: @escaping Completion<SearchOrganizationResponse>) {
+        Task {
+            do {
+                completion(.success(try await searchOrganization(searchOrganizationParameters: searchOrganizationParameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Search for an organization by its slug
+    func searchOrganization(searchOrganizationParameters: SearchOrganizationParameters) -> AnyPublisher<SearchOrganizationResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await searchOrganization(searchOrganizationParameters: searchOrganizationParameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+// swiftlint:disable identifier_name
+
+public extension StytchB2BClient {
+    enum SsoJitProvisioning: String, Codable {
+        case ALL_ALLOWED
+        case RESTRICTED
+        case NOT_ALLOWED
+    }
+
+    enum EmailJitProvisioning: String, Codable {
+        case RESTRICTED
+        case NOT_ALLOWED
+    }
+
+    enum EmailInvites: String, Codable {
+        case ALL_ALLOWED
+        case RESTRICTED
+        case NOT_ALLOWED
+    }
+
+    enum AuthMethods: String, Codable {
+        case ALL_ALLOWED
+        case RESTRICTED
+    }
+
+    enum AllowedAuthMethods: String, Codable {
+        case SSO = "sso"
+        case MAGIC_LINK = "magic_link"
+        case PASSWORD = "password"
+        case GOOGLE_OAUTH = "google_oauth"
+        case MICROSOFT_OAUTH = "microsoft_oauth"
+    }
+
+    enum MfaMethods: String, Codable {
+        case ALL_ALLOWED
+        case RESTRICTED
+    }
+
+    enum MfaMethod: String, Codable {
+        case SMS = "sms_otp"
+        case TOTP = "totp"
+    }
+
+    enum MfaPolicy: String, Codable {
+        case REQUIRED_FOR_ALL
+        case OPTIONAL
+    }
+
+    struct RBACEmailImplicitRoleAssignments: Codable {
+        let roleId: String
+        let domain: String
+
+        public init(roleId: String, domain: String) {
+            self.roleId = roleId
+            self.domain = domain
+        }
+    }
+
+    struct SSOActiveConnection: Codable {
+        let connectionId: String
+        let displayName: String
+
+        init(connectionId: String, displayName: String) {
+            self.connectionId = connectionId
+            self.displayName = displayName
+        }
+    }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/StytchB2BClient+Organizations+UpdateParameters.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/StytchB2BClient+Organizations+UpdateParameters.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-// swiftlint:disable identifier_name
-
 public extension StytchB2BClient.Organizations {
     /// The dedicated parameters type for the update organization call.
     struct UpdateParameters: Codable {
@@ -9,17 +7,17 @@ public extension StytchB2BClient.Organizations {
         let organizationSlug: String?
         let organizationLogoUrl: String?
         let ssoDefaultConnectionId: String?
-        let ssoJitProvisioning: SsoJitProvisioning?
+        let ssoJitProvisioning: StytchB2BClient.SsoJitProvisioning?
         let ssoJitProvisioningAllowedConnections: [String]?
         let emailAllowedDomains: [String]?
-        var emailJitProvisioning: EmailJitProvisioning?
-        var emailInvites: EmailInvites?
-        var authMethods: AuthMethods?
-        var allowedAuthMethods: [AllowedAuthMethods]?
-        var mfaMethods: MfaMethods?
-        var allowedMfaMethods: [MfaMethod]?
-        var mfaPolicy: MfaPolicy?
-        var rbacEmailImplicitRoleAssignments: [RBACEmailImplicitRoleAssignments]?
+        var emailJitProvisioning: StytchB2BClient.EmailJitProvisioning?
+        var emailInvites: StytchB2BClient.EmailInvites?
+        var authMethods: StytchB2BClient.AuthMethods?
+        var allowedAuthMethods: [StytchB2BClient.AllowedAuthMethods]?
+        var mfaMethods: StytchB2BClient.MfaMethods?
+        var allowedMfaMethods: [StytchB2BClient.MfaMethod]?
+        var mfaPolicy: StytchB2BClient.MfaPolicy?
+        var rbacEmailImplicitRoleAssignments: [StytchB2BClient.RBACEmailImplicitRoleAssignments]?
 
         /// The dedicated parameters type for the update organization call.
         /// - Parameters:
@@ -43,17 +41,17 @@ public extension StytchB2BClient.Organizations {
             organizationSlug: String? = nil,
             organizationLogoUrl: String? = nil,
             ssoDefaultConnectionId: String? = nil,
-            ssoJitProvisioning: StytchB2BClient.Organizations.SsoJitProvisioning? = nil,
+            ssoJitProvisioning: StytchB2BClient.SsoJitProvisioning? = nil,
             ssoJitProvisioningAllowedConnections: [String]? = nil,
             emailAllowedDomains: [String]? = nil,
-            emailJitProvisioning: StytchB2BClient.Organizations.EmailJitProvisioning? = nil,
-            emailInvites: StytchB2BClient.Organizations.EmailInvites? = nil,
-            authMethods: StytchB2BClient.Organizations.AuthMethods? = nil,
-            allowedAuthMethods: [StytchB2BClient.Organizations.AllowedAuthMethods]? = nil,
-            mfaMethods: StytchB2BClient.Organizations.MfaMethods? = nil,
-            allowedMfaMethods: [StytchB2BClient.Organizations.MfaMethod]? = nil,
-            mfaPolicy: StytchB2BClient.Organizations.MfaPolicy? = nil,
-            rbacEmailImplicitRoleAssignments: [RBACEmailImplicitRoleAssignments]? = nil
+            emailJitProvisioning: StytchB2BClient.EmailJitProvisioning? = nil,
+            emailInvites: StytchB2BClient.EmailInvites? = nil,
+            authMethods: StytchB2BClient.AuthMethods? = nil,
+            allowedAuthMethods: [StytchB2BClient.AllowedAuthMethods]? = nil,
+            mfaMethods: StytchB2BClient.MfaMethods? = nil,
+            allowedMfaMethods: [StytchB2BClient.MfaMethod]? = nil,
+            mfaPolicy: StytchB2BClient.MfaPolicy? = nil,
+            rbacEmailImplicitRoleAssignments: [StytchB2BClient.RBACEmailImplicitRoleAssignments]? = nil
         ) {
             self.organizationName = organizationName
             self.organizationSlug = organizationSlug
@@ -70,61 +68,6 @@ public extension StytchB2BClient.Organizations {
             self.allowedMfaMethods = allowedMfaMethods
             self.mfaPolicy = mfaPolicy
             self.rbacEmailImplicitRoleAssignments = rbacEmailImplicitRoleAssignments
-        }
-    }
-
-    enum SsoJitProvisioning: String, Codable {
-        case ALL_ALLOWED
-        case RESTRICTED
-        case NOT_ALLOWED
-    }
-
-    enum EmailJitProvisioning: String, Codable {
-        case RESTRICTED
-        case NOT_ALLOWED
-    }
-
-    enum EmailInvites: String, Codable {
-        case ALL_ALLOWED
-        case RESTRICTED
-        case NOT_ALLOWED
-    }
-
-    enum AuthMethods: String, Codable {
-        case ALL_ALLOWED
-        case RESTRICTED
-    }
-
-    enum AllowedAuthMethods: String, Codable {
-        case SSO = "sso"
-        case MAGIC_LINK = "magic_link"
-        case PASSWORD = "password"
-        case GOOGLE_OAUTH = "google_oauth"
-        case MICROSOFT_OAUTH = "microsoft_oauth"
-    }
-
-    enum MfaMethods: String, Codable {
-        case ALL_ALLOWED
-        case RESTRICTED
-    }
-
-    enum MfaMethod: String, Codable {
-        case SMS = "sms_otp"
-        case TOTP = "totp"
-    }
-
-    enum MfaPolicy: String, Codable {
-        case REQUIRED_FOR_ALL
-        case OPTIONAL
-    }
-
-    struct RBACEmailImplicitRoleAssignments: Codable {
-        var roleId: String
-        var domain: String
-
-        public init(roleId: String, domain: String) {
-            self.roleId = roleId
-            self.domain = domain
         }
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
@@ -8,6 +8,7 @@ extension StytchB2BClient {
         case sso(SSORoute)
         case events(EventsRoute)
         case bootstrap(BootstrapRoute)
+        case searchManager(SearchManagerRoute)
 
         var path: Path {
             let (base, next) = routeComponents
@@ -31,6 +32,8 @@ extension StytchB2BClient {
             case let .bootstrap(route):
                 return ("", route)
             case let .events(route):
+                return ("", route)
+            case let .searchManager(route):
                 return ("", route)
             }
         }
@@ -247,6 +250,20 @@ extension StytchB2BClient {
             switch self {
             case let .fetch(publicToken):
                 return "projects/bootstrap".appendingPath(publicToken)
+            }
+        }
+    }
+
+    enum SearchManagerRoute: RouteType {
+        case searchMember
+        case searchOrganization
+
+        var path: Path {
+            switch self {
+            case .searchMember:
+                return "organizations/members/search"
+            case .searchOrganization:
+                return "organizations/search"
             }
         }
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO+OIDC.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO+OIDC.swift
@@ -2,7 +2,7 @@ import Foundation
 
 #if !os(watchOS)
 public extension StytchB2BClient.SSO {
-    /// The interface for XYZ
+    /// The interface for interacting with OIDC SSO.
     var oidc: OIDC {
         .init(router: router.scopedRouter { $0.oidc })
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO+SAML.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO+SAML.swift
@@ -2,7 +2,7 @@ import Foundation
 
 #if !os(watchOS)
 public extension StytchB2BClient.SSO {
-    /// The interface for XYZ
+    /// The interface for interacting with SAML SSO.
     var saml: SAML {
         .init(router: router.scopedRouter { $0.saml })
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SearchManager.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SearchManager.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+public extension StytchB2BClient {
+    /// The interface for interacting with the search manager
+    static var searchManager: SearchManager {
+        .init(router: router.scopedRouter {
+            $0.searchManager
+        })
+    }
+}
+
+public extension StytchB2BClient {
+    struct SearchManager {
+        let router: NetworkingRouter<SearchManagerRoute>
+
+        // sourcery: AsyncVariants
+        /// Search for a member of any organization by their email and organization id
+        public func searchMember(searchMemberParameters: SearchMemberParameters) async throws -> SearchMemberResponse {
+            try await router.post(to: .searchMember, parameters: searchMemberParameters)
+        }
+
+        // sourcery: AsyncVariants
+        /// Search for an organization by its slug
+        public func searchOrganization(searchOrganizationParameters: SearchOrganizationParameters) async throws -> SearchOrganizationResponse {
+            try await router.post(to: .searchOrganization, parameters: searchOrganizationParameters)
+        }
+    }
+}
+
+public extension StytchB2BClient.SearchManager {
+    struct SearchMemberParameters: Codable {
+        public let emailAddress: String
+        public let organizationId: String
+
+        public init(emailAddress: String, organizationId: String) {
+            self.emailAddress = emailAddress
+            self.organizationId = organizationId
+        }
+    }
+}
+
+public extension StytchB2BClient.SearchManager {
+    typealias SearchMemberResponse = Response<SearchMemberResponseData>
+
+    struct SearchMemberResponseData: Codable {
+        public let member: MemberSearchResponse
+    }
+
+    struct MemberSearchResponse: Codable {
+        public let status: String
+        public let name: String
+        public let memberPasswordId: String
+    }
+}
+
+public extension StytchB2BClient.SearchManager {
+    struct SearchOrganizationParameters: Codable {
+        public let organizationSlug: String
+
+        public init(organizationSlug: String) {
+            self.organizationSlug = organizationSlug
+        }
+    }
+}
+
+public extension StytchB2BClient.SearchManager {
+    typealias SearchOrganizationResponse = Response<SearchOrganizationResponseData>
+
+    struct SearchOrganizationResponseData: Codable {
+        public let organization: OrganizationSearchResponse
+    }
+
+    struct OrganizationSearchResponse: Codable {
+        public let organizationId: String
+        public let organizationName: String
+        public let organizationLogoUrl: String?
+        public let ssoActiveConnections: [StytchB2BClient.SSOActiveConnection]?
+        public let ssoDefaultConnectionId: String?
+        public let emailAllowedDomains: [String]?
+        public let emailJitProvisioning: StytchB2BClient.EmailJitProvisioning?
+        public let emailInvites: StytchB2BClient.EmailInvites?
+        public let authMethods: StytchB2BClient.AuthMethods?
+        public let allowedAuthMethods: [StytchB2BClient.AllowedAuthMethods]?
+    }
+}

--- a/StytchDemo/B2BWorkbench/AuthHomeViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthHomeViewController.swift
@@ -3,6 +3,10 @@ import UIKit
 final class AuthHomeViewController: UIViewController {
     let stackView = UIStackView.stytchB2BStackView()
 
+    lazy var orgIdTextField: UITextField = .init(title: "Organization ID", primaryAction: .init { [weak self] _ in
+        self?.saveOrgID()
+    })
+
     lazy var emlButton: UIButton = .init(title: "Email Magic Links", primaryAction: .init { [weak self] _ in
         self?.navigationController?.pushViewController(MagicLinksViewController(), animated: true)
     })
@@ -31,6 +35,14 @@ final class AuthHomeViewController: UIViewController {
         self?.navigationController?.pushViewController(OrganizationViewController(), animated: true)
     })
 
+    lazy var searchManagerButton: UIButton = .init(title: "Search Manager", primaryAction: .init { [weak self] _ in
+        self?.navigationController?.pushViewController(SearchManagerViewController(), animated: true)
+    })
+
+    func saveOrgID() {
+        UserDefaults.standard.set(orgIdTextField.text, forKey: Constants.orgIdDefaultsKey)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -46,6 +58,7 @@ final class AuthHomeViewController: UIViewController {
             stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
         ])
 
+        stackView.addArrangedSubview(orgIdTextField)
         stackView.addArrangedSubview(emlButton)
         stackView.addArrangedSubview(passwordsButton)
         stackView.addArrangedSubview(discoveryButton)
@@ -53,5 +66,23 @@ final class AuthHomeViewController: UIViewController {
         stackView.addArrangedSubview(sessionsButton)
         stackView.addArrangedSubview(memberButton)
         stackView.addArrangedSubview(organizationButton)
+        stackView.addArrangedSubview(searchManagerButton)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        orgIdTextField.text = organizationId
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        saveOrgID()
+    }
+}
+
+extension AuthHomeViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
     }
 }

--- a/StytchDemo/B2BWorkbench/AuthMethodControllers/DiscoveryViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthMethodControllers/DiscoveryViewController.swift
@@ -6,8 +6,6 @@ final class DiscoveryViewController: UIViewController {
 
     lazy var intermediateSessionTextField: UITextField = .init(title: "Intermediate Session Token", primaryAction: submitAction)
 
-    lazy var orgIdTextField: UITextField = .init(title: "Org Id", primaryAction: submitAction)
-
     lazy var orgNameTextField: UITextField = .init(title: "Org Name", primaryAction: submitAction)
 
     lazy var discoverButton: UIButton = .init(title: "Discover", primaryAction: submitAction)
@@ -38,14 +36,12 @@ final class DiscoveryViewController: UIViewController {
         ])
 
         stackView.addArrangedSubview(intermediateSessionTextField)
-        stackView.addArrangedSubview(orgIdTextField)
         stackView.addArrangedSubview(orgNameTextField)
         stackView.addArrangedSubview(discoverButton)
         stackView.addArrangedSubview(exchangeSessionButton)
         stackView.addArrangedSubview(createOrgButton)
 
         intermediateSessionTextField.delegate = self
-        orgIdTextField.delegate = self
         orgNameTextField.delegate = self
     }
 
@@ -66,7 +62,7 @@ final class DiscoveryViewController: UIViewController {
 
     func exchangeSession() {
         guard let token = intermediateSessionTextField.text, !token.isEmpty else { return }
-        guard let orgId = orgIdTextField.text, !orgId.isEmpty else { return }
+        guard let orgId = organizationId else { return }
 
         Task {
             do {

--- a/StytchDemo/B2BWorkbench/AuthMethodControllers/MagicLinksViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthMethodControllers/MagicLinksViewController.swift
@@ -6,8 +6,6 @@ final class MagicLinksViewController: UIViewController {
 
     lazy var emailTextField: UITextField = .init(title: "Email", primaryAction: submitAction, keyboardType: .emailAddress)
 
-    lazy var orgIdTextField: UITextField = .init(title: "Organization ID", primaryAction: submitAction)
-
     lazy var redirectUrlTextField: UITextField = .init(title: "Redirect URL", primaryAction: submitAction, keyboardType: .URL)
 
     lazy var sendButton: UIButton = .init(title: "Submit", primaryAction: submitAction)
@@ -38,28 +36,24 @@ final class MagicLinksViewController: UIViewController {
         ])
 
         stackView.addArrangedSubview(emailTextField)
-        stackView.addArrangedSubview(orgIdTextField)
         stackView.addArrangedSubview(redirectUrlTextField)
         stackView.addArrangedSubview(sendButton)
         stackView.addArrangedSubview(discoverySendButton)
         stackView.addArrangedSubview(inviteSendButton)
 
         emailTextField.text = UserDefaults.standard.string(forKey: Constants.emailDefaultsKey)
-        orgIdTextField.text = UserDefaults.standard.string(forKey: Constants.orgIdDefaultsKey)
         redirectUrlTextField.text = UserDefaults.standard.string(forKey: Constants.redirectUrlDefaultsKey) ?? "b2bworkbench://auth"
 
         emailTextField.delegate = self
-        orgIdTextField.delegate = self
         redirectUrlTextField.delegate = self
     }
 
     func submit() {
         guard let email = emailTextField.text, !email.isEmpty else { return }
-        guard let orgId = orgIdTextField.text, !orgId.isEmpty else { return }
         guard let redirectUrl = redirectUrlTextField.text.map(URL.init(string:)) else { return }
+        guard let orgId = organizationId else { return }
 
         UserDefaults.standard.set(email, forKey: Constants.emailDefaultsKey)
-        UserDefaults.standard.set(orgId, forKey: Constants.orgIdDefaultsKey)
         UserDefaults.standard.set(redirectUrl?.absoluteURL, forKey: Constants.redirectUrlDefaultsKey)
 
         Task {
@@ -81,11 +75,10 @@ final class MagicLinksViewController: UIViewController {
 
     func submitDiscovery() {
         guard let email = emailTextField.text, !email.isEmpty else { return }
-        guard let orgId = orgIdTextField.text, !orgId.isEmpty else { return }
         guard let redirectUrl = redirectUrlTextField.text.map(URL.init(string:)) else { return }
+        guard let orgId = organizationId else { return }
 
         UserDefaults.standard.set(email, forKey: Constants.emailDefaultsKey)
-        UserDefaults.standard.set(orgId, forKey: Constants.orgIdDefaultsKey)
         UserDefaults.standard.set(redirectUrl?.absoluteURL, forKey: Constants.redirectUrlDefaultsKey)
 
         Task {
@@ -105,11 +98,10 @@ final class MagicLinksViewController: UIViewController {
 
     func submitInvite() {
         guard let email = emailTextField.text, !email.isEmpty else { return }
-        guard let orgId = orgIdTextField.text, !orgId.isEmpty else { return }
         guard let redirectUrl = redirectUrlTextField.text.map(URL.init(string:)) else { return }
+        guard let orgId = organizationId else { return }
 
         UserDefaults.standard.set(email, forKey: Constants.emailDefaultsKey)
-        UserDefaults.standard.set(orgId, forKey: Constants.orgIdDefaultsKey)
         UserDefaults.standard.set(redirectUrl?.absoluteURL, forKey: Constants.redirectUrlDefaultsKey)
 
         Task {

--- a/StytchDemo/B2BWorkbench/AuthMethodControllers/OrganizationViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthMethodControllers/OrganizationViewController.swift
@@ -26,8 +26,8 @@ final class OrganizationViewController: UIViewController {
         self?.navigationController?.pushViewController(OrganizationMemberViewController(), animated: true)
     })
 
-    lazy var searchButton: UIButton = .init(title: "Search Members", primaryAction: .init { [weak self] _ in
-        self?.search()
+    lazy var searchMembersButton: UIButton = .init(title: "Search Members", primaryAction: .init { [weak self] _ in
+        self?.searchMembers()
     })
 
     override func viewDidLoad() {
@@ -50,7 +50,7 @@ final class OrganizationViewController: UIViewController {
         stackView.addArrangedSubview(deleteButton)
         stackView.addArrangedSubview(updateButton)
         stackView.addArrangedSubview(membersButton)
-        stackView.addArrangedSubview(searchButton)
+        stackView.addArrangedSubview(searchMembersButton)
 
         setUpOrganizationChangeListener()
     }
@@ -123,7 +123,7 @@ final class OrganizationViewController: UIViewController {
         }
     }
 
-    func search() {
+    func searchMembers() {
         Task {
             do {
                 var operands = [any SearchQueryOperand]()

--- a/StytchDemo/B2BWorkbench/AuthMethodControllers/PasswordsViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthMethodControllers/PasswordsViewController.swift
@@ -6,8 +6,6 @@ final class PasswordsViewController: UIViewController {
 
     lazy var emailTextField: UITextField = .init(title: "Email", primaryAction: submitAction, keyboardType: .emailAddress)
 
-    lazy var orgIdTextField: UITextField = .init(title: "Organization ID", primaryAction: submitAction)
-
     lazy var redirectUrlTextField: UITextField = .init(title: "Redirect URL", primaryAction: submitAction, keyboardType: .URL)
 
     lazy var passwordTextField: UITextField = .init(title: "Password", primaryAction: submitAction, password: true)
@@ -57,7 +55,6 @@ final class PasswordsViewController: UIViewController {
         toggleStackView.spacing = 8
 
         stackView.addArrangedSubview(emailTextField)
-        stackView.addArrangedSubview(orgIdTextField)
         stackView.addArrangedSubview(redirectUrlTextField)
         stackView.addArrangedSubview(passwordTextField)
         stackView.addArrangedSubview(toggleStackView)
@@ -67,7 +64,6 @@ final class PasswordsViewController: UIViewController {
         stackView.addArrangedSubview(resetBySessionButton)
 
         emailTextField.text = UserDefaults.standard.string(forKey: Constants.emailDefaultsKey)
-        orgIdTextField.text = UserDefaults.standard.string(forKey: Constants.orgIdDefaultsKey)
         redirectUrlTextField.text = UserDefaults.standard.string(forKey: Constants.redirectUrlDefaultsKey) ?? "b2bworkbench://auth"
 
         if StytchB2BClient.sessions.memberSession == nil {
@@ -75,7 +71,6 @@ final class PasswordsViewController: UIViewController {
         }
 
         emailTextField.delegate = self
-        orgIdTextField.delegate = self
         redirectUrlTextField.delegate = self
         passwordTextField.delegate = self
     }
@@ -223,7 +218,10 @@ final class PasswordsViewController: UIViewController {
     }
 
     func checkAndStoreTextFieldValues() -> (orgId: Organization.ID, password: String, email: String, redirectUrl: URL?)? {
-        guard let orgId = orgIdTextField.text, !orgId.isEmpty else { return nil }
+        var orgizationID = ""
+        if let orgID = organizationId {
+            orgizationID = orgID
+        }
 
         let redirectUrl = redirectUrlTextField.text.flatMap(URL.init(string:))
 
@@ -234,13 +232,8 @@ final class PasswordsViewController: UIViewController {
         if let email = emailTextField.text, !email.isEmpty {
             UserDefaults.standard.set(email, forKey: Constants.emailDefaultsKey)
         }
-        if let orgId = orgIdTextField.text, !orgId.isEmpty {
-            UserDefaults.standard.set(orgId, forKey: Constants.orgIdDefaultsKey)
-        }
 
-        UserDefaults.standard.set(orgId, forKey: Constants.orgIdDefaultsKey)
-
-        return (.init(rawValue: orgId), passwordTextField.text ?? "", emailTextField.text ?? "", redirectUrl)
+        return (.init(rawValue: orgizationID), passwordTextField.text ?? "", emailTextField.text ?? "", redirectUrl)
     }
 }
 

--- a/StytchDemo/B2BWorkbench/AuthMethodControllers/SearchManagerViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthMethodControllers/SearchManagerViewController.swift
@@ -1,0 +1,66 @@
+import Combine
+import StytchCore
+import UIKit
+
+final class SearchManagerViewController: UIViewController {
+    let stackView = UIStackView.stytchB2BStackView()
+
+    lazy var searchMemberButton: UIButton = .init(title: "Search Member", primaryAction: .init { [weak self] _ in
+        self?.searchMember()
+    })
+
+    lazy var searchOrganizationButton: UIButton = .init(title: "Search Organization", primaryAction: .init { [weak self] _ in
+        self?.searchOrganization()
+    })
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Search Manager"
+        view.backgroundColor = .systemBackground
+
+        view.addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+
+        stackView.addArrangedSubview(searchMemberButton)
+        stackView.addArrangedSubview(searchOrganizationButton)
+    }
+
+    func searchMember() {
+        Task {
+            do {
+                guard let organizationId = self.organizationId else {
+                    return
+                }
+                guard let emailAddress = try await presentTextFieldAlertWithTitle(alertTitle: "Enter Email Address") else {
+                    throw TextFieldAlertError.emptyString
+                }
+                let parameters = StytchB2BClient.SearchManager.SearchMemberParameters(emailAddress: emailAddress, organizationId: organizationId)
+                let response = try await StytchB2BClient.searchManager.searchMember(searchMemberParameters: parameters)
+                presentAlertAndLogMessage(description: "search member success!", object: response)
+            } catch {
+                presentAlertAndLogMessage(description: "search member error", object: error)
+            }
+        }
+    }
+
+    func searchOrganization() {
+        Task {
+            do {
+                guard let organizationSlug = try await presentTextFieldAlertWithTitle(alertTitle: "Enter Organization Slug") else {
+                    throw TextFieldAlertError.emptyString
+                }
+
+                let parameters = StytchB2BClient.SearchManager.SearchOrganizationParameters(organizationSlug: organizationSlug)
+                let response = try await StytchB2BClient.searchManager.searchOrganization(searchOrganizationParameters: parameters)
+                presentAlertAndLogMessage(description: "search organizations success!", object: response)
+            } catch {
+                presentAlertAndLogMessage(description: "search organizations error", object: error)
+            }
+        }
+    }
+}

--- a/StytchDemo/B2BWorkbench/Extensions.swift
+++ b/StytchDemo/B2BWorkbench/Extensions.swift
@@ -7,6 +7,10 @@ enum TextFieldAlertError: Error {
 }
 
 extension UIViewController {
+    var organizationId: String? {
+        UserDefaults.standard.string(forKey: Constants.orgIdDefaultsKey)
+    }
+
     func presentAlertWithTitle(
         alertTitle: String,
         buttonTitle: String = "OK",

--- a/StytchDemo/StytchDemo.xcodeproj/project.pbxproj
+++ b/StytchDemo/StytchDemo.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		53E1282C2B50092F00976CAC /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 53E1282B2B50092F00976CAC /* Preview Assets.xcassets */; };
 		53E128402B50092F00976CAC /* StytchUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E1283F2B50092F00976CAC /* StytchUITests.swift */; };
 		53E128422B50092F00976CAC /* StytchUILaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E128412B50092F00976CAC /* StytchUILaunchTests.swift */; };
+		74234D4C2C21E1240001DA69 /* SearchManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74234D4B2C21E1240001DA69 /* SearchManagerViewController.swift */; };
 		7478F7D92BF595CD00BCB233 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7478F7D82BF595CD00BCB233 /* Launch Screen.storyboard */; };
 		7478F7DC2BF6467900BCB233 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7478F7DA2BF6467900BCB233 /* Extensions.swift */; };
 		749F88862BFBD63E00D7F386 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 749F88852BFBD63E00D7F386 /* Launch Screen.storyboard */; };
@@ -174,6 +175,7 @@
 		53E1283F2B50092F00976CAC /* StytchUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StytchUITests.swift; sourceTree = "<group>"; };
 		53E128412B50092F00976CAC /* StytchUILaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StytchUILaunchTests.swift; sourceTree = "<group>"; };
 		53E1284C2B500C7400976CAC /* StytchUIDemo.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = StytchUIDemo.xctestplan; sourceTree = "<group>"; };
+		74234D4B2C21E1240001DA69 /* SearchManagerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchManagerViewController.swift; sourceTree = "<group>"; };
 		7478F7D82BF595CD00BCB233 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		7478F7DA2BF6467900BCB233 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		749F88852BFBD63E00D7F386 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
@@ -325,6 +327,7 @@
 				74F370292C07B7F400AED9C9 /* OrganizationMemberViewController.swift */,
 				22ABFAB829F7628E00927518 /* DiscoveryViewController.swift */,
 				22ABFABA29F7690100927518 /* SSOViewController.swift */,
+				74234D4B2C21E1240001DA69 /* SearchManagerViewController.swift */,
 			);
 			path = AuthMethodControllers;
 			sourceTree = "<group>";
@@ -692,6 +695,7 @@
 				224E6F2529E8CAEB0031D37A /* PasswordsViewController.swift in Sources */,
 				2254779429A05C6A003DF229 /* MagicLinksViewController.swift in Sources */,
 				2254779229A05C3E003DF229 /* AuthHomeViewController.swift in Sources */,
+				74234D4C2C21E1240001DA69 /* SearchManagerViewController.swift in Sources */,
 				74F3702A2C07B7F400AED9C9 /* OrganizationMemberViewController.swift in Sources */,
 				2231531B299EE16D00BA9126 /* AppDelegate.swift in Sources */,
 				7478F7DC2BF6467900BCB233 /* Extensions.swift in Sources */,

--- a/Tests/StytchCoreTests/B2BSearchManagerTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSearchManagerTestCase.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import StytchCore
+
+final class B2BSearchManagerTestCase: BaseTestCase {
+    func testSearchMember() async throws {
+        networkInterceptor.responses {
+            StytchB2BClient.SearchManager.SearchMemberResponse(
+                requestId: "1234",
+                statusCode: 200,
+                wrapped: .mock
+            )
+        }
+
+        let emailAddress = "johndoe@foo.com"
+        let organizationId = "abcd1234"
+        let parameters = StytchB2BClient.SearchManager.SearchMemberParameters(emailAddress: emailAddress, organizationId: organizationId)
+        _ = try await StytchB2BClient.searchManager.searchMember(searchMemberParameters: parameters)
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/b2b/organizations/members/search",
+            method: .post([
+                "email_address": StytchCore.JSON.string(emailAddress),
+                "organization_id": StytchCore.JSON.string(organizationId),
+            ])
+        )
+    }
+
+    func testSearchOrganizations() async throws {
+        networkInterceptor.responses {
+            StytchB2BClient.SearchManager.SearchOrganizationResponse(
+                requestId: "1234",
+                statusCode: 200,
+                wrapped: .mock
+            )
+        }
+
+        let organizationSlug = "1234"
+        let parameters = StytchB2BClient.SearchManager.SearchOrganizationParameters(organizationSlug: organizationSlug)
+        _ = try await StytchB2BClient.searchManager.searchOrganization(searchOrganizationParameters: parameters)
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/b2b/organizations/search",
+            method: .post([
+                "organization_slug": StytchCore.JSON.string(organizationSlug),
+            ])
+        )
+    }
+}
+
+extension StytchB2BClient.SearchManager.SearchMemberResponseData {
+    static let mock: Self = .init(member: .mock)
+}
+
+extension StytchB2BClient.SearchManager.MemberSearchResponse {
+    static let mock: Self = .init(status: "", name: "", memberPasswordId: "")
+}
+
+extension StytchB2BClient.SearchManager.SearchOrganizationResponseData {
+    static let mock: Self = .init(organization: .mock)
+}
+
+extension StytchB2BClient.SearchManager.OrganizationSearchResponse {
+    static let mock: Self = .init(
+        organizationId: "1234",
+        organizationName: "org foo",
+        organizationLogoUrl: nil,
+        ssoActiveConnections: nil,
+        ssoDefaultConnectionId: nil,
+        emailAllowedDomains: nil,
+        emailJitProvisioning: nil,
+        emailInvites: nil,
+        authMethods: nil,
+        allowedAuthMethods: nil
+    )
+}


### PR DESCRIPTION
Linear Ticket: [SDK-1549](https://linear.app/stytch/issue/SDK-1549/[ios]-[b2b]-add-searchorganizationsearchmember-functionality)

## Changes:

1.  Create `StytchB2BClient.SearchManager`.
2.  Add `searchMember` that allows the search for a member of any organization by their email and organization id.
3. Add `searchOrganization` that allows the search for an organization by its slug.
4. In the b2b sample app move the organization id text field to the root screen instead of in each view controller. 
5. Moved some organization code into a common file `StytchB2BClient+Common.swift`

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A