### PR TITLE
[SDK-1526] Add MFA to B2B (Phase 1)

### DIFF
--- a/Sources/StytchCore/Generated/StytchB2BClient.MagicLinks.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.MagicLinks.authenticate+AsyncVariants.generated.swift
@@ -6,7 +6,7 @@ import Foundation
 public extension StytchB2BClient.MagicLinks {
     /// Wraps the magic link [authenticate](https://stytch.com/docs/b2b/api/authenticate-magic-link) API endpoint which validates the magic link token passed in.
     /// If this method succeeds, the member will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
-    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
+    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<B2BMFAAuthenticateResponse>) {
         Task {
             do {
                 completion(.success(try await authenticate(parameters: parameters)))
@@ -18,7 +18,7 @@ public extension StytchB2BClient.MagicLinks {
 
     /// Wraps the magic link [authenticate](https://stytch.com/docs/b2b/api/authenticate-magic-link) API endpoint which validates the magic link token passed in.
     /// If this method succeeds, the member will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
-    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<B2BAuthenticateResponse, Error> {
+    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<B2BMFAAuthenticateResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/Generated/StytchB2BClient.Passwords.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.Passwords.authenticate+AsyncVariants.generated.swift
@@ -11,7 +11,7 @@ public extension StytchB2BClient.Passwords {
     ///   a. We force a password reset to ensure that the member is the legitimate owner of the email address, and not a malicious actor abusing the compromised credentials.
     /// 2. The member used email based authentication (e.g. Magic Links, Google OAuth) for the first time, and had not previously verified their email address for password based login.
     ///   a. We force a password reset in this instance in order to safely deduplicate the account by email address, without introducing the risk of a pre-hijack account-takeover attack.
-    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
+    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<B2BMFAAuthenticateResponse>) {
         Task {
             do {
                 completion(.success(try await authenticate(parameters: parameters)))
@@ -28,7 +28,7 @@ public extension StytchB2BClient.Passwords {
     ///   a. We force a password reset to ensure that the member is the legitimate owner of the email address, and not a malicious actor abusing the compromised credentials.
     /// 2. The member used email based authentication (e.g. Magic Links, Google OAuth) for the first time, and had not previously verified their email address for password based login.
     ///   a. We force a password reset in this instance in order to safely deduplicate the account by email address, without introducing the risk of a pre-hijack account-takeover attack.
-    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<B2BAuthenticateResponse, Error> {
+    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<B2BMFAAuthenticateResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/Generated/StytchB2BClient.Passwords.resetByEmail+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.Passwords.resetByEmail+AsyncVariants.generated.swift
@@ -7,7 +7,7 @@ public extension StytchB2BClient.Passwords {
     /// Reset the member’s password and authenticate them. This endpoint checks that the magic link token is valid, hasn’t expired, or already been used.
     /// 
     /// The provided password needs to meet our password strength requirements, which can be checked in advance with the password strength endpoint. If the token and password are accepted, the password is securely stored for future authentication and the member is authenticated.
-    func resetByEmail(parameters: ResetByEmailParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
+    func resetByEmail(parameters: ResetByEmailParameters, completion: @escaping Completion<B2BMFAAuthenticateResponse>) {
         Task {
             do {
                 completion(.success(try await resetByEmail(parameters: parameters)))
@@ -20,7 +20,7 @@ public extension StytchB2BClient.Passwords {
     /// Reset the member’s password and authenticate them. This endpoint checks that the magic link token is valid, hasn’t expired, or already been used.
     /// 
     /// The provided password needs to meet our password strength requirements, which can be checked in advance with the password strength endpoint. If the token and password are accepted, the password is securely stored for future authentication and the member is authenticated.
-    func resetByEmail(parameters: ResetByEmailParameters) -> AnyPublisher<B2BAuthenticateResponse, Error> {
+    func resetByEmail(parameters: ResetByEmailParameters) -> AnyPublisher<B2BMFAAuthenticateResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/KeychainClient/KeychainClient+Item.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient+Item.swift
@@ -61,6 +61,7 @@ extension KeychainClient.Item {
     static let privateKeyRegistration: Self = .init(kind: .privateKey, name: "stytch_private_key_registration")
     static let sessionToken: Self = .init(kind: .token, name: SessionToken.Kind.opaque.name)
     static let sessionJwt: Self = .init(kind: .token, name: SessionToken.Kind.jwt.name)
+    static let intermediateSessionToken: Self = .init(kind: .token, name: "stytch_intermediate_session_token")
     static let codeVerifierPKCE: Self = .init(kind: .token, name: "stytch_code_verifier_pkce")
     static let codeChallengePKCE: Self = .init(kind: .token, name: "stytch_code_challenge_pkce")
 }
@@ -72,6 +73,7 @@ extension KeychainClient.Item {
             .privateKeyRegistration,
             .sessionToken,
             .sessionJwt,
+            .intermediateSessionToken,
             .codeVerifierPKCE,
             .codeChallengePKCE,
         ]

--- a/Sources/StytchCore/StytchB2BClient/Models/B2BMFAAuthenticateResponse.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/B2BMFAAuthenticateResponse.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// The concrete response type for B2B MFA `authenticate` calls.
+public typealias B2BMFAAuthenticateResponse = Response<B2BMFAAuthenticateResponseData>
+
+/// Represents the interface of responses for B2B MFA `authenticate` calls.
+public typealias B2BMFAAuthenticateResponseType = BasicResponseType & B2BMFAAuthenticateResponseDataType
+
+/// The underlying data for B2B MFA `authenticate` calls.
+public struct B2BMFAAuthenticateResponseData: Codable, B2BMFAAuthenticateResponseDataType {
+    /// The ``MemberSession`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
+    public let memberSession: MemberSession?
+    /// The current member object.
+    public let member: Member
+    /// The current organization object.
+    public let organization: Organization
+    /// The opaque token for the session. Can be used by your server to verify the validity of your session by confirming with Stytch's servers on each request.
+    public let sessionToken: String
+    /// The JWT for the session. Can be used by your server to verify the validity of your session either by checking the data included in the JWT, or by verifying with Stytch's servers as needed.
+    public let sessionJwt: String
+    ///
+    public let intermediateSessionToken: String?
+}
+
+/// The interface which a data type must conform to for all underlying data in B2B MFA `authenticate` responses.
+public protocol B2BMFAAuthenticateResponseDataType {
+    /// The ``MemberSession`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
+    var memberSession: MemberSession? { get }
+    /// The current member object.
+    var member: Member { get }
+    /// The current organization object.
+    var organization: Organization { get }
+    /// The opaque token for the session. Can be used by your server to verify the validity of your session by confirming with Stytch's servers on each request.
+    var sessionToken: String { get }
+    /// The JWT for the session. Can be used by your server to verify the validity of your session either by checking the data included in the JWT, or by verifying with Stytch's servers as needed.
+    var sessionJwt: String { get }
+    ///
+    var intermediateSessionToken: String? { get }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+MagicLinks.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+MagicLinks.swift
@@ -20,7 +20,7 @@ public extension StytchB2BClient {
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps the magic link [authenticate](https://stytch.com/docs/b2b/api/authenticate-magic-link) API endpoint which validates the magic link token passed in.
         /// If this method succeeds, the member will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
-        public func authenticate(parameters: AuthenticateParameters) async throws -> B2BAuthenticateResponse {
+        public func authenticate(parameters: AuthenticateParameters) async throws -> B2BMFAAuthenticateResponse {
             // For authenticating if loginOrSignup was called
             if let codeVerifier: String = pkcePairManager.getPKCECodePair()?.codeVerifier {
                 return try await router.post(

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP.swift
@@ -13,16 +13,38 @@ public extension StytchB2BClient {
     struct OTP {
         let router: NetworkingRouter<StytchB2BClient.OTPRoute>
 
+        @Dependency(\.sessionStorage) private var sessionStorage
+
         // sourcery: AsyncVariants
         /// Send a one-time passcode (OTP) to a user using their phone number via SMS.
         public func send(parameters: SendParameters) async throws -> BasicResponse {
-            try await router.post(to: .send, parameters: parameters)
+            if let intermediateSessionToken = sessionStorage.intermediateSessionToken {
+                return try await router.post(
+                    to: .send,
+                    parameters: IntermediateSessionTokenParameters(
+                        intermediateSessionToken: intermediateSessionToken,
+                        wrapped: parameters
+                    )
+                )
+            } else {
+                return try await router.post(to: .send, parameters: parameters)
+            }
         }
 
         // sourcery: AsyncVariants
         /// Authenticate a one-time passcode (OTP) sent to a user via SMS.
         public func authenticate(parameters: AuthenticateParameters) async throws -> B2BAuthenticateResponse {
-            try await router.post(to: .authenticate, parameters: parameters)
+            if let intermediateSessionToken = sessionStorage.intermediateSessionToken {
+                return try await router.post(
+                    to: .authenticate,
+                    parameters: IntermediateSessionTokenParameters(
+                        intermediateSessionToken: intermediateSessionToken,
+                        wrapped: parameters
+                    )
+                )
+            } else {
+                return try await router.post(to: .authenticate, parameters: parameters)
+            }
         }
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Passwords.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Passwords.swift
@@ -16,7 +16,7 @@ public extension StytchB2BClient {
         ///   a. We force a password reset to ensure that the member is the legitimate owner of the email address, and not a malicious actor abusing the compromised credentials.
         /// 2. The member used email based authentication (e.g. Magic Links, Google OAuth) for the first time, and had not previously verified their email address for password based login.
         ///   a. We force a password reset in this instance in order to safely deduplicate the account by email address, without introducing the risk of a pre-hijack account-takeover attack.
-        public func authenticate(parameters: AuthenticateParameters) async throws -> B2BAuthenticateResponse {
+        public func authenticate(parameters: AuthenticateParameters) async throws -> B2BMFAAuthenticateResponse {
             try await router.post(to: .authenticate, parameters: parameters)
         }
 
@@ -39,12 +39,12 @@ public extension StytchB2BClient {
         /// Reset the member’s password and authenticate them. This endpoint checks that the magic link token is valid, hasn’t expired, or already been used.
         ///
         /// The provided password needs to meet our password strength requirements, which can be checked in advance with the password strength endpoint. If the token and password are accepted, the password is securely stored for future authentication and the member is authenticated.
-        public func resetByEmail(parameters: ResetByEmailParameters) async throws -> B2BAuthenticateResponse {
+        public func resetByEmail(parameters: ResetByEmailParameters) async throws -> B2BMFAAuthenticateResponse {
             guard let pkcePair: PKCECodePair = pkcePairManager.getPKCECodePair() else {
                 throw StytchSDKError.missingPKCE
             }
 
-            let response: B2BAuthenticateResponse = try await router.post(
+            let response: B2BMFAAuthenticateResponse = try await router.post(
                 to: .resetByEmail(.complete),
                 parameters: CodeVerifierParameters(codeVerifier: pkcePair.codeVerifier, wrapped: parameters)
             )

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Sessions.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Sessions.swift
@@ -47,7 +47,7 @@ public struct StytchB2BClientSessions {
     /// `Set-Cookie` headers, you must call this method after receiving the updated tokens to ensure the `StytchClient`
     /// and persistent storage are kept up-to-date. You are required to include both the opaque token and the jwt.
     public func update(sessionTokens: SessionTokens) {
-        sessionTokens.updatePersistentStorage(sessionStorage: sessionStorage)
+        sessionStorage.updatePersistentStorage(tokens: sessionTokens)
     }
 
     // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -77,7 +77,7 @@ public struct StytchB2BClient: StytchClientType {
             Task {
                 try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
-            return try await .handled(response: .auth(magicLinks.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
+            return try await .handled(response: .mfauth(magicLinks.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
         case .multiTenantPasswords:
             Task {
                 try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
@@ -139,6 +139,7 @@ public extension StytchB2BClient {
     /// Wrapper around the possible types returned from the `handle(url:sessionDuration:)` function.
     enum DeeplinkResponse {
         case auth(B2BAuthenticateResponse)
+        case mfauth(B2BMFAAuthenticateResponse)
         case discovery(StytchB2BClient.MagicLinks.DiscoveryAuthenticateResponse)
         #if !os(watchOS)
         case discoveryOauth(StytchB2BClient.OAuth.Discovery.DiscoveryAuthenticateResponse)

--- a/Sources/StytchCore/StytchClient/StytchClient+Sessions.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient+Sessions.swift
@@ -57,7 +57,7 @@ public struct StytchClientSessions {
     /// `Set-Cookie` headers, you must call this method after receiving the updated tokens to ensure the `StytchClient`
     /// and persistent storage are kept up-to-date. You are required to include both the opaque token and the jwt.
     public func update(sessionTokens: SessionTokens) {
-        sessionTokens.updatePersistentStorage(sessionStorage: sessionStorage)
+        sessionStorage.updatePersistentStorage(tokens: sessionTokens)
     }
 
     // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)

--- a/Sources/StytchCore/StytchClientCommon/IntermediateSessionTokenParameters.swift
+++ b/Sources/StytchCore/StytchClientCommon/IntermediateSessionTokenParameters.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct IntermediateSessionTokenParameters<T: Encodable>: Encodable {
+    private enum CodingKeys: String, CodingKey {
+        case intermediateSessionToken
+    }
+
+    let intermediateSessionToken: String
+    let wrapped: T
+
+    init(intermediateSessionToken: String, wrapped: T) {
+        self.intermediateSessionToken = intermediateSessionToken
+        self.wrapped = wrapped
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try wrapped.encode(to: encoder)
+        try container.encode(intermediateSessionToken, forKey: .intermediateSessionToken)
+    }
+}

--- a/StytchDemo/B2BWorkbench/SceneDelegate.swift
+++ b/StytchDemo/B2BWorkbench/SceneDelegate.swift
@@ -34,6 +34,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                         print("discovery auth response: \(authResponse)")
                     case let .discoveryOauth(authResponse):
                         print("discovery oauth response: \(authResponse)")
+                    case let .mfauth(authResponse):
+                        print("mfa response: \(authResponse)")
                     }
                 case let .manualHandlingRequired(_, token):
                     if let navigationController = window?.rootViewController as? UINavigationController,

--- a/Tests/StytchCoreTests/B2BPasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BPasswordsTestCase.swift
@@ -11,7 +11,7 @@ final class B2BPasswordsTestCase: BaseTestCase {
             password: "password123",
             sessionDuration: 26
         )
-        networkInterceptor.responses { B2BAuthenticateResponse.mock }
+        networkInterceptor.responses { B2BMFAAuthenticateResponse.mock }
         Current.timer = { _, _, _ in .init() }
         _ = try await client.authenticate(parameters: authParams)
 
@@ -51,7 +51,7 @@ final class B2BPasswordsTestCase: BaseTestCase {
 
         networkInterceptor.responses {
             BasicResponse(requestId: "123", statusCode: 200)
-            B2BAuthenticateResponse.mock
+            B2BMFAAuthenticateResponse.mock
         }
         _ = try await client.resetByEmailStart(
             parameters: .init(organizationId: "org123", email: "user@stytch.com", loginUrl: nil, resetPasswordUrl: XCTUnwrap(URL(string: "https://stytch.com/reset")), resetPasswordExpiration: 15, resetPasswordTemplateId: "one-two-buckle-my-shoe")

--- a/Tests/StytchCoreTests/B2BSessionsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSessionsTestCase.swift
@@ -11,8 +11,8 @@ final class B2BSessionsTestCase: BaseTestCase {
         XCTAssertNil(StytchB2BClient.sessions.memberSession)
 
         Current.sessionStorage.updateSession(
-            .user(.mock(userId: "i_am_user")),
-            tokens: [.jwt("i'm_jwt"), .opaque("opaque_all_day")],
+            sessionType: .user(.mock(userId: "i_am_user")),
+            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day")),
             hostUrl: try XCTUnwrap(URL(string: "https://url.com"))
         )
 
@@ -34,8 +34,8 @@ final class B2BSessionsTestCase: BaseTestCase {
         Current.timer = { _, _, _ in .init() }
 
         Current.sessionStorage.updateSession(
-            .user(.mock(userId: "i_am_user")),
-            tokens: [.jwt("i'm_jwt"), .opaque("opaque_all_day")],
+            sessionType: .user(.mock(userId: "i_am_user")),
+            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day")),
             hostUrl: try XCTUnwrap(URL(string: "https://url.com"))
         )
 

--- a/Tests/StytchCoreTests/SessionsTestCase.swift
+++ b/Tests/StytchCoreTests/SessionsTestCase.swift
@@ -11,8 +11,8 @@ final class SessionsTestCase: BaseTestCase {
         XCTAssertNil(StytchClient.sessions.session)
 
         Current.sessionStorage.updateSession(
-            .user(.mock(userId: "i_am_user")),
-            tokens: [.jwt("i'm_jwt"), .opaque("opaque_all_day")],
+            sessionType: .user(.mock(userId: "i_am_user")),
+            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day")),
             hostUrl: try XCTUnwrap(URL(string: "https://url.com"))
         )
 
@@ -34,8 +34,8 @@ final class SessionsTestCase: BaseTestCase {
         Current.timer = { _, _, _ in .init() }
 
         Current.sessionStorage.updateSession(
-            .user(.mock(userId: "i_am_user")),
-            tokens: [.jwt("i'm_jwt"), .opaque("opaque_all_day")],
+            sessionType: .user(.mock(userId: "i_am_user")),
+            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day")),
             hostUrl: try XCTUnwrap(URL(string: "https://url.com"))
         )
 
@@ -58,8 +58,8 @@ final class SessionsTestCase: BaseTestCase {
         Current.timer = { _, _, _ in .init() }
 
         Current.sessionStorage.updateSession(
-            .user(.mock(userId: "i_am_user")),
-            tokens: [.jwt("i'm_jwt"), .opaque("opaque_all_day")],
+            sessionType: .user(.mock(userId: "i_am_user")),
+            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day")),
             hostUrl: try XCTUnwrap(URL(string: "https://url.com"))
         )
 
@@ -98,5 +98,31 @@ final class SessionsTestCase: BaseTestCase {
         } else {
             XCTFail("SessionTokens should not be nil")
         }
+    }
+
+    func testIntermediateSessionToken() {
+        Current.timer = { _, _, _ in .init() }
+
+        // Given we call update session with valid member session and tokens
+        Current.sessionStorage.updateSession(
+            sessionType: .member(.mock),
+            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day")),
+            hostUrl: URL(string: "https://url.com")
+        )
+
+        // And it correctly applies the values
+        XCTAssertNotNil(Current.sessionStorage.sessionToken)
+        XCTAssertNotNil(Current.sessionStorage.sessionJwt)
+        XCTAssertNotNil(Current.sessionStorage.memberSession)
+        XCTAssertNil(Current.sessionStorage.intermediateSessionToken)
+
+        // When we call update session with a IST value
+        Current.sessionStorage.updateSession(intermediateSessionToken: "ist")
+
+        // Then our IST is not nil but the other values are
+        XCTAssertNil(Current.sessionStorage.sessionToken)
+        XCTAssertNil(Current.sessionStorage.sessionJwt)
+        XCTAssertNil(Current.sessionStorage.memberSession)
+        XCTAssertNotNil(Current.sessionStorage.intermediateSessionToken)
     }
 }


### PR DESCRIPTION
Linear Ticket: [SDK-1526](https://linear.app/stytch/issue/SDK-1526/[ios]-support-mfa-in-b2b)

This PR adds the first part of B2B MFA and much of the groundwork and plumbing. From here I will need to now add it to all the places that need changes more easily.

## Changes:

1. Add a new response type for the first phase of MFA called `B2BMFAAuthenticateResponse` it has an optional IST and an optional member session.
2. Implement the plumbing for saving a retrieving the IST as well as a new type of parameters for injecting the IST into requests that need it.
3. Change the OTP for to allow for MFA.
4. Refactor `SessionStorage` and change the implementation of `updateSession` to allow for the IST and more flexible use. I considered splitting it up into many functions, but I felt that single function with all optional parameters allowed for a flexible use and centralized point of logic.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A