### PR TITLE
[SDK-1827] Conditionally use PKCE in magic links authenticate

### DIFF
--- a/Sources/StytchCore/Generated/StytchB2BClient.MagicLinks.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.MagicLinks.authenticate+AsyncVariants.generated.swift
@@ -4,7 +4,8 @@ import Combine
 import Foundation
 
 public extension StytchB2BClient.MagicLinks {
-    /// Wraps the magic link [authenticate](https://stytch.com/docs/b2b/api/authenticate-magic-link) API endpoint which validates the magic link token passed in. If this method succeeds, the member will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
+    /// Wraps the magic link [authenticate](https://stytch.com/docs/b2b/api/authenticate-magic-link) API endpoint which validates the magic link token passed in.
+    /// If this method succeeds, the member will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
     func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
         Task {
             do {
@@ -15,7 +16,8 @@ public extension StytchB2BClient.MagicLinks {
         }
     }
 
-    /// Wraps the magic link [authenticate](https://stytch.com/docs/b2b/api/authenticate-magic-link) API endpoint which validates the magic link token passed in. If this method succeeds, the member will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
+    /// Wraps the magic link [authenticate](https://stytch.com/docs/b2b/api/authenticate-magic-link) API endpoint which validates the magic link token passed in.
+    /// If this method succeeds, the member will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
     func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<B2BAuthenticateResponse, Error> {
         return Deferred {
             Future({ promise in

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+MagicLinks.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+MagicLinks.swift
@@ -18,14 +18,23 @@ public extension StytchB2BClient {
         @Dependency(\.keychainClient) private var keychainClient
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
-        /// Wraps the magic link [authenticate](https://stytch.com/docs/b2b/api/authenticate-magic-link) API endpoint which validates the magic link token passed in. If this method succeeds, the member will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
+        /// Wraps the magic link [authenticate](https://stytch.com/docs/b2b/api/authenticate-magic-link) API endpoint which validates the magic link token passed in.
+        /// If this method succeeds, the member will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
         public func authenticate(parameters: AuthenticateParameters) async throws -> B2BAuthenticateResponse {
-            guard let codeVerifier: String = try? keychainClient.get(.codeVerifierPKCE) else { throw StytchSDKError.missingPKCE }
-
-            return try await router.post(
-                to: .authenticate,
-                parameters: CodeVerifierParameters(codingPrefix: .pkce, codeVerifier: codeVerifier, wrapped: parameters)
-            )
+            // For authenticating if loginOrSignup was called
+            if let codeVerifier: String = try? keychainClient.get(.codeVerifierPKCE) {
+                return try await router.post(
+                    to: .authenticate,
+                    parameters: CodeVerifierParameters(codingPrefix: .pkce, codeVerifier: codeVerifier, wrapped: parameters)
+                )
+            }
+            // For authenticating if inviteSend was called, in which case we will not have a PKCE challenge code
+            else {
+                return try await router.post(
+                    to: .authenticate,
+                    parameters: parameters
+                )
+            }
         }
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)

--- a/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
@@ -104,11 +104,6 @@ final class B2BMagicLinksTestCase: BaseTestCase {
             sessionDuration: 15
         )
 
-        await XCTAssertThrowsErrorAsync(
-            try await StytchB2BClient.magicLinks.authenticate(parameters: parameters),
-            StytchSDKError.missingPKCE
-        )
-
         try Current.keychainClient.set(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
 
         XCTAssertNotNil(try Current.keychainClient.get(.codeVerifierPKCE))
@@ -121,7 +116,7 @@ final class B2BMagicLinksTestCase: BaseTestCase {
         XCTAssertEqual(response.member.id, authResponse.member.id)
         XCTAssertEqual(response.sessionToken, "xyzasdf")
         XCTAssertEqual(response.sessionJwt, "i'mvalidjson")
-        XCTAssertTrue(Calendar.current.isDate(response.memberSession.expiresAt, equalTo: authResponse.memberSession.expiresAt, toGranularity: .nanosecond))
+        XCTAssertTrue(Calendar.current.isDate(response.memberSession.expiresAt, equalTo: authResponse.memberSession.expiresAt, toGranularity: .second))
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],

--- a/Tests/StytchCoreTests/MagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/MagicLinksTestCase.swift
@@ -133,7 +133,7 @@ final class MagicLinksTestCase: BaseTestCase {
         XCTAssertEqual(response.user.id, authResponse.user.id)
         XCTAssertEqual(response.sessionToken, "hello_session")
         XCTAssertEqual(response.sessionJwt, "jwt_for_me")
-        XCTAssertTrue(Calendar.current.isDate(response.session.expiresAt, equalTo: authResponse.session.expiresAt, toGranularity: .nanosecond))
+        XCTAssertTrue(Calendar.current.isDate(response.session.expiresAt, equalTo: authResponse.session.expiresAt, toGranularity: .second))
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],


### PR DESCRIPTION
Linear Ticket: [SDK-1827](https://linear.app/stytch/issue/SDK-1827/[ios]-magic-links-authenticate-should-optionally-use-the-pkce-code)

## Changes:

1.  `b2b/magic_links/authenticate` should use PKCE code challenge if link was created by login or create because the assumption is that its on the same device, but not use the PKCE code challenge if it was sent via the invite endpoint because that would be from a separate device.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A