### PR TITLE
[SDK-1717][SDK-1832] Continue adding MFA to B2B

### DIFF
--- a/Sources/StytchCore/Generated/StytchB2BClient.OAuth.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.OAuth.authenticate+AsyncVariants.generated.swift
@@ -5,7 +5,7 @@ import Foundation
 
 public extension StytchB2BClient.OAuth {
     /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
-    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
+    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<B2BMFAAuthenticateResponse>) {
         Task {
             do {
                 completion(.success(try await authenticate(parameters: parameters)))
@@ -16,7 +16,7 @@ public extension StytchB2BClient.OAuth {
     }
 
     /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
-    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<B2BAuthenticateResponse, Error> {
+    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<B2BMFAAuthenticateResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/Generated/StytchB2BClient.Passwords.resetByExistingPassword+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.Passwords.resetByExistingPassword+AsyncVariants.generated.swift
@@ -7,7 +7,7 @@ public extension StytchB2BClient.Passwords {
     /// Reset the member’s password and authenticate them. This endpoint checks that the existing password matches the stored value.
     /// 
     /// The provided password needs to meet our password strength requirements, which can be checked in advance with the password strength endpoint. If the password and accompanying parameters are accepted, the password is securely stored for future authentication and the member is authenticated.
-    func resetByExistingPassword(parameters: ResetByExistingPasswordParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
+    func resetByExistingPassword(parameters: ResetByExistingPasswordParameters, completion: @escaping Completion<B2BMFAAuthenticateResponse>) {
         Task {
             do {
                 completion(.success(try await resetByExistingPassword(parameters: parameters)))
@@ -20,7 +20,7 @@ public extension StytchB2BClient.Passwords {
     /// Reset the member’s password and authenticate them. This endpoint checks that the existing password matches the stored value.
     /// 
     /// The provided password needs to meet our password strength requirements, which can be checked in advance with the password strength endpoint. If the password and accompanying parameters are accepted, the password is securely stored for future authentication and the member is authenticated.
-    func resetByExistingPassword(parameters: ResetByExistingPasswordParameters) -> AnyPublisher<B2BAuthenticateResponse, Error> {
+    func resetByExistingPassword(parameters: ResetByExistingPasswordParameters) -> AnyPublisher<B2BMFAAuthenticateResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/Generated/StytchB2BClient.SSO.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.SSO.authenticate+AsyncVariants.generated.swift
@@ -7,7 +7,7 @@ import Foundation
 public extension StytchB2BClient.SSO {
     /// Authenticate a member given a token. This endpoint verifies that the memeber completed the SSO Authentication flow by
     /// verifying that the token is valid and hasn't expired.
-    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
+    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<B2BMFAAuthenticateResponse>) {
         Task {
             do {
                 completion(.success(try await authenticate(parameters: parameters)))
@@ -19,7 +19,7 @@ public extension StytchB2BClient.SSO {
 
     /// Authenticate a member given a token. This endpoint verifies that the memeber completed the SSO Authentication flow by
     /// verifying that the token is valid and hasn't expired.
-    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<B2BAuthenticateResponse, Error> {
+    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<B2BMFAAuthenticateResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/Generated/StytchB2BClientSessions.exchange+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClientSessions.exchange+AsyncVariants.generated.swift
@@ -5,7 +5,7 @@ import Foundation
 
 public extension StytchB2BClientSessions {
     /// Use this endpoint to exchange a Member's existing session for another session in a different Organization.
-    func exchange(parameters: ExchangeParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
+    func exchange(parameters: ExchangeParameters, completion: @escaping Completion<B2BMFAAuthenticateResponse>) {
         Task {
             do {
                 completion(.success(try await exchange(parameters: parameters)))
@@ -16,7 +16,7 @@ public extension StytchB2BClientSessions {
     }
 
     /// Use this endpoint to exchange a Member's existing session for another session in a different Organization.
-    func exchange(parameters: ExchangeParameters) -> AnyPublisher<B2BAuthenticateResponse, Error> {
+    func exchange(parameters: ExchangeParameters) -> AnyPublisher<B2BMFAAuthenticateResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/KeychainClient/KeychainClient.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient.swift
@@ -24,12 +24,18 @@ struct KeychainClient {
     }
 }
 
+extension KeychainClient {
+    func getQueryResult(_ item: Item) throws -> QueryResult? {
+        try get(item).first
+    }
+}
+
 // String convenience methods
 extension KeychainClient {
     func get(_ item: Item) throws -> String? {
         try get(item)
             .first
-            .flatMap { String(data: $0.data, encoding: .utf8) }
+            .flatMap(\.stringValue)
     }
 
     func set(_ value: String, for item: Item) throws {
@@ -68,6 +74,10 @@ extension KeychainClient {
         let label: String?
         let account: String?
         let generic: Data?
+
+        var stringValue: String? {
+            String(data: data, encoding: .utf8)
+        }
     }
 
     struct KeyRegistration: Codable {

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Discovery.swift
@@ -9,21 +9,26 @@ public extension StytchB2BClient {
     struct Discovery {
         let router: NetworkingRouter<DiscoveryRoute>
 
+        @Dependency(\.sessionStorage) private var sessionStorage
+
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's [list discovered Organizations](https://stytch.com/docs/b2b/api/list-discovered-organizations) endpoint. If the `intermediate_session_token` is not passed in and there is a current Member Session, the SDK will call the endpoint with the session token.
         public func listOrganizations(parameters: ListOrganizationsParameters) async throws -> ListOrganizationsResponse {
+            // TODO: IST - ADD
             try await router.post(to: .organizations, parameters: parameters)
         }
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's [exchange intermediate session](https://stytch.com/docs/b2b/api/exchange-intermediate-session) endpoint. This operation consumes the `intermediate_session_token`. If this method succeeds, the Member will be logged in, and granted an active session.
         public func exchangeIntermediateSession(parameters: ExchangeIntermediateSessionParameters) async throws -> ExchangeIntermediateSessionResponse {
+            // TODO: IST - ADD
             try await router.post(to: .intermediateSessionsExchange, parameters: parameters)
         }
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's [create Organization via discovery](https://stytch.com/docs/b2b/api/create-organization-via-discovery) endpoint. This operation consumes the `intermediate_session_token`. If this method succeeds, the Member will be logged in, and granted an active session.
         public func createOrganization(parameters: CreateOrganizationParameters) async throws -> CreateOrganizationResponse {
+            // TODO: IST - ADD
             try await router.post(to: .organizationsCreate, parameters: parameters)
         }
     }
@@ -53,7 +58,7 @@ public extension StytchB2BClient.Discovery {
 
     /// A dedicated parameters type for Discover `listOrganizations` calls.
     struct ListOrganizationsParameters: Encodable {
-        let intermediateSessionToken: String
+        let intermediateSessionToken: String // TODO: IST
 
         /// - Parameter intermediateSessionToken: The Intermediate Session Token. This token does not belong to a specific instance of a member, but may be exchanged for an existing Member Session or used to create a new organization.
         public init(intermediateSessionToken: String) {
@@ -80,6 +85,8 @@ public extension StytchB2BClient.Discovery {
         public let member: Member
         /// The current organization object.
         public let organization: Organization
+
+        // TODO: IST - I THINK THIS RETURNS A IST ALSO
     }
 
     /// The dedicated parameters type for Discovery `exchangeIntermediateSession` calls.
@@ -90,7 +97,7 @@ public extension StytchB2BClient.Discovery {
             case sessionDuration = "sessionDurationMinutes"
         }
 
-        let intermediateSessionToken: String
+        let intermediateSessionToken: String // TODO: IST
         let organizationId: Organization.ID
         let sessionDuration: Minutes
 
@@ -124,6 +131,8 @@ public extension StytchB2BClient.Discovery {
         public let member: Member
         /// The current organization object.
         public let organization: Organization
+
+        // TODO: IST - I THINK THIS RETURNS A IST ALSO
     }
 
     /// A dedicated parameters type for Discovery `createOrganization` calls.
@@ -142,7 +151,7 @@ public extension StytchB2BClient.Discovery {
             case allowedAuthMethods
         }
 
-        let intermediateSessionToken: String
+        let intermediateSessionToken: String // TODO: IST
         let sessionDuration: Minutes
         let organizationName: String?
         let organizationSlug: String?

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+Discovery.swift
@@ -53,7 +53,7 @@ public extension StytchB2BClient.OAuth.Discovery {
     typealias DiscoveryAuthenticateResponse = Response<DiscoveryAuthenticateResponseData>
 
     struct DiscoveryAuthenticateResponseData: Codable {
-        public let intermediateSessionToken: String
+        public let intermediateSessionToken: String // TODO: IST
         public let emailAddress: String
         public let discoveredOrganizations: [DiscoveredOrganization]
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP.swift
@@ -18,33 +18,25 @@ public extension StytchB2BClient {
         // sourcery: AsyncVariants
         /// Send a one-time passcode (OTP) to a user using their phone number via SMS.
         public func send(parameters: SendParameters) async throws -> BasicResponse {
-            if let intermediateSessionToken = sessionStorage.intermediateSessionToken {
-                return try await router.post(
-                    to: .send,
-                    parameters: IntermediateSessionTokenParameters(
-                        intermediateSessionToken: intermediateSessionToken,
-                        wrapped: parameters
-                    )
+            try await router.post(
+                to: .send,
+                parameters: IntermediateSessionTokenParameters(
+                    intermediateSessionToken: sessionStorage.intermediateSessionToken,
+                    wrapped: parameters
                 )
-            } else {
-                return try await router.post(to: .send, parameters: parameters)
-            }
+            )
         }
 
         // sourcery: AsyncVariants
         /// Authenticate a one-time passcode (OTP) sent to a user via SMS.
         public func authenticate(parameters: AuthenticateParameters) async throws -> B2BAuthenticateResponse {
-            if let intermediateSessionToken = sessionStorage.intermediateSessionToken {
-                return try await router.post(
-                    to: .authenticate,
-                    parameters: IntermediateSessionTokenParameters(
-                        intermediateSessionToken: intermediateSessionToken,
-                        wrapped: parameters
-                    )
+            try await router.post(
+                to: .authenticate,
+                parameters: IntermediateSessionTokenParameters(
+                    intermediateSessionToken: sessionStorage.intermediateSessionToken,
+                    wrapped: parameters
                 )
-            } else {
-                return try await router.post(to: .authenticate, parameters: parameters)
-            }
+            )
         }
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Sessions.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Sessions.swift
@@ -65,7 +65,7 @@ public struct StytchB2BClientSessions {
 
     // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
     /// Use this endpoint to exchange a Member's existing session for another session in a different Organization.
-    public func exchange(parameters: ExchangeParameters) async throws -> B2BAuthenticateResponse {
+    public func exchange(parameters: ExchangeParameters) async throws -> B2BMFAAuthenticateResponse {
         try await router.post(to: .exchange, parameters: parameters)
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+TOTP.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+TOTP.swift
@@ -18,23 +18,25 @@ public extension StytchB2BClient {
         // sourcery: AsyncVariants
         /// Create a TOTP for a member
         public func create(parameters: CreateParameters) async throws -> CreateResponse {
-            try await router.post(to: .create, parameters: parameters)
+            try await router.post(
+                to: .create,
+                parameters: IntermediateSessionTokenParameters(
+                    intermediateSessionToken: sessionStorage.intermediateSessionToken,
+                    wrapped: parameters
+                )
+            )
         }
 
         // sourcery: AsyncVariants
         /// Authenticate a TOTP for a member
         public func authenticate(parameters: AuthenticateParameters) async throws -> B2BAuthenticateResponse {
-            if let intermediateSessionToken = sessionStorage.intermediateSessionToken {
-                return try await router.post(
-                    to: .authenticate,
-                    parameters: IntermediateSessionTokenParameters(
-                        intermediateSessionToken: intermediateSessionToken,
-                        wrapped: parameters
-                    )
+            try await router.post(
+                to: .authenticate,
+                parameters: IntermediateSessionTokenParameters(
+                    intermediateSessionToken: sessionStorage.intermediateSessionToken,
+                    wrapped: parameters
                 )
-            } else {
-                return try await router.post(to: .authenticate, parameters: parameters)
-            }
+            )
         }
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -88,12 +88,12 @@ public struct StytchB2BClient: StytchClientType {
             Task {
                 try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
-            return try await .handled(response: .auth(sso.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
+            return try await .handled(response: .mfauth(sso.authenticate(parameters: .init(token: token, sessionDuration: sessionDuration))))
         case .oauth:
             Task {
                 try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
-            return try await .handled(response: .auth(oauth.authenticate(parameters: .init(oauthToken: token, sessionDurationMinutes: sessionDuration))))
+            return try await .handled(response: .mfauth(oauth.authenticate(parameters: .init(oauthToken: token, sessionDurationMinutes: sessionDuration))))
         case .discoveryOauth:
             Task {
                 try? await Self.events.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))

--- a/Sources/StytchCore/StytchClientCommon/IntermediateSessionTokenParameters.swift
+++ b/Sources/StytchCore/StytchClientCommon/IntermediateSessionTokenParameters.swift
@@ -5,10 +5,10 @@ struct IntermediateSessionTokenParameters<T: Encodable>: Encodable {
         case intermediateSessionToken
     }
 
-    let intermediateSessionToken: String
+    let intermediateSessionToken: String?
     let wrapped: T
 
-    init(intermediateSessionToken: String, wrapped: T) {
+    init(intermediateSessionToken: String?, wrapped: T) {
         self.intermediateSessionToken = intermediateSessionToken
         self.wrapped = wrapped
     }
@@ -16,6 +16,8 @@ struct IntermediateSessionTokenParameters<T: Encodable>: Encodable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try wrapped.encode(to: encoder)
-        try container.encode(intermediateSessionToken, forKey: .intermediateSessionToken)
+        if let intermediateSessionToken {
+            try container.encode(intermediateSessionToken, forKey: .intermediateSessionToken)
+        }
     }
 }

--- a/Tests/StytchCoreTests/B2BOAuthTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOAuthTestCase.swift
@@ -5,7 +5,7 @@ final class B2BOAuthTestCase: BaseTestCase {
     @available(tvOS 16.0, *)
     func testAuthenticate() async throws {
         networkInterceptor.responses {
-            B2BAuthenticateResponse.mock
+            B2BMFAAuthenticateResponse.mock
         }
 
         Current.timer = { _, _, _ in .init() }

--- a/Tests/StytchCoreTests/B2BSSOTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSSOTestCase.swift
@@ -35,7 +35,9 @@ final class B2BSSOTestCase: BaseTestCase {
     }
 
     func testAuthenticate() async throws {
-        networkInterceptor.responses { B2BAuthenticateResponse.mock }
+        networkInterceptor.responses {
+            B2BMFAAuthenticateResponse.mock
+        }
         Current.timer = { _, _, _ in .init() }
 
         await XCTAssertThrowsErrorAsync(

--- a/Tests/StytchCoreTests/KeychainClient+Mock.swift
+++ b/Tests/StytchCoreTests/KeychainClient+Mock.swift
@@ -1,6 +1,9 @@
 import Foundation
 @testable import StytchCore
 
+// used for testing the expiration of the IST
+public var keychainDateCreatedOffsetInMinutes = 0
+
 extension KeychainClient {
     static func mock() -> Self {
         let lock: NSLock = .init()
@@ -12,7 +15,14 @@ extension KeychainClient {
             lock.withLock { keychainItems[item.name].map { !$0.isEmpty } ?? false }
         } setValueForItem: { value, item in
             lock.withLock {
-                let queryResult: KeychainClient.QueryResult = .init(data: value.data, createdAt: .init(), modifiedAt: .init(), label: value.label, account: value.account, generic: value.generic)
+                let queryResult: KeychainClient.QueryResult = .init(
+                    data: value.data,
+                    createdAt: .init().minutesAgo(minutes: keychainDateCreatedOffsetInMinutes),
+                    modifiedAt: .init().minutesAgo(minutes: keychainDateCreatedOffsetInMinutes),
+                    label: value.label,
+                    account: value.account,
+                    generic: value.generic
+                )
                 var results = keychainItems[item.name, default: []]
                 if let index = results.firstIndex(where: { $0.label == queryResult.label && $0.account == queryResult.account }) {
                     results[index] = queryResult
@@ -28,5 +38,11 @@ extension KeychainClient {
 
     func resultsExistForItem(_ item: Item) -> Bool {
         (try? get(item).map { !$0.isEmpty }) ?? false
+    }
+}
+
+extension Date {
+    func minutesAgo(minutes: Int) -> Date {
+        Calendar.current.date(byAdding: .minute, value: -minutes, to: self) ?? self
     }
 }

--- a/Tests/StytchCoreTests/SessionStorageTestCase.swift
+++ b/Tests/StytchCoreTests/SessionStorageTestCase.swift
@@ -3,6 +3,11 @@ import XCTest
 @testable import StytchCore
 
 final class SessionStorageTestCase: BaseTestCase {
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        keychainDateCreatedOffsetInMinutes = 0
+    }
+
     func testNotification() throws {
         XCTAssertNil(StytchClient.sessions.sessionJwt)
         XCTAssertNil(StytchClient.sessions.sessionToken)
@@ -19,5 +24,37 @@ final class SessionStorageTestCase: BaseTestCase {
         NotificationCenter.default.post(name: .NSHTTPCookieManagerCookiesChanged, object: HTTPCookieStorage.shared)
         XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("new_value"))
         XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("opaque"))
+    }
+
+    func testIntermediateSessionTokenExpiresAfter11Minutes() {
+        let keychainItem: KeychainClient.Item = .intermediateSessionToken
+
+        // clear the IST
+        try? Current.keychainClient.removeItem(keychainItem)
+
+        // set the date created offset to 11 minutes so that the IST will be expired and return nil
+        keychainDateCreatedOffsetInMinutes = 11
+
+        // call updateSession with only the IST which will assign it to the keychain item for the IST
+        Current.sessionStorage.updateSession(intermediateSessionToken: "1234567890")
+
+        // the IST should be nil since its been more than 10 minutes
+        XCTAssertNil(Current.sessionStorage.intermediateSessionToken)
+    }
+
+    func testIntermediateSessionTokenIsStillValidAfter5Minutes() {
+        let keychainItem: KeychainClient.Item = .intermediateSessionToken
+
+        // clear the IST
+        try? Current.keychainClient.removeItem(keychainItem)
+
+        // set the date created offset to only 5 minutes so that the IST is still valid
+        keychainDateCreatedOffsetInMinutes = 5
+
+        // call updateSession with only the IST which will assign it to the keychain item for the IST
+        Current.sessionStorage.updateSession(intermediateSessionToken: "1234567890")
+
+        // the IST should not be nil since its only been more than 5 minutes
+        XCTAssertNotNil(Current.sessionStorage.intermediateSessionToken)
     }
 }


### PR DESCRIPTION
Linear Ticket: [SDK-1717: Implement 10 minute IST lifespan](https://linear.app/stytch/issue/SDK-1717/[ios]-implement-10-minute-ist-lifespan)
Linear Ticket: [SDK-1832: Support MFA in B2B - All Flows Non Discovery](https://linear.app/stytch/issue/SDK-1832/[ios]-support-mfa-in-b2b-all-flows-non-discovery)

This specific page is super helpful in understanding b2b mfa: https://stytch.com/docs/b2b/guides/mfa/headless

## Changes:

1.  Modify `IntermediateSessionTokenParameters` to take an optional `intermediateSessionToken: String?` and if its nil do not include it, I did this so we don't have to check for its nullability everywhere these parameters are used.
2. Add a 10 minute expiration to the IST stored in the keychain and expose a new method on the `KeychainClient` called `func getQueryResult(_ item: Item) throws -> QueryResult?`. The `QueryResult` has a `createdAt` field that can be used to determine the age of the IST in the keychain and if need be manually expire it in `SessionStorage` when the caller attempts to retrieve it.
3. Modify the response type of the `SSO.authenticate` and `OAuth.authenticate` to be the response type including the IST and make those flows compatible with MFA.
4. Modify the parameters of the `TOTP.create` and `TOTP.authenticate` to use the `IntermediateSessionTokenParameters` and I verified that both work when MFA is enabled and being called with an IST.
5. Added some `TODO: IST` comments that will be caught in the next PR when I implement the discovery MFA flows.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A