### PR TITLE
[SDK-1477] Add StytchB2BClient.OAuth

### DIFF
--- a/Sources/StytchCore/ClientType.swift
+++ b/Sources/StytchCore/ClientType.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-internal enum ClientType {
+public enum ClientType {
     case consumer
     case b2b
 }

--- a/Sources/StytchCore/Domain.swift
+++ b/Sources/StytchCore/Domain.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension LocalStorage {
+    func stytchDomain(_ publicToken: String) -> String {
+        let domain: String
+        if let cnameDomain = bootstrapData?.cnameDomain {
+            domain = cnameDomain
+        } else if publicToken.hasPrefix("public-token-test") {
+            domain = "test.stytch.com"
+        } else {
+            domain = "api.stytch.com"
+        }
+        return domain
+    }
+}

--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -74,7 +74,7 @@ struct Environment {
     var keychainClient: KeychainClient = .live
 
     #if !os(watchOS)
-    private var _webAuthSessionClient: Any? = {
+    private var _webAuthenticationSessionClient: Any? = {
         if #available(tvOS 16.0, *) {
             return WebAuthenticationSessionClient.live
         }
@@ -82,10 +82,10 @@ struct Environment {
     }()
 
     @available(tvOS 16.0, *)
-    var webAuthSessionClient: WebAuthenticationSessionClient {
+    var webAuthenticationSessionClient: WebAuthenticationSessionClient {
         // swiftlint:disable:next force_cast
-        get { _webAuthSessionClient as! WebAuthenticationSessionClient }
-        set { _webAuthSessionClient = newValue }
+        get { _webAuthenticationSessionClient as! WebAuthenticationSessionClient }
+        set { _webAuthenticationSessionClient = newValue }
     }
 
     private var _passkeysClent: Any? = {
@@ -117,18 +117,6 @@ struct Environment {
         runloop.add(timer, forMode: .common)
         return timer
     }
-
-    #if !os(watchOS)
-    var openUrl: (URL) -> Void = { url in
-        DispatchQueue.main.async {
-            #if os(macOS)
-            NSWorkspace.shared.open(url)
-            #else
-            UIApplication.shared.open(url)
-            #endif
-        }
-    }
-    #endif
 
     var initializationState: InitializationState = .init()
 }

--- a/Sources/StytchCore/Extensions/URL+Stytch.swift
+++ b/Sources/StytchCore/Extensions/URL+Stytch.swift
@@ -1,18 +1,39 @@
 import Foundation
 
 extension URL {
-    func appending(queryParameters: [(name: String, value: String)]?) -> URL {
-        guard
-            let queryParameters = queryParameters,
-            !queryParameters.isEmpty,
-            var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: false)
-        else { return self }
+    /// Filters the queryParameters to remove any tuple pairs with a nil secondary value.
+    /// Turning it from an array of [(String, String?)] to an array of [(String, String)].
+    private func filteredQueryParameters(_ queryParameters: [(String, String?)]) -> [(String, String)] {
+        var filteredQueryParameters = [(String, String)]()
+        queryParameters.forEach { name, value in
+            guard let value = value else {
+                return
+            }
+            filteredQueryParameters.append((name, value))
+        }
+        return filteredQueryParameters
+    }
+
+    func appending(queryParameters: [(name: String, value: String?)]) -> URL {
+        let filteredQueryParamters = filteredQueryParameters(queryParameters)
+        guard filteredQueryParamters.isEmpty == false, var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            return self
+        }
 
         var queryItems = urlComponents.queryItems ?? []
-        queryItems.append(contentsOf: queryParameters.map(URLQueryItem.init(name:value:)))
-
+        queryItems.append(contentsOf: filteredQueryParamters.map(URLQueryItem.init(name:value:)))
         urlComponents.queryItems = queryItems
-
         return urlComponents.url ?? self
+    }
+}
+
+extension Dictionary where Key == String, Value == String {
+    func toURLParameters() -> String {
+        let urlComponents = map { key, value in
+            let escapedKey = key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+            let escapedValue = value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+            return "\(escapedKey)=\(escapedValue)"
+        }
+        return urlComponents.joined(separator: "&")
     }
 }

--- a/Sources/StytchCore/Generated/StytchB2BClient.OAuth.Discovery.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.OAuth.Discovery.authenticate+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchB2BClient.OAuth.Discovery {
+    /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
+    func authenticate(parameters: DiscoveryAuthenticateParameters, completion: @escaping Completion<DiscoveryAuthenticateResponse>) {
+        Task {
+            do {
+                completion(.success(try await authenticate(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
+    func authenticate(parameters: DiscoveryAuthenticateParameters) -> AnyPublisher<DiscoveryAuthenticateResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await authenticate(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/Generated/StytchB2BClient.OAuth.ThirdParty.Discovery.start+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.OAuth.ThirdParty.Discovery.start+AsyncVariants.generated.swift
@@ -4,15 +4,15 @@ import Combine
 import Foundation
 
 #if !os(watchOS)
-public extension StytchClient.OAuth.ThirdParty {
+public extension StytchB2BClient.OAuth.ThirdParty.Discovery {
     /// Initiates the OAuth flow by using the included parameters to generate a URL and start an `ASWebAuthenticationSession`.
     /// **NOTE:** The user will be prompted for permission to use "stytch.com" to sign in — you may want to inform your users of this expectation.
     /// The user will see an in-app browser—with shared sessions from their default browser—which will dismiss after completing the authentication challenge with the identity provider.
     /// 
     /// **Usage:**
     /// ``` swift
-    /// let (token, url) = try await StytchClient.oauth.google.start(parameters: parameters)
-    /// let authResponse = try await StytchClient.oauth.authenticate(parameters: .init(token: token))
+    /// let (token, url) = try await StytchB2BClient.oauth.discovery.google.start(parameters: parameters)
+    /// let authResponse = try await StytchB2BClient.oauth.discovery.authenticate(parameters: .init(token: token))
     /// // You can parse the returned `url` value to understand whether this authentication was a login or a signup.
     /// ```
     /// - Returns: A tuple containing an authentication token, for use in the ``StytchClient/OAuth-swift.struct/authenticate(parameters:)-3tjwd`` method as well as the redirect url to inform whether this authentication was a login or signup.
@@ -33,8 +33,8 @@ public extension StytchClient.OAuth.ThirdParty {
     /// 
     /// **Usage:**
     /// ``` swift
-    /// let (token, url) = try await StytchClient.oauth.google.start(parameters: parameters)
-    /// let authResponse = try await StytchClient.oauth.authenticate(parameters: .init(token: token))
+    /// let (token, url) = try await StytchB2BClient.oauth.discovery.google.start(parameters: parameters)
+    /// let authResponse = try await StytchB2BClient.oauth.discovery.authenticate(parameters: .init(token: token))
     /// // You can parse the returned `url` value to understand whether this authentication was a login or a signup.
     /// ```
     /// - Returns: A tuple containing an authentication token, for use in the ``StytchClient/OAuth-swift.struct/authenticate(parameters:)-3tjwd`` method as well as the redirect url to inform whether this authentication was a login or signup.

--- a/Sources/StytchCore/Generated/StytchB2BClient.OAuth.ThirdParty.start+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.OAuth.ThirdParty.start+AsyncVariants.generated.swift
@@ -4,15 +4,15 @@ import Combine
 import Foundation
 
 #if !os(watchOS)
-public extension StytchClient.OAuth.ThirdParty {
+public extension StytchB2BClient.OAuth.ThirdParty {
     /// Initiates the OAuth flow by using the included parameters to generate a URL and start an `ASWebAuthenticationSession`.
     /// **NOTE:** The user will be prompted for permission to use "stytch.com" to sign in — you may want to inform your users of this expectation.
     /// The user will see an in-app browser—with shared sessions from their default browser—which will dismiss after completing the authentication challenge with the identity provider.
     /// 
     /// **Usage:**
     /// ``` swift
-    /// let (token, url) = try await StytchClient.oauth.google.start(parameters: parameters)
-    /// let authResponse = try await StytchClient.oauth.authenticate(parameters: .init(token: token))
+    /// let (token, url) = try await StytchB2BClient.oauth.google.start(parameters: parameters)
+    /// let authResponse = try await StytchB2BClient.oauth.authenticate(parameters: .init(token: token))
     /// // You can parse the returned `url` value to understand whether this authentication was a login or a signup.
     /// ```
     /// - Returns: A tuple containing an authentication token, for use in the ``StytchClient/OAuth-swift.struct/authenticate(parameters:)-3tjwd`` method as well as the redirect url to inform whether this authentication was a login or signup.
@@ -33,8 +33,8 @@ public extension StytchClient.OAuth.ThirdParty {
     /// 
     /// **Usage:**
     /// ``` swift
-    /// let (token, url) = try await StytchClient.oauth.google.start(parameters: parameters)
-    /// let authResponse = try await StytchClient.oauth.authenticate(parameters: .init(token: token))
+    /// let (token, url) = try await StytchB2BClient.oauth.google.start(parameters: parameters)
+    /// let authResponse = try await StytchB2BClient.oauth.authenticate(parameters: .init(token: token))
     /// // You can parse the returned `url` value to understand whether this authentication was a login or a signup.
     /// ```
     /// - Returns: A tuple containing an authentication token, for use in the ``StytchClient/OAuth-swift.struct/authenticate(parameters:)-3tjwd`` method as well as the redirect url to inform whether this authentication was a login or signup.

--- a/Sources/StytchCore/Generated/StytchB2BClient.OAuth.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.OAuth.authenticate+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchB2BClient.OAuth {
+    /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
+    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
+        Task {
+            do {
+                completion(.success(try await authenticate(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
+    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<B2BAuthenticateResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await authenticate(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/Generated/StytchB2BClient.SSO.start+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.SSO.start+AsyncVariants.generated.swift
@@ -7,10 +7,10 @@ import Foundation
 public extension StytchB2BClient.SSO {
     /// Start an SSO authentication flow.
     @available(tvOS 16.0, *)
-    func start(parameters: StartParameters, completion: @escaping Completion<(token: String, url: URL)>) {
+    func start(configuration: WebAuthenticationConfiguration, completion: @escaping Completion<(token: String, url: URL)>) {
         Task {
             do {
-                completion(.success(try await start(parameters: parameters)))
+                completion(.success(try await start(configuration: configuration)))
             } catch {
                 completion(.failure(error))
             }
@@ -19,12 +19,12 @@ public extension StytchB2BClient.SSO {
 
     /// Start an SSO authentication flow.
     @available(tvOS 16.0, *)
-    func start(parameters: StartParameters) -> AnyPublisher<(token: String, url: URL), Error> {
+    func start(configuration: WebAuthenticationConfiguration) -> AnyPublisher<(token: String, url: URL), Error> {
         return Deferred {
             Future({ promise in
                 Task {
                     do {
-                        promise(.success(try await start(parameters: parameters)))
+                        promise(.success(try await start(configuration: configuration)))
                     } catch {
                         promise(.failure(error))
                     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Events.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Events.swift
@@ -130,10 +130,12 @@ public extension StytchB2BClient.Events {
     struct Parameters {
         let eventName: String
         let details: [String: String]?
+        let error: Error?
 
-        public init(eventName: String, details: [String: String]? = nil) {
+        public init(eventName: String, details: [String: String]? = nil, error: Error? = nil) {
             self.eventName = eventName
             self.details = details
+            self.error = error
         }
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+Discovery.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+public extension StytchB2BClient.OAuth {
+    /// The interface for interacting with OAuth products.
+    var discovery: Discovery {
+        .init(router: router.scopedRouter {
+            $0.discoveryRoute
+        })
+    }
+}
+
+public extension StytchB2BClient.OAuth {
+    struct Discovery {
+        let router: NetworkingRouter<StytchB2BClient.OAuthRoute.DiscoveryRoute>
+
+        @Dependency(\.keychainClient) private var keychainClient
+
+        // sourcery: AsyncVariants
+        /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
+        public func authenticate(parameters: DiscoveryAuthenticateParameters) async throws -> DiscoveryAuthenticateResponse {
+            guard let codeVerifier: String = try keychainClient.get(.codeVerifierPKCE) else {
+                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "oauth_failure", error: StytchSDKError.missingPKCE))
+                throw StytchSDKError.missingPKCE
+            }
+            do {
+                let result = try await router.post(
+                    to: .authenticate,
+                    parameters: CodeVerifierParameters(codingPrefix: .pkce, codeVerifier: codeVerifier, wrapped: parameters)
+                ) as DiscoveryAuthenticateResponse
+                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "oauth_success"))
+                return result
+            } catch {
+                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "oauth_failure", error: error))
+                throw error
+            }
+        }
+    }
+}
+
+public extension StytchB2BClient.OAuth.Discovery {
+    struct DiscoveryAuthenticateParameters: Codable {
+        public let discoveryOauthToken: String
+
+        /// A data class wrapping the parameters necessary to authenticate an OAuth Discovery flow
+        /// - Parameter discoveryOauthToken: The oauth token used to finish the discovery flow
+        public init(discoveryOauthToken: String) {
+            self.discoveryOauthToken = discoveryOauthToken
+        }
+    }
+}
+
+public extension StytchB2BClient.OAuth.Discovery {
+    typealias DiscoveryAuthenticateResponse = Response<DiscoveryAuthenticateResponseData>
+
+    struct DiscoveryAuthenticateResponseData: Codable {
+        public let intermediateSessionToken: String
+        public let emailAddress: String
+        public let discoveredOrganizations: [DiscoveredOrganization]
+    }
+
+    struct DiscoveredOrganization: Codable {
+        public let organization: Organization
+        public let membership: Membership
+        public let memberAuthenticated: Bool
+    }
+
+    struct Membership: Codable {
+        public let type: String
+        public let details: MembershipDetails?
+        public let member: Member?
+    }
+
+    struct MembershipDetails: Codable {
+        public let domain: String
+    }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
@@ -2,14 +2,14 @@ import AuthenticationServices
 import Foundation
 
 #if !os(watchOS)
-public protocol ThirdPartyOAuthProviderProtocol {
+protocol ThirdPartyB2BOAuthProviderProtocol {
     @available(tvOS 16.0, *)
-    func start(configuration: StytchClient.OAuth.ThirdParty.WebAuthenticationConfiguration) async throws -> (token: String, url: URL)
+    func start(configuration: StytchB2BClient.OAuth.ThirdParty.WebAuthenticationConfiguration) async throws -> (token: String, url: URL)
 }
 
-public extension StytchClient.OAuth {
+public extension StytchB2BClient.OAuth {
     // sourcery: ExcludeWatchOS
-    struct ThirdParty: ThirdPartyOAuthProviderProtocol {
+    struct ThirdParty: ThirdPartyB2BOAuthProviderProtocol {
         /// The SDK provides the ability to integrate with third-party identity providers for OAuth experiences beyond the natively-supported Sign In With Apple flow.
         let provider: Provider
 
@@ -21,8 +21,8 @@ public extension StytchClient.OAuth {
         ///
         /// **Usage:**
         /// ``` swift
-        /// let (token, url) = try await StytchClient.oauth.google.start(parameters: parameters)
-        /// let authResponse = try await StytchClient.oauth.authenticate(parameters: .init(token: token))
+        /// let (token, url) = try await StytchB2BClient.oauth.google.start(parameters: parameters)
+        /// let authResponse = try await StytchB2BClient.oauth.authenticate(parameters: .init(token: token))
         /// // You can parse the returned `url` value to understand whether this authentication was a login or a signup.
         /// ```
         /// - Returns: A tuple containing an authentication token, for use in the ``StytchClient/OAuth-swift.struct/authenticate(parameters:)-3tjwd`` method as well as the redirect url to inform whether this authentication was a login or signup.
@@ -33,12 +33,15 @@ public extension StytchClient.OAuth {
     }
 }
 
-public extension StytchClient.OAuth.ThirdParty {
+public extension StytchB2BClient.OAuth.ThirdParty {
     struct WebAuthenticationConfiguration: WebAuthenticationSessionClientConfiguration {
         let loginRedirectUrl: URL?
         let signupRedirectUrl: URL?
+        let organizationId: String?
+        let organizationSlug: String?
         let customScopes: [String]?
-        public let clientType: ClientType = .consumer
+        let providerParams: [String: String]?
+        public let clientType: ClientType = .b2b
 
         #if !os(tvOS)
         /// You may need to pass in your own context provider to give the `ASWebAuthenticationSession` the proper window to present from.
@@ -48,32 +51,63 @@ public extension StytchClient.OAuth.ThirdParty {
         /// - Parameters:
         ///   - loginRedirectUrl: The url an existing user is redirected to after authenticating with the identity provider. This url **must** use a custom scheme and be added to your Stytch Dashboard.
         ///   - signupRedirectUrl: The url a new user is redirected to after authenticating with the identity provider. This url **must** use a custom scheme and be added to your Stytch Dashboard.
+        ///   - organizationId: The id of the organization the member belongs to.
         ///   - customScopes: Any additional scopes to be requested from the identity provider.
+        ///   - providerParams: An optional mapping of provider specific values to pass through to the OAuth provider
         public init(
             loginRedirectUrl: URL? = nil,
             signupRedirectUrl: URL? = nil,
-            customScopes: [String]? = nil
+            organizationId: String? = nil,
+            customScopes: [String]? = nil,
+            providerParams: [String: String]? = nil
         ) {
             self.loginRedirectUrl = loginRedirectUrl
             self.signupRedirectUrl = signupRedirectUrl
+            self.organizationId = organizationId
+            organizationSlug = nil
             self.customScopes = customScopes
+            self.providerParams = providerParams
+        }
+
+        /// - Parameters:
+        ///   - loginRedirectUrl: The url an existing user is redirected to after authenticating with the identity provider. This url **must** use a custom scheme and be added to your Stytch Dashboard.
+        ///   - signupRedirectUrl: The url a new user is redirected to after authenticating with the identity provider. This url **must** use a custom scheme and be added to your Stytch Dashboard.
+        ///   - organizationSlug: The slug of the organization the member belongs to
+        ///   - customScopes: Any additional scopes to be requested from the identity provider.
+        ///   - providerParams: An optional mapping of provider specific values to pass through to the OAuth provider
+        public init(
+            loginRedirectUrl: URL? = nil,
+            signupRedirectUrl: URL? = nil,
+            organizationSlug: String? = nil,
+            customScopes: [String]? = nil,
+            providerParams: [String: String]? = nil
+        ) {
+            self.loginRedirectUrl = loginRedirectUrl
+            self.signupRedirectUrl = signupRedirectUrl
+            organizationId = nil
+            self.organizationSlug = organizationSlug
+            self.customScopes = customScopes
+            self.providerParams = providerParams
         }
 
         public func startUrl(_ providerName: String) throws -> URL {
-            guard let publicToken = StytchClient.instance.configuration?.publicToken else {
+            guard let publicToken = StytchB2BClient.instance.configuration?.publicToken else {
                 throw StytchSDKError.consumerSDKNotConfigured
             }
 
             let queryParameters: [(String, String?)] = [
-                ("code_challenge", try StytchClient.generateAndStorePKCE(keychainItem: .codeVerifierPKCE).challenge),
+                ("pkce_code_challenge", try StytchB2BClient.generateAndStorePKCE(keychainItem: .codeVerifierPKCE).challenge),
                 ("public_token", publicToken),
+                ("organization_id", organizationId),
+                ("slug", organizationSlug),
+                ("custom_scopes", customScopes?.joined(separator: " ")),
+                ("provider_params", providerParams?.toURLParameters()),
                 ("login_redirect_url", loginRedirectUrl?.absoluteString),
                 ("signup_redirect_url", signupRedirectUrl?.absoluteString),
-                ("custom_scopes", customScopes?.joined(separator: " ")),
             ]
 
             let domain = Current.localStorage.stytchDomain(publicToken)
-            guard let url = URL(string: "https://\(domain)/v1/public/oauth/\(providerName)/start")?.appending(queryParameters: queryParameters) else {
+            guard let url = URL(string: "https://\(domain)/v1/b2b/public/oauth/\(providerName)/start")?.appending(queryParameters: queryParameters) else {
                 throw StytchSDKError.invalidStartURL
             }
 
@@ -89,27 +123,10 @@ public extension StytchClient.OAuth.ThirdParty {
     }
 }
 
-public extension StytchClient.OAuth.ThirdParty {
+public extension StytchB2BClient.OAuth.ThirdParty {
     enum Provider: String, CaseIterable, Codable {
-        case amazon
-        case bitbucket
-        case coinbase
-        case discord
-        case facebook
-        case figma
-        case github
-        case gitlab
         case google
-        case linkedin
         case microsoft
-        case salesforce
-        case slack
-        case snapchat
-        case spotify
-        case tiktok
-        case twitch
-        case twitter
-        case yahoo
     }
 }
 #endif

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public extension StytchB2BClient {
+    /// The interface for interacting with OAuth products.
+    static var oauth: OAuth {
+        .init(router: router.scopedRouter {
+            $0.oauthRoute
+        })
+    }
+}
+
+public extension StytchB2BClient {
+    struct OAuth {
+        let router: NetworkingRouter<StytchB2BClient.OAuthRoute>
+
+        @Dependency(\.keychainClient) private var keychainClient
+
+        // sourcery: AsyncVariants
+        /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
+        public func authenticate(parameters: AuthenticateParameters) async throws -> B2BAuthenticateResponse {
+            guard let codeVerifier: String = try keychainClient.get(.codeVerifierPKCE) else {
+                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "oauth_failure", error: StytchSDKError.missingPKCE))
+                throw StytchSDKError.missingPKCE
+            }
+            do {
+                let result = try await router.post(
+                    to: .authenticate,
+                    parameters: CodeVerifierParameters(codingPrefix: .pkce, codeVerifier: codeVerifier, wrapped: parameters)
+                ) as B2BAuthenticateResponse
+                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "oauth_success"))
+                return result
+            } catch {
+                try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "oauth_failure", error: error))
+                throw error
+            }
+        }
+    }
+}
+
+public extension StytchB2BClient.OAuth {
+    struct AuthenticateParameters: Encodable {
+        let oauthToken: String
+        let sessionDurationMinutes: Minutes
+        let locale: String?
+
+        public init(
+            oauthToken: String,
+            sessionDurationMinutes: Minutes = .defaultSessionDuration,
+            locale: String? = nil
+        ) {
+            self.oauthToken = oauthToken
+            self.sessionDurationMinutes = sessionDurationMinutes
+            self.locale = locale
+        }
+    }
+}
+
+#if !os(watchOS)
+public extension StytchB2BClient.OAuth {
+    /// The interface for authenticating a user with Google.
+    var google: ThirdParty {
+        .init(provider: .google)
+    }
+
+    /// The interface for authenticating a user with Microsoft.
+    var microsoft: ThirdParty {
+        .init(provider: .microsoft)
+    }
+}
+#endif

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
@@ -12,6 +12,7 @@ extension StytchB2BClient {
         case totp(TOTPRoute)
         case otp(OTPRoute)
         case recoveryCodes(RecoveryCodesRoute)
+        case oauthRoute(OAuthRoute)
 
         var path: Path {
             let (base, next) = routeComponents
@@ -44,6 +45,8 @@ extension StytchB2BClient {
                 return ("otps", route)
             case let .recoveryCodes(route):
                 return ("recovery_codes", route)
+            case let .oauthRoute(route):
+                return ("oauth", route)
             }
         }
     }
@@ -329,6 +332,31 @@ extension StytchB2BClient {
 
         var path: Path {
             .init(rawValue: rawValue)
+        }
+    }
+
+    enum OAuthRoute: RouteType {
+        case authenticate
+        case discoveryRoute(DiscoveryRoute)
+
+        var path: Path {
+            switch self {
+            case .authenticate:
+                return "authenticate"
+            case let .discoveryRoute(route):
+                return "discovery".appendingPath(route.path)
+            }
+        }
+
+        enum DiscoveryRoute: RouteType {
+            case authenticate
+
+            var path: Path {
+                switch self {
+                case .authenticate:
+                    return "authenticate"
+                }
+            }
         }
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -89,6 +89,16 @@ public struct StytchB2BClient: StytchClientType {
                 try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
             return try await .handled(response: .auth(sso.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
+        case .oauth:
+            Task {
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+            }
+            return try await .handled(response: .auth(oauth.authenticate(parameters: .init(oauthToken: token, sessionDurationMinutes: sessionDuration))))
+        case .discoveryOauth:
+            Task {
+                try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
+            }
+            return try await .handled(response: .discoveryOauth(oauth.discovery.authenticate(parameters: .init(discoveryOauthToken: token))))
         #endif
         }
     }
@@ -117,6 +127,8 @@ public extension StytchB2BClient {
         case multiTenantPasswords = "multi_tenant_passwords"
         #if !os(watchOS)
         case sso
+        case oauth
+        case discoveryOauth = "discovery_oauth"
         #endif
     }
 
@@ -124,5 +136,8 @@ public extension StytchB2BClient {
     enum DeeplinkResponse {
         case auth(B2BAuthenticateResponse)
         case discovery(StytchB2BClient.MagicLinks.DiscoveryAuthenticateResponse)
+        #if !os(watchOS)
+        case discoveryOauth(StytchB2BClient.OAuth.Discovery.DiscoveryAuthenticateResponse)
+        #endif
     }
 }

--- a/Sources/StytchCore/WebAuthenticationSessionClient/WebAuthenticationSessionClientConfiguration.swift
+++ b/Sources/StytchCore/WebAuthenticationSessionClient/WebAuthenticationSessionClientConfiguration.swift
@@ -1,0 +1,37 @@
+import AuthenticationServices
+import Foundation
+
+#if !os(watchOS)
+/// The dedicated parameters type for the ``start(parameters:)-p3l8`` call.
+@available(tvOS 16.0, *)
+public protocol WebAuthenticationSessionClientConfiguration {
+    var clientType: ClientType { get }
+    #if !os(tvOS)
+    var presentationContextProvider: ASWebAuthenticationPresentationContextProviding? { get }
+    #endif
+    func startUrl(_ providerName: String) throws -> URL
+    func callbackUrlScheme() throws -> String
+}
+
+@available(tvOS 16.0, *)
+extension WebAuthenticationSessionClientConfiguration {
+    func webAuthenticationSessionClientParameters(providerName: String) throws -> WebAuthenticationSessionClient.Parameters {
+        #if !os(tvOS)
+        let webAuthenticationSessionClientParameters: WebAuthenticationSessionClient.Parameters = .init(
+            url: try startUrl(providerName),
+            callbackUrlScheme: try callbackUrlScheme(),
+            presentationContextProvider: presentationContextProvider ?? WebAuthenticationSessionClient.DefaultPresentationProvider(),
+            clientType: clientType
+        )
+        return webAuthenticationSessionClientParameters
+        #else
+        let webAuthenticationSessionClientParameters: WebAuthenticationSessionClient.Parameters = .init(
+            url: try startUrl(providerName),
+            callbackUrlScheme: try callbackUrlScheme(),
+            clientType: clientType
+        )
+        return webAuthenticationSessionClientParameters
+        #endif
+    }
+}
+#endif

--- a/Sources/StytchUI/OAuthViewModel.swift
+++ b/Sources/StytchUI/OAuthViewModel.swift
@@ -35,7 +35,7 @@ extension OAuthViewModel: OAuthViewModelProtocol {
         case let .thirdParty(provider):
             if let oauth = state.config.oauth {
                 let (token, _) = try await (thirdPartyClientForTesting ?? provider.client).start(
-                    parameters: .init(loginRedirectUrl: oauth.loginRedirectUrl, signupRedirectUrl: oauth.signupRedirectUrl)
+                    configuration: .init(loginRedirectUrl: oauth.loginRedirectUrl, signupRedirectUrl: oauth.signupRedirectUrl)
                 )
                 let response = try await oAuthProvider.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))
                 StytchUIClient.onAuthCallback?(response)

--- a/StytchDemo/B2BWorkbench/SceneDelegate.swift
+++ b/StytchDemo/B2BWorkbench/SceneDelegate.swift
@@ -31,7 +31,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     case .auth:
                         print("auth response: \(response)")
                     case let .discovery(authResponse):
-                        print("discovery authResponse: \(authResponse)")
+                        print("discovery auth response: \(authResponse)")
+                    case let .discoveryOauth(authResponse):
+                        print("discovery oauth response: \(authResponse)")
                     }
                 case let .manualHandlingRequired(_, token):
                     if let navigationController = window?.rootViewController as? UINavigationController,

--- a/StytchDemo/B2BWorkbench/ViewControllers/AuthHomeViewController.swift
+++ b/StytchDemo/B2BWorkbench/ViewControllers/AuthHomeViewController.swift
@@ -51,6 +51,10 @@ final class AuthHomeViewController: UIViewController {
         self?.navigationController?.pushViewController(RecoveryCodesViewController(), animated: true)
     })
 
+    lazy var oauthButton: UIButton = .init(title: "OAuth", primaryAction: .init { [weak self] _ in
+        self?.navigationController?.pushViewController(OAuthViewController(), animated: true)
+    })
+
     func saveOrgID() {
         UserDefaults.standard.set(orgIdTextField.text, forKey: Constants.orgIdDefaultsKey)
     }
@@ -82,6 +86,7 @@ final class AuthHomeViewController: UIViewController {
         stackView.addArrangedSubview(totpButton)
         stackView.addArrangedSubview(otpButton)
         stackView.addArrangedSubview(recoveryCodesButton)
+        stackView.addArrangedSubview(oauthButton)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/StytchDemo/B2BWorkbench/ViewControllers/AuthMethodControllers/OAuthViewController.swift
+++ b/StytchDemo/B2BWorkbench/ViewControllers/AuthMethodControllers/OAuthViewController.swift
@@ -1,0 +1,125 @@
+import StytchCore
+import UIKit
+
+final class OAuthViewController: UIViewController {
+    let stackView = UIStackView.stytchB2BStackView()
+
+    lazy var startButton: UIButton = .init(title: "Start", primaryAction: .init { [weak self] _ in
+        self?.start()
+    })
+
+    lazy var authenticateButton: UIButton = .init(title: "Authenticate", primaryAction: .init { [weak self] _ in
+        self?.authenticate()
+    })
+
+    lazy var discoveryStartButton: UIButton = .init(title: "Discovery Start", primaryAction: .init { [weak self] _ in
+        self?.discoveryStart()
+    })
+
+    lazy var discoveryAuthenticateButton: UIButton = .init(title: "Discovery Authenticate", primaryAction: .init { [weak self] _ in
+        self?.discoveryAuthenticate()
+    })
+
+    var token: String?
+    var discoveryToken: String?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "OAuth"
+        view.backgroundColor = .systemBackground
+
+        view.addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+
+        stackView.addArrangedSubview(startButton)
+        stackView.addArrangedSubview(authenticateButton)
+        stackView.addArrangedSubview(discoveryStartButton)
+        stackView.addArrangedSubview(discoveryAuthenticateButton)
+    }
+
+    func start() {
+        guard let organizationId = organizationId else {
+            presentAlertWithTitle(alertTitle: "No organization ID.")
+            return
+        }
+
+        guard let url = URL(string: "B2BWorkbench://auth") else {
+            return
+        }
+
+        let configuraiton = StytchB2BClient.OAuth.ThirdParty.WebAuthenticationConfiguration(
+            loginRedirectUrl: url,
+            signupRedirectUrl: url,
+            organizationId: organizationId,
+            customScopes: nil,
+            providerParams: nil
+        )
+
+        Task {
+            do {
+                let (token, url) = try await StytchB2BClient.oauth.google.start(configuration: configuraiton)
+                self.token = token
+                presentAlertAndLogMessage(description: "oauth start success!", object: (token, url))
+            } catch {
+                presentAlertAndLogMessage(description: "oauth start error", object: error)
+            }
+        }
+    }
+
+    func authenticate() {
+        guard let token = token else {
+            return
+        }
+
+        Task {
+            do {
+                let response = try await StytchB2BClient.oauth.authenticate(parameters: .init(oauthToken: token, sessionDurationMinutes: .defaultSessionDuration, locale: nil))
+                presentAlertAndLogMessage(description: "oauth authenticate success!", object: response)
+            } catch {
+                presentAlertAndLogMessage(description: "oauth authenticate error", object: error)
+            }
+        }
+    }
+
+    func discoveryStart() {
+        guard let url = URL(string: "B2BWorkbench://auth") else {
+            return
+        }
+
+        let configuraiton = StytchB2BClient.OAuth.ThirdParty.Discovery.WebAuthenticationConfiguration(
+            discoveryRedirectUrl: url,
+            customScopes: nil,
+            providerParams: nil
+        )
+
+        Task {
+            do {
+                let (token, url) = try await StytchB2BClient.oauth.google.discovery.start(configuration: configuraiton)
+                self.discoveryToken = token
+                presentAlertAndLogMessage(description: "oauth discovery start success!", object: (token, url))
+            } catch {
+                presentAlertAndLogMessage(description: "oauth discovery start error", object: error)
+            }
+        }
+    }
+
+    func discoveryAuthenticate() {
+        guard let token = discoveryToken else {
+            return
+        }
+
+        Task {
+            do {
+                let response = try await StytchB2BClient.oauth.discovery.authenticate(parameters: .init(discoveryOauthToken: token))
+                presentAlertAndLogMessage(description: "oauth discovery authenticate success!", object: response)
+            } catch {
+                presentAlertAndLogMessage(description: "oauth discovery authenticate error", object: error)
+            }
+        }
+    }
+}

--- a/StytchDemo/B2BWorkbench/ViewControllers/AuthMethodControllers/SSOViewController.swift
+++ b/StytchDemo/B2BWorkbench/ViewControllers/AuthMethodControllers/SSOViewController.swift
@@ -92,7 +92,7 @@ final class SSOViewController: UIViewController {
         Task {
             do {
                 let (token, _) = try await StytchB2BClient.sso.start(
-                    parameters: .init(
+                    configuration: .init(
                         connectionId: connectionId,
                         loginRedirectUrl: redirectUrl,
                         signupRedirectUrl: redirectUrl

--- a/StytchDemo/Client/Shared/OAuthAuthenticationView.swift
+++ b/StytchDemo/Client/Shared/OAuthAuthenticationView.swift
@@ -43,7 +43,7 @@ struct OAuthAuthenticationView: View {
             Task {
                 do {
                     let (token, _) = try await provider.interface.start(
-                        parameters: .init(
+                        configuration: .init(
                             loginRedirectUrl: URL(string: "stytch-authentication://login")!,
                             signupRedirectUrl: URL(string: "stytch-authentication://signup")!
                         )

--- a/StytchDemo/StytchDemo.xcodeproj/project.pbxproj
+++ b/StytchDemo/StytchDemo.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		7478F7DC2BF6467900BCB233 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7478F7DA2BF6467900BCB233 /* Extensions.swift */; };
 		749F88862BFBD63E00D7F386 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 749F88852BFBD63E00D7F386 /* Launch Screen.storyboard */; };
 		74A2D1912C21FDF8007F8F20 /* OTPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A2D1902C21FDF8007F8F20 /* OTPViewController.swift */; };
+		74DD38CB2C2A2ABA00BEB0DD /* OAuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DD38CA2C2A2ABA00BEB0DD /* OAuthViewController.swift */; };
 		74F0088D2C24C05100E0F863 /* RecoveryCodesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F0088C2C24C05000E0F863 /* RecoveryCodesViewController.swift */; };
 		74F3702A2C07B7F400AED9C9 /* OrganizationMemberViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F370292C07B7F400AED9C9 /* OrganizationMemberViewController.swift */; };
 /* End PBXBuildFile section */
@@ -184,6 +185,7 @@
 		749F88852BFBD63E00D7F386 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		74A2D1902C21FDF8007F8F20 /* OTPViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPViewController.swift; sourceTree = "<group>"; };
 		74D1157E2BFBDFFD002EAB79 /* B2BWorkbench-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "B2BWorkbench-Bridging-Header.h"; sourceTree = "<group>"; };
+		74DD38CA2C2A2ABA00BEB0DD /* OAuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthViewController.swift; sourceTree = "<group>"; };
 		74F0088C2C24C05000E0F863 /* RecoveryCodesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryCodesViewController.swift; sourceTree = "<group>"; };
 		74F370292C07B7F400AED9C9 /* OrganizationMemberViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationMemberViewController.swift; sourceTree = "<group>"; };
 		7763D5AF2B58698F00F00737 /* StytchUIDemo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StytchUIDemo.entitlements; sourceTree = "<group>"; };
@@ -325,6 +327,7 @@
 				22ABFAB829F7628E00927518 /* DiscoveryViewController.swift */,
 				2254779329A05C6A003DF229 /* MagicLinksViewController.swift */,
 				2254779729A05D08003DF229 /* MemberViewController.swift */,
+				74DD38CA2C2A2ABA00BEB0DD /* OAuthViewController.swift */,
 				2254779929A05D37003DF229 /* OrganizationViewController.swift */,
 				74F370292C07B7F400AED9C9 /* OrganizationMemberViewController.swift */,
 				74A2D1902C21FDF8007F8F20 /* OTPViewController.swift */,
@@ -726,6 +729,7 @@
 				2254779829A05D08003DF229 /* MemberViewController.swift in Sources */,
 				2254779629A05C93003DF229 /* Constants.swift in Sources */,
 				74F0088D2C24C05100E0F863 /* RecoveryCodesViewController.swift in Sources */,
+				74DD38CB2C2A2ABA00BEB0DD /* OAuthViewController.swift in Sources */,
 				2231531D299EE16D00BA9126 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/StytchCoreTests/B2BOAuthTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOAuthTestCase.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import StytchCore
+
+final class B2BOAuthTestCase: BaseTestCase {
+    @available(tvOS 16.0, *)
+    func testAuthenticate() async throws {
+        networkInterceptor.responses {
+            B2BAuthenticateResponse.mock
+        }
+
+        Current.timer = { _, _, _ in .init() }
+
+        _ = try StytchB2BClient.generateAndStorePKCE(keychainItem: .codeVerifierPKCE)
+        _ = try await StytchB2BClient.oauth.authenticate(parameters: .init(oauthToken: "i-am-token", sessionDurationMinutes: 12))
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/b2b/oauth/authenticate",
+            method: .post([
+                "session_duration_minutes": 12,
+                "pkce_code_verifier": "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741",
+                "oauth_token": "i-am-token",
+            ])
+        )
+    }
+
+    func testAuthenticateFailsWithPKCE() async throws {
+        await XCTAssertThrowsErrorAsync(
+            try await StytchB2BClient.oauth.authenticate(parameters: .init(oauthToken: "i-am-token", sessionDurationMinutes: 12)),
+            StytchSDKError.missingPKCE
+        )
+    }
+
+    @available(tvOS 16.0, *)
+    func testDiscoveryAuthenticate() async throws {
+        networkInterceptor.responses {
+            StytchB2BClient.OAuth.Discovery.DiscoveryAuthenticateResponse(
+                requestId: "1234",
+                statusCode: 200,
+                wrapped: .mock
+            )
+        }
+
+        Current.timer = { _, _, _ in .init() }
+
+        _ = try StytchB2BClient.generateAndStorePKCE(keychainItem: .codeVerifierPKCE)
+        _ = try await StytchB2BClient.oauth.discovery.authenticate(parameters: .init(discoveryOauthToken: "i-am-token"))
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://web.stytch.com/sdk/v1/b2b/oauth/discovery/authenticate",
+            method: .post([
+                "pkce_code_verifier": "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741",
+                "discovery_oauth_token": "i-am-token",
+            ])
+        )
+    }
+
+    func testDiscoveryAuthenticateFailsWithPKCE() async throws {
+        await XCTAssertThrowsErrorAsync(
+            try await StytchB2BClient.oauth.discovery.authenticate(parameters: .init(discoveryOauthToken: "i-am-token")),
+            StytchSDKError.missingPKCE
+        )
+    }
+}
+
+extension StytchB2BClient.OAuth.Discovery.DiscoveryAuthenticateResponseData {
+    static var mock: Self {
+        .init(
+            intermediateSessionToken: "",
+            emailAddress: "",
+            discoveredOrganizations: []
+        )
+    }
+}

--- a/Tests/StytchCoreTests/B2BSSOTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSSOTestCase.swift
@@ -5,12 +5,12 @@ import XCTest
 final class B2BSSOTestCase: BaseTestCase {
     @available(tvOS 16.0, *)
     func testStart() async throws {
-        Current.webAuthSessionClient = .init { params in
+        Current.webAuthenticationSessionClient = .init { params in
             ("random-token", try XCTUnwrap(URL(string: "\(params.callbackUrlScheme)://something")))
         }
         var baseUrl = try XCTUnwrap(URL(string: "https://blah"))
 
-        let createParams: (URL) -> StytchB2BClient.SSO.StartParameters = { url in
+        let createConfiguration: (URL) -> StytchB2BClient.SSO.WebAuthenticationConfiguration = { url in
             .init(
                 connectionId: "connection-id:123",
                 loginRedirectUrl: url.appendingPathComponent("/login"),
@@ -18,18 +18,18 @@ final class B2BSSOTestCase: BaseTestCase {
             )
         }
 
-        let invalidStartParams = createParams(baseUrl)
+        let invalidStartParams = createConfiguration(baseUrl)
 
         await XCTAssertThrowsErrorAsync(
-            try await StytchB2BClient.sso.start(parameters: invalidStartParams),
+            try await StytchB2BClient.sso.start(configuration: invalidStartParams),
             StytchSDKError.invalidRedirectScheme
         )
 
         baseUrl = try XCTUnwrap(URL(string: "custom-scheme://blah"))
 
-        let validStartParams = createParams(baseUrl)
+        let validStartParams = createConfiguration(baseUrl)
 
-        let (token, url) = try await StytchB2BClient.sso.start(parameters: validStartParams)
+        let (token, url) = try await StytchB2BClient.sso.start(configuration: validStartParams)
         XCTAssertEqual(token, "random-token")
         XCTAssertEqual(url.absoluteString, "custom-scheme://something")
     }

--- a/Tests/StytchCoreTests/XCTestHelpers.swift
+++ b/Tests/StytchCoreTests/XCTestHelpers.swift
@@ -1,7 +1,7 @@
 import StytchCore
 import XCTest
 
-func XCTAssertThrowsErrorAsync<T, R>(
+func XCTAssertThrowsErrorAsync<T, R: Error>(
     _ expression: @autoclosure () async throws -> T,
     _ errorThrown: @autoclosure () -> R,
     _ message: @autoclosure () -> String = "This method should fail",

--- a/Tests/StytchUIUnitTests/Spies.swift
+++ b/Tests/StytchUIUnitTests/Spies.swift
@@ -139,7 +139,7 @@ class ThirdPartyOAuthSpy: ThirdPartyOAuthProviderProtocol {
         self.callback = callback
     }
 
-    func start(parameters _: StytchClient.OAuth.ThirdParty.WebAuthSessionStartParameters) async throws -> (token: String, url: URL) {
+    func start(configuration _: StytchClient.OAuth.ThirdParty.WebAuthenticationConfiguration) async throws -> (token: String, url: URL) {
         callback(.oauthThirdPartyStart)
         // swiftlint:disable:next force_unwrapping
         return ("", .init(string: "oauth-url")!)


### PR DESCRIPTION
Linear Ticket: [SDK-1477](https://linear.app/stytch/issue/SDK-1477/[ios]-[b2b]-add-oauth-client)

## Changes:

1. Create `StytchB2BClient.OAuth` which adds flows for authenticate and discovery authenticate.
2. Also massively refactor any flow that requires authenticating with a web view and centralize all functionality with a newly defined protocol for `WebAuthenticationSessionClientConfiguration`.
4. The `WebAuthenticationSessionClientConfiguration` is able to create an instance of `WebAuthenticationSessionClient.Parameters` which is the object that directs the actual authentication flow.
5. I then refactored B2C OAuth and B2B SSO in addition to adding this new configuration object to the newly created B2B O Auth flows.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A