### PR TITLE
[SDK-1723] Fix dependencies to an exact version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
         .library(name: "StytchUI", targets: ["StytchUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/marmelroy/PhoneNumberKit", .upToNextMinor(from: "3.5.9")),
-        .package(url: "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk", from: "18.4.0"),
+        .package(url: "https://github.com/marmelroy/PhoneNumberKit", .exact("3.5.9")),
+        .package(url: "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk", .exact("18.4.0")),
     ],
     targets: [
         .target(

--- a/StytchDemo/StytchDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StytchDemo/StytchDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/vapor/jwt-kit.git",
         "state": {
           "branch": null,
-          "revision": "87ce13a1df913ba4d51cf00606df7ef24d455571",
-          "version": "4.7.0"
+          "revision": "c2595b9ad7f512d7f334830b4df1fed6e917946a",
+          "version": "4.13.4"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/marmelroy/PhoneNumberKit",
         "state": {
           "branch": null,
-          "revision": "0fd43eb71d215afd0f9453d8e94200c9d6faf28a",
-          "version": "3.5.10"
+          "revision": "6edd6e38a30aec087cb97f7377edf876c29a427e",
+          "version": "3.5.9"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "92a04c10fc5ce0504f8396aac7392126033e547c",
-          "version": "2.2.2"
+          "revision": "46072478ca365fe48370993833cb22de9b41567f",
+          "version": "3.5.2"
         }
       },
       {


### PR DESCRIPTION
Linear Ticket: [SDK-1723](https://linear.app/stytch/issue/SDK-1723/[ios]-specify-the-exact-version-number-of-the-dependencies)

## Changes:

1. In the `Package.swift` file we now fix the version of the dependencies using `.exact`.
2. We will now need to manually update the version of the dependencies.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A