### PR TITLE
[SDK-1726]: Require non-null session_token and session_jwt in updateSession

### DIFF
--- a/Sources/StytchCore/StytchClientCommon/Models/SessionToken.swift
+++ b/Sources/StytchCore/StytchClientCommon/Models/SessionToken.swift
@@ -43,3 +43,23 @@ public struct SessionToken: Equatable {
         .init(kind: .opaque, value: value)
     }
 }
+
+/// A public interface to require the caller to explicitly pass one of each type of non nil token in order to update a session.
+public struct SessionTokens {
+    let jwt: SessionToken
+    let opaque: SessionToken
+
+    init?(jwt: SessionToken, opaque: SessionToken) {
+        if jwt.kind != .jwt, opaque.kind != .opaque {
+            return nil
+        }
+
+        self.jwt = jwt
+        self.opaque = opaque
+    }
+
+    func updatePersistentStorage(sessionStorage: SessionStorage) {
+        sessionStorage.updatePersistentStorage(token: jwt)
+        sessionStorage.updatePersistentStorage(token: opaque)
+    }
+}

--- a/Sources/StytchCore/StytchClientCommon/Sessions/Sessions.swift
+++ b/Sources/StytchCore/StytchClientCommon/Sessions/Sessions.swift
@@ -19,9 +19,9 @@ public struct Sessions<AuthResponseType: Decodable> {
 
     /// If your app has cookies disabled or simply receives updated session tokens from your backend via means other than
     /// `Set-Cookie` headers, you must call this method after receiving the updated tokens to ensure the `StytchClient`
-    /// and persistent storage are kept up-to-date. You should include both the opaque token and the jwt.
-    public func update(sessionTokens tokens: [SessionToken]) {
-        tokens.forEach(sessionStorage.updatePersistentStorage)
+    /// and persistent storage are kept up-to-date. You are required to include both the opaque token and the jwt.
+    public func update(sessionTokens: SessionTokens) {
+        sessionTokens.updatePersistentStorage(sessionStorage: sessionStorage)
     }
 
     // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)

--- a/Tests/StytchCoreTests/B2BSessionsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSessionsTestCase.swift
@@ -54,9 +54,12 @@ final class B2BSessionsTestCase: BaseTestCase {
         XCTAssertNil(StytchB2BClient.sessions.sessionToken)
         XCTAssertNil(StytchB2BClient.sessions.sessionJwt)
 
-        StytchB2BClient.sessions.update(sessionTokens: [.opaque("token"), .jwt("jwt")])
-
-        XCTAssertEqual(StytchB2BClient.sessions.sessionToken, .opaque("token"))
-        XCTAssertEqual(StytchB2BClient.sessions.sessionJwt, .jwt("jwt"))
+        if let tokens = SessionTokens(jwt: .jwt("jwt"), opaque: .opaque("token")) {
+            StytchB2BClient.sessions.update(sessionTokens: tokens)
+            XCTAssertEqual(StytchB2BClient.sessions.sessionToken, .opaque("token"))
+            XCTAssertEqual(StytchB2BClient.sessions.sessionJwt, .jwt("jwt"))
+        } else {
+            XCTFail("SessionTokens should not be nil")
+        }
     }
 }

--- a/Tests/StytchCoreTests/SessionsTestCase.swift
+++ b/Tests/StytchCoreTests/SessionsTestCase.swift
@@ -91,9 +91,12 @@ final class SessionsTestCase: BaseTestCase {
         XCTAssertNil(StytchClient.sessions.sessionToken)
         XCTAssertNil(StytchClient.sessions.sessionJwt)
 
-        StytchClient.sessions.update(sessionTokens: [.opaque("token"), .jwt("jwt")])
-
-        XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("token"))
-        XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("jwt"))
+        if let tokens = SessionTokens(jwt: .jwt("jwt"), opaque: .opaque("token")) {
+            StytchClient.sessions.update(sessionTokens: tokens)
+            XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("token"))
+            XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("jwt"))
+        } else {
+            XCTFail("SessionTokens should not be nil")
+        }
     }
 }


### PR DESCRIPTION
Linear Ticket: [SDK-1726](https://linear.app/stytch/issue/SDK-1726/[ios]-require-non-null-session-token-and-session-jwt-in-updatesession)

## Changes:

1. Create the `SessionTokens` (notice the plural) to enforce updating with both tokens. It is impossible to create this object without one of each token type.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A