### PR TITLE
[SDK-1478] Add StytchB2BClient+OTP

### DIFF
--- a/Sources/StytchCore/Generated/StytchB2BClient.OTP.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.OTP.authenticate+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchB2BClient.OTP {
+    /// Authenticate a one-time passcode (OTP) sent to a user via SMS.
+    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
+        Task {
+            do {
+                completion(.success(try await authenticate(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Authenticate a one-time passcode (OTP) sent to a user via SMS.
+    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<B2BAuthenticateResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await authenticate(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/Generated/StytchB2BClient.OTP.send+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.OTP.send+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchB2BClient.OTP {
+    /// Send a one-time passcode (OTP) to a user using their phone number via SMS.
+    func send(parameters: SendParameters, completion: @escaping Completion<BasicResponse>) {
+        Task {
+            do {
+                completion(.success(try await send(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Send a one-time passcode (OTP) to a user using their phone number via SMS.
+    func send(parameters: SendParameters) -> AnyPublisher<BasicResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await send(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
@@ -48,6 +48,11 @@ public extension StytchB2BClient {
         case OPTIONAL
     }
 
+    enum MFAEnrollment: String, Codable {
+        case enroll
+        case unenroll
+    }
+
     struct RBACEmailImplicitRoleAssignments: Codable {
         let roleId: String
         let domain: String

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP.swift
@@ -1,78 +1,62 @@
 import Foundation
 
 public extension StytchB2BClient {
-    /// The interface for interacting with totp products.
-    static var totp: TOTP {
+    /// The interface for interacting with otp products.
+    static var otp: OTP {
         .init(router: router.scopedRouter {
-            $0.totp
+            $0.otp
         })
     }
 }
 
 public extension StytchB2BClient {
-    struct TOTP {
-        let router: NetworkingRouter<StytchB2BClient.TOTPRoute>
+    struct OTP {
+        let router: NetworkingRouter<StytchB2BClient.OTPRoute>
 
         // sourcery: AsyncVariants
-        /// Create a TOTP for a member
-        public func create(parameters: CreateParameters) async throws -> CreateResponse {
-            try await router.post(to: .create, parameters: parameters)
+        /// Send a one-time passcode (OTP) to a user using their phone number via SMS.
+        public func send(parameters: SendParameters) async throws -> BasicResponse {
+            try await router.post(to: .send, parameters: parameters)
         }
 
         // sourcery: AsyncVariants
-        /// Authenticate a TOTP for a member
+        /// Authenticate a one-time passcode (OTP) sent to a user via SMS.
         public func authenticate(parameters: AuthenticateParameters) async throws -> B2BAuthenticateResponse {
             try await router.post(to: .authenticate, parameters: parameters)
         }
     }
 }
 
-public extension StytchB2BClient.TOTP {
-    struct CreateParameters: Codable {
-        let organizationId: String
-        let memberId: String
-        let expirationMinutes: Minutes
+public extension StytchB2BClient.OTP {
+    struct SendParameters: Codable {
+        public let organizationId: String
+        public let memberId: String
+        public let mfaPhoneNumber: String?
+        public let locale: String?
 
         /// - Parameters:
         ///   - organizationId: The ID of the organization the member belongs to
-        ///   - memberId: The ID of the member creating a TOTP
-        ///   - expirationMinutes: The expiration for the TOTP instance.
-        ///   If the newly created TOTP is not authenticated within this time frame the TOTP will be unusable.
-        ///   Defaults to 60 (1 hour) with a minimum of 5 and a maximum of 1440.
-        public init(organizationId: String, memberId: String, expirationMinutes: Minutes) {
+        ///   - memberId: The ID of the member to send the OTP to
+        ///   - mfaPhoneNumber: The phone number to send the OTP to. If the member already has a phone number, this argument is not needed.
+        ///     If the member does not have a phone number and this argument is not provided, an error will be thrown.
+        ///   - locale: The locale is used to determine which language to use in the email. Parameter is a https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag, e.g. "en".
+        //      Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
+        public init(organizationId: String, memberId: String, mfaPhoneNumber: String? = nil, locale: String? = nil) {
             self.organizationId = organizationId
             self.memberId = memberId
-            self.expirationMinutes = expirationMinutes
+            self.mfaPhoneNumber = mfaPhoneNumber
+            self.locale = locale
         }
     }
 }
 
-public extension StytchB2BClient.TOTP {
-    typealias CreateResponse = Response<CreateResponseData>
-
-    struct CreateResponseData: Codable {
-        /// Globally unique UUID that identifies a specific TOTP registration in the Stytch API.
-        public let totpRegistrationId: String
-
-        /// The TOTP secret key shared between the authenticator app and the server used to generate TOTP codes.
-        public let secret: String
-
-        /// The QR code image encoded in base64.
-        public let qrCode: String
-
-        /// The recovery codes used to authenticate the member without an authenticator app.
-        public let recoveryCodes: [String]
-    }
-}
-
-public extension StytchB2BClient.TOTP {
+public extension StytchB2BClient.OTP {
     struct AuthenticateParameters: Codable {
         let sessionDurationMinutes: Minutes
         let organizationId: String
         let memberId: String
         let code: String
         let setMfaEnrollment: StytchB2BClient.MFAEnrollment?
-        let setDefaultMfa: Bool?
 
         /// - Parameters:
         ///   - sessionDurationMinutes: Set the session lifetime to be this many minutes from now.
@@ -81,25 +65,22 @@ public extension StytchB2BClient.TOTP {
         ///     This value must be a minimum of 5 and may not exceed the maximum session duration minutes value set in the https://stytch.com/dashboard/sdk-configuration SDK Configuration page of the Stytch dashboard.
         ///   - organizationId: The ID of the organization the member belongs to
         ///   - memberId: The ID of the member to authenticate
-        ///   - code: The TOTP code to authenticate
+        ///   - code: The OTP code to authenticate
         ///   - setMfaEnrollment: If set to 'enroll', enrolls the member in MFA by setting the "mfa_enrolled" boolean to true.
         ///     If set to 'unenroll', unenrolls the member in MFA by setting the "mfa_enrolled" boolean to false.
         ///     If not set, does not affect the member's MFA enrollment.
-        ///   - setDefaultMfa: If set to true, sets TOTP as the member's default MFA method.
         public init(
             sessionDurationMinutes: Minutes,
             organizationId: String,
             memberId: String,
             code: String,
-            setMfaEnrollment: StytchB2BClient.MFAEnrollment? = nil,
-            setDefaultMfa: Bool? = nil
+            setMfaEnrollment: StytchB2BClient.MFAEnrollment? = nil
         ) {
             self.sessionDurationMinutes = sessionDurationMinutes
             self.organizationId = organizationId
             self.memberId = memberId
             self.code = code
             self.setMfaEnrollment = setMfaEnrollment
-            self.setDefaultMfa = setDefaultMfa
         }
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
@@ -10,6 +10,7 @@ extension StytchB2BClient {
         case bootstrap(BootstrapRoute)
         case searchManager(SearchManagerRoute)
         case totp(TOTPRoute)
+        case otp(OTPRoute)
 
         var path: Path {
             let (base, next) = routeComponents
@@ -38,6 +39,8 @@ extension StytchB2BClient {
                 return ("", route)
             case let .totp(route):
                 return ("totp", route)
+            case let .otp(route):
+                return ("otps", route)
             }
         }
     }
@@ -281,6 +284,20 @@ extension StytchB2BClient {
                 return ""
             case .authenticate:
                 return "authenticate"
+            }
+        }
+    }
+
+    enum OTPRoute: RouteType {
+        case send
+        case authenticate
+
+        var path: Path {
+            switch self {
+            case .send:
+                return "sms/send"
+            case .authenticate:
+                return "sms/authenticate"
             }
         }
     }

--- a/StytchDemo/B2BWorkbench/AuthHomeViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthHomeViewController.swift
@@ -43,6 +43,10 @@ final class AuthHomeViewController: UIViewController {
         self?.navigationController?.pushViewController(TOTPViewController(), animated: true)
     })
 
+    lazy var otpButton: UIButton = .init(title: "OTP", primaryAction: .init { [weak self] _ in
+        self?.navigationController?.pushViewController(OTPViewController(), animated: true)
+    })
+
     func saveOrgID() {
         UserDefaults.standard.set(orgIdTextField.text, forKey: Constants.orgIdDefaultsKey)
     }
@@ -72,6 +76,7 @@ final class AuthHomeViewController: UIViewController {
         stackView.addArrangedSubview(organizationButton)
         stackView.addArrangedSubview(searchManagerButton)
         stackView.addArrangedSubview(totpButton)
+        stackView.addArrangedSubview(otpButton)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/StytchDemo/B2BWorkbench/AuthMethodControllers/OTPViewController.swift
+++ b/StytchDemo/B2BWorkbench/AuthMethodControllers/OTPViewController.swift
@@ -1,0 +1,85 @@
+import StytchCore
+import SwiftOTP
+import UIKit
+
+final class OTPViewController: UIViewController {
+    let stackView = UIStackView.stytchB2BStackView()
+
+    lazy var sendButton: UIButton = .init(title: "Send OTP", primaryAction: .init { [weak self] _ in
+        self?.send()
+    })
+
+    lazy var authenticateButton: UIButton = .init(title: "Authenticate", primaryAction: .init { [weak self] _ in
+        self?.authenticate()
+    })
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "TOTP"
+        view.backgroundColor = .systemBackground
+
+        view.addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+
+        stackView.addArrangedSubview(sendButton)
+        stackView.addArrangedSubview(authenticateButton)
+    }
+
+    func send() {
+        guard let organizationId = organizationId, let memberId = memberId else {
+            presentAlertWithTitle(alertTitle: "No member or organization ID, you need to authenticate first.")
+            return
+        }
+
+        Task {
+            do {
+                guard let phoneNumber = try await presentTextFieldAlertWithTitle(alertTitle: "Enter Your Phone Number In The Format +1xxxxxxxxxx") else {
+                    throw TextFieldAlertError.emptyString
+                }
+
+                let parameters = StytchB2BClient.OTP.SendParameters(
+                    organizationId: organizationId,
+                    memberId: memberId,
+                    mfaPhoneNumber: phoneNumber,
+                    locale: nil
+                )
+                let response = try await StytchB2BClient.otp.send(parameters: parameters)
+                presentAlertAndLogMessage(description: "send otp success!", object: response)
+            } catch {
+                presentAlertAndLogMessage(description: "send otp error", object: error)
+            }
+        }
+    }
+
+    func authenticate() {
+        guard let organizationId = organizationId, let memberId = memberId else {
+            presentAlertWithTitle(alertTitle: "No member or organization ID, you need to authenticate first.")
+            return
+        }
+
+        Task {
+            do {
+                guard let code = try await presentTextFieldAlertWithTitle(alertTitle: "Enter The OTP Code") else {
+                    throw TextFieldAlertError.emptyString
+                }
+
+                let parameters = StytchB2BClient.OTP.AuthenticateParameters(
+                    sessionDurationMinutes: .defaultSessionDuration,
+                    organizationId: organizationId,
+                    memberId: memberId,
+                    code: code,
+                    setMfaEnrollment: nil
+                )
+                let response = try await StytchB2BClient.otp.authenticate(parameters: parameters)
+                presentAlertAndLogMessage(description: "authenticate otp success!", object: response)
+            } catch {
+                presentAlertAndLogMessage(description: "authenticate otp error", object: error)
+            }
+        }
+    }
+}

--- a/StytchDemo/StytchDemo.xcodeproj/project.pbxproj
+++ b/StytchDemo/StytchDemo.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		7478F7D92BF595CD00BCB233 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7478F7D82BF595CD00BCB233 /* Launch Screen.storyboard */; };
 		7478F7DC2BF6467900BCB233 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7478F7DA2BF6467900BCB233 /* Extensions.swift */; };
 		749F88862BFBD63E00D7F386 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 749F88852BFBD63E00D7F386 /* Launch Screen.storyboard */; };
+		74A2D1912C21FDF8007F8F20 /* OTPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A2D1902C21FDF8007F8F20 /* OTPViewController.swift */; };
 		74F3702A2C07B7F400AED9C9 /* OrganizationMemberViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F370292C07B7F400AED9C9 /* OrganizationMemberViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -182,6 +183,7 @@
 		7478F7D82BF595CD00BCB233 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		7478F7DA2BF6467900BCB233 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		749F88852BFBD63E00D7F386 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+		74A2D1902C21FDF8007F8F20 /* OTPViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPViewController.swift; sourceTree = "<group>"; };
 		74D1157E2BFBDFFD002EAB79 /* B2BWorkbench-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "B2BWorkbench-Bridging-Header.h"; sourceTree = "<group>"; };
 		74F370292C07B7F400AED9C9 /* OrganizationMemberViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationMemberViewController.swift; sourceTree = "<group>"; };
 		7763D5AF2B58698F00F00737 /* StytchUIDemo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StytchUIDemo.entitlements; sourceTree = "<group>"; };
@@ -333,6 +335,7 @@
 				22ABFABA29F7690100927518 /* SSOViewController.swift */,
 				74234D4B2C21E1240001DA69 /* SearchManagerViewController.swift */,
 				74234D4D2C21EAC10001DA69 /* TOTPViewController.swift */,
+				74A2D1902C21FDF8007F8F20 /* OTPViewController.swift */,
 			);
 			path = AuthMethodControllers;
 			sourceTree = "<group>";
@@ -710,6 +713,7 @@
 				2254779A29A05D37003DF229 /* OrganizationViewController.swift in Sources */,
 				2254779C29A05D4E003DF229 /* SessionsViewController.swift in Sources */,
 				22ABFABB29F7690100927518 /* SSOViewController.swift in Sources */,
+				74A2D1912C21FDF8007F8F20 /* OTPViewController.swift in Sources */,
 				22ABFAB929F7628E00927518 /* DiscoveryViewController.swift in Sources */,
 				2254779829A05D08003DF229 /* MemberViewController.swift in Sources */,
 				2254779629A05C93003DF229 /* Constants.swift in Sources */,

--- a/Tests/StytchCoreTests/B2BOTPTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOTPTestCase.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import StytchCore
+
+final class B2BOTPTestCase: BaseTestCase {
+    func testSend() async throws {
+        networkInterceptor.responses {
+            BasicResponse(requestId: "1234", statusCode: 200)
+        }
+
+        let organizationId = "orgid1234"
+        let memberId = "memberid1234"
+        let mfaPhoneNumber = "+15555555555"
+        let locale = "en_us"
+
+        let parameters = StytchB2BClient.OTP.SendParameters(
+            organizationId: organizationId,
+            memberId: memberId,
+            mfaPhoneNumber: mfaPhoneNumber,
+            locale: locale
+        )
+
+        _ = try await StytchB2BClient.otp.send(parameters: parameters)
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/b2b/otps/sms/send",
+            method: .post([
+                "organization_id": JSON.string(organizationId),
+                "member_id": JSON.string(memberId),
+                "mfa_phone_number": JSON.string(mfaPhoneNumber),
+                "locale": JSON.string(locale),
+            ])
+        )
+    }
+
+    func testAuthenticate() async throws {
+        networkInterceptor.responses {
+            B2BAuthenticateResponse.mock
+        }
+
+        Current.timer = { _, _, _ in .init() }
+
+        let organizationId = "orgid1234"
+        let memberId = "memberid1234"
+        let code = "code1234"
+
+        let parameters = StytchB2BClient.OTP.AuthenticateParameters(
+            sessionDurationMinutes: .defaultSessionDuration,
+            organizationId: organizationId,
+            memberId: memberId,
+            code: code
+        )
+        _ = try await StytchB2BClient.otp.authenticate(parameters: parameters)
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/b2b/otps/sms/authenticate",
+            method: .post([
+                "session_duration_minutes": JSON.number(30),
+                "organization_id": JSON.string(organizationId),
+                "member_id": JSON.string(memberId),
+                "code": JSON.string(code),
+            ])
+        )
+    }
+}


### PR DESCRIPTION
Linear Ticket: [SDK-1478](https://linear.app/stytch/issue/SDK-1478/[ios]-[b2b]-add-otp-client)

## Changes:

1. Add `StytchB2BClient+OTP` including `send` which will send an opt code via sms, and a `authenticate` with that code.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A