### PR TITLE
[SDK-1479] Add StytchB2BClient+TOTP

### DIFF
--- a/Sources/StytchCore/Generated/StytchB2BClient.TOTP.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.TOTP.authenticate+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchB2BClient.TOTP {
+    /// Authenticate a TOTP for a member
+    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
+        Task {
+            do {
+                completion(.success(try await authenticate(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Authenticate a TOTP for a member
+    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<B2BAuthenticateResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await authenticate(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/Generated/StytchB2BClient.TOTP.create+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.TOTP.create+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchB2BClient.TOTP {
+    /// Create a TOTP for a member
+    func create(parameters: CreateParameters, completion: @escaping Completion<CreateResponse>) {
+        Task {
+            do {
+                completion(.success(try await create(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Create a TOTP for a member
+    func create(parameters: CreateParameters) -> AnyPublisher<CreateResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await create(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
@@ -9,6 +9,7 @@ extension StytchB2BClient {
         case events(EventsRoute)
         case bootstrap(BootstrapRoute)
         case searchManager(SearchManagerRoute)
+        case totp(TOTPRoute)
 
         var path: Path {
             let (base, next) = routeComponents
@@ -35,6 +36,8 @@ extension StytchB2BClient {
                 return ("", route)
             case let .searchManager(route):
                 return ("", route)
+            case let .totp(route):
+                return ("totp", route)
             }
         }
     }
@@ -264,6 +267,20 @@ extension StytchB2BClient {
                 return "organizations/members/search"
             case .searchOrganization:
                 return "organizations/search"
+            }
+        }
+    }
+
+    enum TOTPRoute: RouteType {
+        case create
+        case authenticate
+
+        var path: Path {
+            switch self {
+            case .create:
+                return ""
+            case .authenticate:
+                return "authenticate"
             }
         }
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+TOTP.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+TOTP.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+public extension StytchB2BClient {
+    /// The interface for interacting with totp products.
+    static var totp: TOTP {
+        .init(router: router.scopedRouter {
+            $0.totp
+        })
+    }
+}
+
+public extension StytchB2BClient {
+    struct TOTP {
+        let router: NetworkingRouter<StytchB2BClient.TOTPRoute>
+
+        // sourcery: AsyncVariants
+        /// Create a TOTP for a member
+        public func create(parameters: CreateParameters) async throws -> CreateResponse {
+            try await router.post(to: .create, parameters: parameters)
+        }
+
+        // sourcery: AsyncVariants
+        /// Authenticate a TOTP for a member
+        public func authenticate(parameters: AuthenticateParameters) async throws -> B2BAuthenticateResponse {
+            try await router.post(to: .authenticate, parameters: parameters)
+        }
+    }
+}
+
+public extension StytchB2BClient.TOTP {
+    struct CreateParameters: Codable {
+        let organizationId: String
+        let memberId: String
+        let expirationMinutes: Minutes
+
+        /// - Parameters:
+        ///   - organizationId: The ID of the organization the member belongs to
+        ///   - memberId: The ID of the member creating a TOTP
+        ///   - expirationMinutes: The expiration for the TOTP instance.
+        ///   If the newly created TOTP is not authenticated within this time frame the TOTP will be unusable.
+        ///   Defaults to 60 (1 hour) with a minimum of 5 and a maximum of 1440.
+        public init(organizationId: String, memberId: String, expirationMinutes: Minutes) {
+            self.organizationId = organizationId
+            self.memberId = memberId
+            self.expirationMinutes = expirationMinutes
+        }
+    }
+}
+
+public extension StytchB2BClient.TOTP {
+    typealias CreateResponse = Response<CreateResponseData>
+
+    struct CreateResponseData: Codable {
+        /// Globally unique UUID that identifies a specific TOTP registration in the Stytch API.
+        public let totpRegistrationId: String
+
+        /// The TOTP secret key shared between the authenticator app and the server used to generate TOTP codes.
+        public let secret: String
+
+        /// The QR code image encoded in base64.
+        public let qrCode: String
+
+        /// The recovery codes used to authenticate the member without an authenticator app.
+        public let recoveryCodes: [String]
+    }
+}
+
+public extension StytchB2BClient.TOTP {
+    struct AuthenticateParameters: Codable {
+        let sessionDurationMinutes: Minutes
+        let organizationId: String
+        let memberId: String
+        let code: String
+        let setMfaEnrollment: MFAEnrollment?
+        let setDefaultMfa: Bool?
+
+        /// - Parameters:
+        ///   - sessionDurationMinutes: Set the session lifetime to be this many minutes from now.
+        ///     This will return both an opaque `session_token` and `session_jwt` for this session, which will automatically be stored in the browser cookies.
+        ///     The `session_jwt` will have a fixed lifetime of five minutes regardless of the underlying session duration, and will be automatically refreshed by the SDK in the background over time.
+        ///     This value must be a minimum of 5 and may not exceed the maximum session duration minutes value set in the https://stytch.com/dashboard/sdk-configuration SDK Configuration page of the Stytch dashboard.
+        ///   - organizationId: The ID of the organization the member belongs to
+        ///   - memberId: The ID of the member to authenticate
+        ///   - code: The TOTP code to authenticate
+        ///   - setMfaEnrollment: If set to 'enroll', enrolls the member in MFA by setting the "mfa_enrolled" boolean to true.
+        ///     If set to 'unenroll', unenrolls the member in MFA by setting the "mfa_enrolled" boolean to false.
+        ///     If not set, does not affect the member's MFA enrollment.
+        ///   - setDefaultMfa: If set to true, sets TOTP as the member's default MFA method.
+        public init(
+            sessionDurationMinutes: Minutes,
+            organizationId: String,
+            memberId: String,
+            code: String,
+            setMfaEnrollment: MFAEnrollment? = nil,
+            setDefaultMfa: Bool? = nil
+        ) {
+            self.sessionDurationMinutes = sessionDurationMinutes
+            self.organizationId = organizationId
+            self.memberId = memberId
+            self.code = code
+            self.setMfaEnrollment = setMfaEnrollment
+            self.setDefaultMfa = setDefaultMfa
+        }
+    }
+}
+
+public extension StytchB2BClient.TOTP {
+    enum MFAEnrollment: String, Codable {
+        case enroll
+        case unenroll
+    }
+}

--- a/StytchDemo/B2BWorkbench/AuthHomeViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthHomeViewController.swift
@@ -39,6 +39,10 @@ final class AuthHomeViewController: UIViewController {
         self?.navigationController?.pushViewController(SearchManagerViewController(), animated: true)
     })
 
+    lazy var totpButton: UIButton = .init(title: "TOTP", primaryAction: .init { [weak self] _ in
+        self?.navigationController?.pushViewController(TOTPViewController(), animated: true)
+    })
+
     func saveOrgID() {
         UserDefaults.standard.set(orgIdTextField.text, forKey: Constants.orgIdDefaultsKey)
     }
@@ -67,6 +71,7 @@ final class AuthHomeViewController: UIViewController {
         stackView.addArrangedSubview(memberButton)
         stackView.addArrangedSubview(organizationButton)
         stackView.addArrangedSubview(searchManagerButton)
+        stackView.addArrangedSubview(totpButton)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/StytchDemo/B2BWorkbench/AuthMethodControllers/OrganizationMemberViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthMethodControllers/OrganizationMemberViewController.swift
@@ -34,10 +34,6 @@ class OrganizationMemberViewController: UIViewController {
         self?.deleteFactorPassword()
     })
 
-    var memberId: String? {
-        memberIdTextField.text
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Organization Member"
@@ -124,7 +120,7 @@ class OrganizationMemberViewController: UIViewController {
     }
 
     func reactivate() {
-        guard let memberId = memberId else {
+        guard let memberId = memberIdTextField.text else {
             presentAlertWithTitle(alertTitle: "Fill out member id text field")
             return
         }
@@ -140,7 +136,7 @@ class OrganizationMemberViewController: UIViewController {
     }
 
     func delete() {
-        guard let memberId = memberId else {
+        guard let memberId = memberIdTextField.text else {
             presentAlertWithTitle(alertTitle: "Fill out member id text field")
             return
         }
@@ -156,7 +152,7 @@ class OrganizationMemberViewController: UIViewController {
     }
 
     func deleteFactorTotp() {
-        guard let memberId = memberId else {
+        guard let memberId = memberIdTextField.text else {
             presentAlertWithTitle(alertTitle: "Fill out member id text field")
             return
         }
@@ -172,7 +168,7 @@ class OrganizationMemberViewController: UIViewController {
     }
 
     func deleteFactorPhoneNumber() {
-        guard let memberId = memberId else {
+        guard let memberId = memberIdTextField.text else {
             presentAlertWithTitle(alertTitle: "Fill out member id text field")
             return
         }

--- a/StytchDemo/B2BWorkbench/AuthMethodControllers/TOTPViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthMethodControllers/TOTPViewController.swift
@@ -1,0 +1,89 @@
+import StytchCore
+import SwiftOTP
+import UIKit
+
+final class TOTPViewController: UIViewController {
+    let stackView = UIStackView.stytchB2BStackView()
+
+    lazy var createButton: UIButton = .init(title: "Create TOTP", primaryAction: .init { [weak self] _ in
+        self?.create()
+    })
+
+    lazy var authenticateButton: UIButton = .init(title: "Authenticate", primaryAction: .init { [weak self] _ in
+        self?.authenticate()
+    })
+
+    private var secret: String?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "TOTP"
+        view.backgroundColor = .systemBackground
+
+        view.addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+
+        stackView.addArrangedSubview(createButton)
+        stackView.addArrangedSubview(authenticateButton)
+    }
+
+    func create() {
+        guard let organizationId = organizationId, let memberId = memberId else {
+            presentAlertWithTitle(alertTitle: "No member or organization ID, you need to authenticate first.")
+            return
+        }
+
+        Task {
+            do {
+                let parameters = StytchB2BClient.TOTP.CreateParameters(organizationId: organizationId, memberId: memberId, expirationMinutes: 30)
+                let response = try await StytchB2BClient.totp.create(parameters: parameters)
+                secret = response.wrapped.secret
+                presentAlertAndLogMessage(description: "create totp success!", object: response)
+            } catch {
+                presentAlertAndLogMessage(description: "create totp error", object: error)
+            }
+        }
+    }
+
+    func authenticate() {
+        guard
+            let organizationId = organizationId,
+            let memberId = memberId
+        else {
+            presentAlertWithTitle(alertTitle: "No member or organization ID, you need to authenticate first.")
+            return
+        }
+
+        guard
+            let secret = secret,
+            let dataSecret = base32DecodeToData(secret),
+            let totp = TOTP(secret: dataSecret),
+            let code = totp.generate(time: Date())
+        else {
+            presentAlertWithTitle(alertTitle: "Failed to generate the the totp code")
+            return
+        }
+
+        Task {
+            do {
+                let parameters = StytchB2BClient.TOTP.AuthenticateParameters(
+                    sessionDurationMinutes: .defaultSessionDuration,
+                    organizationId: organizationId,
+                    memberId: memberId,
+                    code: code,
+                    setMfaEnrollment: nil,
+                    setDefaultMfa: false
+                )
+                let response = try await StytchB2BClient.totp.authenticate(parameters: parameters)
+                presentAlertAndLogMessage(description: "authenticate totp success!", object: response)
+            } catch {
+                presentAlertAndLogMessage(description: "authenticate totp error", object: error)
+            }
+        }
+    }
+}

--- a/StytchDemo/B2BWorkbench/Extensions.swift
+++ b/StytchDemo/B2BWorkbench/Extensions.swift
@@ -11,6 +11,10 @@ extension UIViewController {
         UserDefaults.standard.string(forKey: Constants.orgIdDefaultsKey)
     }
 
+    var memberId: String? {
+        StytchB2BClient.member.getSync()?.id.rawValue
+    }
+
     func presentAlertWithTitle(
         alertTitle: String,
         buttonTitle: String = "OK",

--- a/StytchDemo/StytchDemo.xcodeproj/project.pbxproj
+++ b/StytchDemo/StytchDemo.xcodeproj/project.pbxproj
@@ -88,6 +88,8 @@
 		53E128402B50092F00976CAC /* StytchUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E1283F2B50092F00976CAC /* StytchUITests.swift */; };
 		53E128422B50092F00976CAC /* StytchUILaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E128412B50092F00976CAC /* StytchUILaunchTests.swift */; };
 		74234D4C2C21E1240001DA69 /* SearchManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74234D4B2C21E1240001DA69 /* SearchManagerViewController.swift */; };
+		74234D4E2C21EAC10001DA69 /* TOTPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74234D4D2C21EAC10001DA69 /* TOTPViewController.swift */; };
+		74234D512C21EB770001DA69 /* SwiftOTP in Frameworks */ = {isa = PBXBuildFile; productRef = 74234D502C21EB770001DA69 /* SwiftOTP */; };
 		7478F7D92BF595CD00BCB233 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7478F7D82BF595CD00BCB233 /* Launch Screen.storyboard */; };
 		7478F7DC2BF6467900BCB233 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7478F7DA2BF6467900BCB233 /* Extensions.swift */; };
 		749F88862BFBD63E00D7F386 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 749F88852BFBD63E00D7F386 /* Launch Screen.storyboard */; };
@@ -176,6 +178,7 @@
 		53E128412B50092F00976CAC /* StytchUILaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StytchUILaunchTests.swift; sourceTree = "<group>"; };
 		53E1284C2B500C7400976CAC /* StytchUIDemo.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = StytchUIDemo.xctestplan; sourceTree = "<group>"; };
 		74234D4B2C21E1240001DA69 /* SearchManagerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchManagerViewController.swift; sourceTree = "<group>"; };
+		74234D4D2C21EAC10001DA69 /* TOTPViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TOTPViewController.swift; sourceTree = "<group>"; };
 		7478F7D82BF595CD00BCB233 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		7478F7DA2BF6467900BCB233 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		749F88852BFBD63E00D7F386 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
@@ -190,6 +193,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				74234D512C21EB770001DA69 /* SwiftOTP in Frameworks */,
 				2231532D299EE5E700BA9126 /* StytchCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -328,6 +332,7 @@
 				22ABFAB829F7628E00927518 /* DiscoveryViewController.swift */,
 				22ABFABA29F7690100927518 /* SSOViewController.swift */,
 				74234D4B2C21E1240001DA69 /* SearchManagerViewController.swift */,
+				74234D4D2C21EAC10001DA69 /* TOTPViewController.swift */,
 			);
 			path = AuthMethodControllers;
 			sourceTree = "<group>";
@@ -468,6 +473,7 @@
 			name = B2BWorkbench;
 			packageProductDependencies = (
 				2231532C299EE5E700BA9126 /* StytchCore */,
+				74234D502C21EB770001DA69 /* SwiftOTP */,
 			);
 			productName = B2BWorkbench;
 			productReference = 22315318299EE16D00BA9126 /* B2BWorkbench.app */;
@@ -621,6 +627,7 @@
 				224FC03428486013009C9740 /* XCRemoteSwiftPackageReference "swifter" */,
 				22909075284BE79400ADD3C4 /* XCRemoteSwiftPackageReference "jwt-kit" */,
 				77AC9C5E2AA0FCCD004059CF /* XCRemoteSwiftPackageReference "recaptcha-enterprise-mobile-sdk" */,
+				74234D4F2C21EB6D0001DA69 /* XCRemoteSwiftPackageReference "SwiftOTP" */,
 			);
 			productRefGroup = 229B82192809EA3F007BC3F1 /* Products */;
 			projectDirPath = "";
@@ -693,6 +700,7 @@
 			files = (
 				2231531F299EE16D00BA9126 /* RootViewController.swift in Sources */,
 				224E6F2529E8CAEB0031D37A /* PasswordsViewController.swift in Sources */,
+				74234D4E2C21EAC10001DA69 /* TOTPViewController.swift in Sources */,
 				2254779429A05C6A003DF229 /* MagicLinksViewController.swift in Sources */,
 				2254779229A05C3E003DF229 /* AuthHomeViewController.swift in Sources */,
 				74234D4C2C21E1240001DA69 /* SearchManagerViewController.swift in Sources */,
@@ -1415,6 +1423,14 @@
 				minimumVersion = 4.0.0;
 			};
 		};
+		74234D4F2C21EB6D0001DA69 /* XCRemoteSwiftPackageReference "SwiftOTP" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/lachlanbell/SwiftOTP.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.0.2;
+			};
+		};
 		77AC9C5E2AA0FCCD004059CF /* XCRemoteSwiftPackageReference "recaptcha-enterprise-mobile-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk";
@@ -1459,6 +1475,11 @@
 		5354B59F2B507F1500B3081C /* StytchUI */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = StytchUI;
+		};
+		74234D502C21EB770001DA69 /* SwiftOTP */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 74234D4F2C21EB6D0001DA69 /* XCRemoteSwiftPackageReference "SwiftOTP" */;
+			productName = SwiftOTP;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/StytchDemo/StytchDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StytchDemo/StytchDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -54,6 +54,15 @@
           "revision": "a51ae97214d6d24e18aa9e824eea5f1f4021d171",
           "version": null
         }
+      },
+      {
+        "package": "SwiftOTP",
+        "repositoryURL": "https://github.com/lachlanbell/SwiftOTP.git",
+        "state": {
+          "branch": null,
+          "revision": "9660551ea3df153c3cbacfa34ac3abbec73a8b84",
+          "version": "3.0.2"
+        }
       }
     ]
   },

--- a/Tests/StytchCoreTests/B2BTOTPTestCase.swift
+++ b/Tests/StytchCoreTests/B2BTOTPTestCase.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import StytchCore
+
+final class B2BTOTPTestCase: BaseTestCase {
+    func testCreate() async throws {
+        networkInterceptor.responses {
+            StytchB2BClient.TOTP.CreateResponse(
+                requestId: "1234",
+                statusCode: 200,
+                wrapped: .mock
+            )
+        }
+
+        let organizationId = "orgid1234"
+        let memberId = "memberid1234"
+
+        let parameters = StytchB2BClient.TOTP.CreateParameters(
+            organizationId: organizationId,
+            memberId: memberId,
+            expirationMinutes: .defaultSessionDuration
+        )
+        _ = try await StytchB2BClient.totp.create(parameters: parameters)
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/b2b/totp",
+            method: .post([
+                "expiration_minutes": JSON.number(30),
+                "organization_id": JSON.string(organizationId),
+                "member_id": JSON.string(memberId),
+            ])
+        )
+    }
+
+    func testAuthenticate() async throws {
+        networkInterceptor.responses {
+            B2BAuthenticateResponse.mock
+        }
+
+        Current.timer = { _, _, _ in .init() }
+
+        let organizationId = "orgid1234"
+        let memberId = "memberid1234"
+        let code = "code1234"
+
+        let parameters = StytchB2BClient.TOTP.AuthenticateParameters(
+            sessionDurationMinutes: .defaultSessionDuration,
+            organizationId: organizationId,
+            memberId: memberId,
+            code: code
+        )
+        _ = try await StytchB2BClient.totp.authenticate(parameters: parameters)
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/b2b/totp/authenticate",
+            method: .post([
+                "session_duration_minutes": JSON.number(30),
+                "organization_id": JSON.string(organizationId),
+                "member_id": JSON.string(memberId),
+                "code": JSON.string(code),
+            ])
+        )
+    }
+}
+
+extension StytchB2BClient.TOTP.CreateResponseData {
+    static var mock: Self {
+        .init(
+            totpRegistrationId: "",
+            secret: "",
+            qrCode: "",
+            recoveryCodes: []
+        )
+    }
+}


### PR DESCRIPTION
Linear Ticket: [SDK-1479](https://linear.app/stytch/issue/SDK-1479/[ios]-[b2b]-add-totp-client)

## Changes:

1.  Add `StytchB2BClient+TOTP` and the methods `create` to create a totp secret for the member and `authenticate` to authenticate based on the secret returned.
2. In the sample app add the package `SwiftOTP` which will help generate the code from the secret returned.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A