### PR TITLE
[SDK-1833] Handle the IST for discovery flows

### DIFF
--- a/Sources/StytchCore/Generated/StytchB2BClient.Discovery.listOrganizations+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.Discovery.listOrganizations+AsyncVariants.generated.swift
@@ -5,10 +5,10 @@ import Foundation
 
 public extension StytchB2BClient.Discovery {
     /// Wraps Stytch's [list discovered Organizations](https://stytch.com/docs/b2b/api/list-discovered-organizations) endpoint. If the `intermediate_session_token` is not passed in and there is a current Member Session, the SDK will call the endpoint with the session token.
-    func listOrganizations(parameters: ListOrganizationsParameters, completion: @escaping Completion<ListOrganizationsResponse>) {
+    func listOrganizations(completion: @escaping Completion<ListOrganizationsResponse>) {
         Task {
             do {
-                completion(.success(try await listOrganizations(parameters: parameters)))
+                completion(.success(try await listOrganizations()))
             } catch {
                 completion(.failure(error))
             }
@@ -16,12 +16,12 @@ public extension StytchB2BClient.Discovery {
     }
 
     /// Wraps Stytch's [list discovered Organizations](https://stytch.com/docs/b2b/api/list-discovered-organizations) endpoint. If the `intermediate_session_token` is not passed in and there is a current Member Session, the SDK will call the endpoint with the session token.
-    func listOrganizations(parameters: ListOrganizationsParameters) -> AnyPublisher<ListOrganizationsResponse, Error> {
+    func listOrganizations() -> AnyPublisher<ListOrganizationsResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {
                     do {
-                        promise(.success(try await listOrganizations(parameters: parameters)))
+                        promise(.success(try await listOrganizations()))
                     } catch {
                         promise(.failure(error))
                     }

--- a/Sources/StytchCore/Routing/NetworkingRouter.swift
+++ b/Sources/StytchCore/Routing/NetworkingRouter.swift
@@ -123,7 +123,7 @@ public extension NetworkingRouter {
                 )
                 localStorage.member = sessionResponse.member
                 localStorage.organization = sessionResponse.organization
-            } else if let sessionResponse = dataContainer.data as? B2BMFAAuthenticateResponse {
+            } else if let sessionResponse = dataContainer.data as? B2BMFAAuthenticateResponseType {
                 if let memberSession = sessionResponse.memberSession {
                     sessionStorage.updateSession(
                         sessionType: .member(memberSession),
@@ -137,6 +137,10 @@ public extension NetworkingRouter {
                 }
                 localStorage.member = sessionResponse.member
                 localStorage.organization = sessionResponse.organization
+            } else if let sessionResponse = dataContainer.data as? DiscoveryIntermediateSessionTokenDataType {
+                sessionStorage.updateSession(
+                    intermediateSessionToken: sessionResponse.intermediateSessionToken
+                )
             }
             return dataContainer.data
         } catch let error as StytchAPIError where error.statusCode == 401 {

--- a/Sources/StytchCore/SessionStorage.swift
+++ b/Sources/StytchCore/SessionStorage.swift
@@ -159,6 +159,8 @@ final class SessionStorage {
         session = nil
         memberSession = nil
 
+        intermediateSessionToken = nil
+
         userStorage.reset()
         localStorage.organization = nil
         localStorage.member = nil
@@ -172,8 +174,6 @@ final class SessionStorage {
     func clearTokens() {
         sessionToken = nil
         sessionJwt = nil
-        cookieClient.deleteCookie(named: SessionToken.Kind.jwt.name)
-        cookieClient.deleteCookie(named: SessionToken.Kind.opaque.name)
     }
 
     @objc

--- a/Sources/StytchCore/StytchB2BClient/Models/B2BMFAAuthenticateResponse.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/B2BMFAAuthenticateResponse.swift
@@ -18,7 +18,7 @@ public struct B2BMFAAuthenticateResponseData: Codable, B2BMFAAuthenticateRespons
     public let sessionToken: String
     /// The JWT for the session. Can be used by your server to verify the validity of your session either by checking the data included in the JWT, or by verifying with Stytch's servers as needed.
     public let sessionJwt: String
-    ///
+    /// An optional intermediate session token to be returned if multi factor authentication is enabled
     public let intermediateSessionToken: String?
 }
 
@@ -34,6 +34,12 @@ public protocol B2BMFAAuthenticateResponseDataType {
     var sessionToken: String { get }
     /// The JWT for the session. Can be used by your server to verify the validity of your session either by checking the data included in the JWT, or by verifying with Stytch's servers as needed.
     var sessionJwt: String { get }
-    ///
+    /// An optional intermediate session token to be returned if multi factor authentication is enabled
     var intermediateSessionToken: String? { get }
+}
+
+/// The interface which a data type must conform to for all discovery flows that return a non optional intermediate session token
+public protocol DiscoveryIntermediateSessionTokenDataType {
+    /// The non optional intermediate session token returned by discovery flows separate from multi factor authentication
+    var intermediateSessionToken: String { get }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Discovery.swift
@@ -1,6 +1,15 @@
 import Foundation
 
 public extension StytchB2BClient {
+    /// The interface for interacting with discovery products.
+    static var discovery: Discovery {
+        .init(router: router.scopedRouter {
+            $0.discovery
+        })
+    }
+}
+
+public extension StytchB2BClient {
     /**
      * The Discovery product lets End Users discover and log in to Organizations they are a Member of, invited to, or eligible to join.
      * Unlike our other B2B products, Discovery allows End Users to authenticate without specifying an Organization in advance. This is done via a [Discovery Magic Link](https://stytch.com/docs/b2b/sdks/javascript-sdk#email-magic-links_methods_send-discovery-email) flow. After an End User is [authenticated](https://stytch.com/docs/b2b/sdks/javascript-sdk#email-magic-links_methods_authenticate-discovery-magic-link), an Intermediate Session is returned along with a list of associated Organizations.
@@ -13,30 +22,39 @@ public extension StytchB2BClient {
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's [list discovered Organizations](https://stytch.com/docs/b2b/api/list-discovered-organizations) endpoint. If the `intermediate_session_token` is not passed in and there is a current Member Session, the SDK will call the endpoint with the session token.
-        public func listOrganizations(parameters: ListOrganizationsParameters) async throws -> ListOrganizationsResponse {
-            // TODO: IST - ADD
-            try await router.post(to: .organizations, parameters: parameters)
+        public func listOrganizations() async throws -> ListOrganizationsResponse {
+            try await router.post(
+                to: .organizations,
+                parameters: IntermediateSessionTokenParametersWithNoWrappedValue(
+                    intermediateSessionToken: sessionStorage.intermediateSessionToken
+                )
+            )
         }
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's [exchange intermediate session](https://stytch.com/docs/b2b/api/exchange-intermediate-session) endpoint. This operation consumes the `intermediate_session_token`. If this method succeeds, the Member will be logged in, and granted an active session.
         public func exchangeIntermediateSession(parameters: ExchangeIntermediateSessionParameters) async throws -> ExchangeIntermediateSessionResponse {
-            // TODO: IST - ADD
-            try await router.post(to: .intermediateSessionsExchange, parameters: parameters)
+            try await router.post(
+                to: .intermediateSessionsExchange,
+                parameters: IntermediateSessionTokenParameters(
+                    intermediateSessionToken: sessionStorage.intermediateSessionToken,
+                    wrapped: parameters
+                )
+            )
         }
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's [create Organization via discovery](https://stytch.com/docs/b2b/api/create-organization-via-discovery) endpoint. This operation consumes the `intermediate_session_token`. If this method succeeds, the Member will be logged in, and granted an active session.
         public func createOrganization(parameters: CreateOrganizationParameters) async throws -> CreateOrganizationResponse {
-            // TODO: IST - ADD
-            try await router.post(to: .organizationsCreate, parameters: parameters)
+            try await router.post(
+                to: .organizationsCreate,
+                parameters: IntermediateSessionTokenParameters(
+                    intermediateSessionToken: sessionStorage.intermediateSessionToken,
+                    wrapped: parameters
+                )
+            )
         }
     }
-}
-
-public extension StytchB2BClient {
-    /// The interface for interacting with discovery products.
-    static var discovery: Discovery { .init(router: router.scopedRouter { $0.discovery }) }
 }
 
 public extension StytchB2BClient.Discovery {
@@ -55,16 +73,6 @@ public extension StytchB2BClient.Discovery {
         /// A list of discovered organizations.
         public let discoveredOrganizations: [DiscoveredOrganization]
     }
-
-    /// A dedicated parameters type for Discover `listOrganizations` calls.
-    struct ListOrganizationsParameters: Encodable {
-        let intermediateSessionToken: String // TODO: IST
-
-        /// - Parameter intermediateSessionToken: The Intermediate Session Token. This token does not belong to a specific instance of a member, but may be exchanged for an existing Member Session or used to create a new organization.
-        public init(intermediateSessionToken: String) {
-            self.intermediateSessionToken = intermediateSessionToken
-        }
-    }
 }
 
 public extension StytchB2BClient.Discovery {
@@ -72,11 +80,11 @@ public extension StytchB2BClient.Discovery {
     typealias ExchangeIntermediateSessionResponse = Response<ExchangeIntermediateSessionResponseData>
 
     /// The underlying data for `ExchangeIntermediateSessionResponse`.
-    struct ExchangeIntermediateSessionResponseData: Codable, B2BAuthenticateResponseDataType {
+    struct ExchangeIntermediateSessionResponseData: Codable, B2BMFAAuthenticateResponseDataType {
         /// The current member's ID.
         public let memberId: Member.ID
         /// The ``MemberSession`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
-        public let memberSession: MemberSession
+        public let memberSession: MemberSession?
         /// The opaque token for the session. Can be used by your server to verify the validity of your session by confirming with Stytch's servers on each request.
         public let sessionToken: String
         /// The JWT for the session. Can be used by your server to verify the validity of your session either by checking the data included in the JWT, or by verifying with Stytch's servers as needed.
@@ -85,28 +93,24 @@ public extension StytchB2BClient.Discovery {
         public let member: Member
         /// The current organization object.
         public let organization: Organization
-
-        // TODO: IST - I THINK THIS RETURNS A IST ALSO
+        /// An optional intermediate session token to be returned if multi factor authentication is enabled
+        public var intermediateSessionToken: String?
     }
 
     /// The dedicated parameters type for Discovery `exchangeIntermediateSession` calls.
     struct ExchangeIntermediateSessionParameters: Encodable {
         private enum CodingKeys: String, CodingKey {
-            case intermediateSessionToken
             case organizationId
             case sessionDuration = "sessionDurationMinutes"
         }
 
-        let intermediateSessionToken: String // TODO: IST
         let organizationId: Organization.ID
         let sessionDuration: Minutes
 
         /// - Parameters:
-        ///   - intermediateSessionToken: The Intermediate Session Token. This token does not belong to a specific instance of a member, but may be exchanged for a Member Session or used to create a new organization.
         ///   - organizationId: Globally unique UUID that identifies a specific Organization. The `organization_id` is critical to perform operations on an Organization, so be sure to preserve this value.
         ///   - sessionDuration: The duration, in minutes, for the requested session. Defaults to 30 minutes.
-        public init(intermediateSessionToken: String, organizationId: Organization.ID, sessionDuration: Minutes = .defaultSessionDuration) {
-            self.intermediateSessionToken = intermediateSessionToken
+        public init(organizationId: Organization.ID, sessionDuration: Minutes = .defaultSessionDuration) {
             self.organizationId = organizationId
             self.sessionDuration = sessionDuration
         }
@@ -118,11 +122,11 @@ public extension StytchB2BClient.Discovery {
     typealias CreateOrganizationResponse = Response<CreateOrganizationResponseData>
 
     /// The underlying data for `CreateOrganizationResponse`.
-    struct CreateOrganizationResponseData: Codable, B2BAuthenticateResponseDataType {
+    struct CreateOrganizationResponseData: Codable, B2BMFAAuthenticateResponseDataType {
         /// The current member's ID.
         public let memberId: Member.ID
         /// The ``MemberSession`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
-        public let memberSession: MemberSession
+        public let memberSession: MemberSession?
         /// The opaque token for the session. Can be used by your server to verify the validity of your session by confirming with Stytch's servers on each request.
         public let sessionToken: String
         /// The JWT for the session. Can be used by your server to verify the validity of your session either by checking the data included in the JWT, or by verifying with Stytch's servers as needed.
@@ -131,14 +135,13 @@ public extension StytchB2BClient.Discovery {
         public let member: Member
         /// The current organization object.
         public let organization: Organization
-
-        // TODO: IST - I THINK THIS RETURNS A IST ALSO
+        /// An optional intermediate session token to be returned if multi factor authentication is enabled
+        public var intermediateSessionToken: String?
     }
 
     /// A dedicated parameters type for Discovery `createOrganization` calls.
     struct CreateOrganizationParameters: Codable {
         private enum CodingKeys: String, CodingKey {
-            case intermediateSessionToken
             case sessionDuration = "sessionDurationMinutes"
             case organizationName
             case organizationSlug
@@ -151,7 +154,6 @@ public extension StytchB2BClient.Discovery {
             case allowedAuthMethods
         }
 
-        let intermediateSessionToken: String // TODO: IST
         let sessionDuration: Minutes
         let organizationName: String?
         let organizationSlug: String?
@@ -164,7 +166,6 @@ public extension StytchB2BClient.Discovery {
         let allowedAuthMethods: [AllowedAuthMethods]?
 
         /// - Parameters:
-        ///   - intermediateSessionToken: The Intermediate Session Token. This token does not belong to a specific instance of a member, but may be exchanged for a Member Session or used to create a new organization.
         ///   - sessionDuration: The duration, in minutes, for the requested session. Defaults to 30 minutes.
         ///   - organizationName: The name of the Organization. If the name is not specified, a default name will be created based on the email used to initiate the discovery flow. If the email domain is a common email provider such as gmail.com, or if the email is a .edu email, the organization name will be generated based on the name portion of the email. Otherwise, the organization name will be generated based on the email domain.
         ///   - organizationSlug: The unique URL slug of the Organization. A minimum of two characters is required. The slug only accepts alphanumeric characters and the following reserved characters: - . _ ~. If the slug is not specified, a default slug will be created based on the email used to initiate the discovery flow. If the email domain is a common email provider such as gmail.com, or if the email is a .edu email, the organization slug will be generated based on the name portion of the email. Otherwise, the organization slug will be generated based on the email domain.
@@ -176,7 +177,6 @@ public extension StytchB2BClient.Discovery {
         ///   - authMethods: The setting that controls which authentication methods can be used by Members of an Organization.
         ///   - allowedAuthMethods: An array of allowed authentication methods. This list is enforced when `auth_methods` is set to `RESTRICTED`.
         public init(
-            intermediateSessionToken: String,
             sessionDuration: Minutes = .defaultSessionDuration,
             organizationName: String? = nil,
             organizationSlug: String? = nil,
@@ -188,7 +188,6 @@ public extension StytchB2BClient.Discovery {
             authMethods: AuthMethods? = nil,
             allowedAuthMethods: [AllowedAuthMethods]? = nil
         ) {
-            self.intermediateSessionToken = intermediateSessionToken
             self.sessionDuration = sessionDuration
             self.organizationName = organizationName
             self.organizationSlug = organizationSlug

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+MagicLinks.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+MagicLinks.swift
@@ -280,7 +280,7 @@ public extension StytchB2BClient.MagicLinks {
     typealias DiscoveryAuthenticateResponse = Response<DiscoveryAuthenticateResponseData>
 
     /// The underlying data for the DiscoveryAuthenticateResponse type.
-    struct DiscoveryAuthenticateResponseData: Codable {
+    struct DiscoveryAuthenticateResponseData: DiscoveryIntermediateSessionTokenDataType, Codable {
         private enum CodingKeys: String, CodingKey {
             case discoveredOrganizations
             case email = "emailAddress"
@@ -290,7 +290,7 @@ public extension StytchB2BClient.MagicLinks {
         /// The discovered organizations.
         public let discoveredOrganizations: [StytchB2BClient.Discovery.DiscoveredOrganization]
         /// The intermediate session token.
-        public let intermediateSessionToken: String // TODO: IST
+        public let intermediateSessionToken: String
         /// The member's email address.
         public let email: String
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+Discovery.swift
@@ -52,8 +52,8 @@ public extension StytchB2BClient.OAuth.Discovery {
 public extension StytchB2BClient.OAuth.Discovery {
     typealias DiscoveryAuthenticateResponse = Response<DiscoveryAuthenticateResponseData>
 
-    struct DiscoveryAuthenticateResponseData: Codable {
-        public let intermediateSessionToken: String // TODO: IST
+    struct DiscoveryAuthenticateResponseData: DiscoveryIntermediateSessionTokenDataType, Codable {
+        public let intermediateSessionToken: String
         public let emailAddress: String
         public let discoveredOrganizations: [DiscoveredOrganization]
     }

--- a/Sources/StytchCore/StytchClientCommon/IntermediateSessionTokenParameters.swift
+++ b/Sources/StytchCore/StytchClientCommon/IntermediateSessionTokenParameters.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// swiftlint:disable type_name
+
 struct IntermediateSessionTokenParameters<T: Encodable>: Encodable {
     private enum CodingKeys: String, CodingKey {
         case intermediateSessionToken
@@ -19,5 +21,13 @@ struct IntermediateSessionTokenParameters<T: Encodable>: Encodable {
         if let intermediateSessionToken {
             try container.encode(intermediateSessionToken, forKey: .intermediateSessionToken)
         }
+    }
+}
+
+struct IntermediateSessionTokenParametersWithNoWrappedValue: Codable {
+    let intermediateSessionToken: String?
+
+    init(intermediateSessionToken: String?) {
+        self.intermediateSessionToken = intermediateSessionToken
     }
 }

--- a/Sources/StytchCore/StytchClientCommon/Models/Response.swift
+++ b/Sources/StytchCore/StytchClientCommon/Models/Response.swift
@@ -81,3 +81,16 @@ extension Response: B2BAuthenticateResponseDataType where Wrapped: B2BAuthentica
     public var sessionToken: String { wrapped.sessionToken }
     public var sessionJwt: String { wrapped.sessionJwt }
 }
+
+extension Response: B2BMFAAuthenticateResponseDataType where Wrapped: B2BMFAAuthenticateResponseDataType {
+    public var member: Member { wrapped.member }
+    public var memberSession: MemberSession? { wrapped.memberSession }
+    public var organization: Organization { wrapped.organization }
+    public var sessionToken: String { wrapped.sessionToken }
+    public var sessionJwt: String { wrapped.sessionJwt }
+    public var intermediateSessionToken: String? { wrapped.intermediateSessionToken }
+}
+
+extension Response: DiscoveryIntermediateSessionTokenDataType where Wrapped: DiscoveryIntermediateSessionTokenDataType {
+    public var intermediateSessionToken: String { wrapped.intermediateSessionToken }
+}

--- a/StytchDemo/B2BWorkbench/ViewControllers/AuthMethodControllers/DiscoveryViewController.swift
+++ b/StytchDemo/B2BWorkbench/ViewControllers/AuthMethodControllers/DiscoveryViewController.swift
@@ -4,8 +4,6 @@ import UIKit
 final class DiscoveryViewController: UIViewController {
     let stackView = UIStackView.stytchB2BStackView()
 
-    lazy var intermediateSessionTextField: UITextField = .init(title: "Intermediate Session Token", primaryAction: submitAction)
-
     lazy var orgNameTextField: UITextField = .init(title: "Org Name", primaryAction: submitAction)
 
     lazy var discoverButton: UIButton = .init(title: "Discover", primaryAction: submitAction)
@@ -35,24 +33,18 @@ final class DiscoveryViewController: UIViewController {
             stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
         ])
 
-        stackView.addArrangedSubview(intermediateSessionTextField)
         stackView.addArrangedSubview(orgNameTextField)
         stackView.addArrangedSubview(discoverButton)
         stackView.addArrangedSubview(exchangeSessionButton)
         stackView.addArrangedSubview(createOrgButton)
 
-        intermediateSessionTextField.delegate = self
         orgNameTextField.delegate = self
     }
 
     func discover() {
-        guard let token = intermediateSessionTextField.text, !token.isEmpty else { return }
-
         Task {
             do {
-                let response = try await StytchB2BClient.discovery.listOrganizations(
-                    parameters: .init(intermediateSessionToken: token)
-                )
+                let response = try await StytchB2BClient.discovery.listOrganizations()
                 presentAlertAndLogMessage(description: "list organizations success!", object: response)
             } catch {
                 presentAlertAndLogMessage(description: "list organizations error", object: error)
@@ -61,13 +53,12 @@ final class DiscoveryViewController: UIViewController {
     }
 
     func exchangeSession() {
-        guard let token = intermediateSessionTextField.text, !token.isEmpty else { return }
         guard let orgId = organizationId else { return }
 
         Task {
             do {
                 let response = try await StytchB2BClient.discovery.exchangeIntermediateSession(
-                    parameters: .init(intermediateSessionToken: token, organizationId: .init(rawValue: orgId))
+                    parameters: .init(organizationId: .init(rawValue: orgId))
                 )
                 presentAlertAndLogMessage(description: "exchange session success!", object: response)
             } catch {
@@ -77,13 +68,12 @@ final class DiscoveryViewController: UIViewController {
     }
 
     func createOrg() {
-        guard let token = intermediateSessionTextField.text, !token.isEmpty else { return }
         guard let orgName = orgNameTextField.text, !orgName.isEmpty else { return }
 
         Task {
             do {
                 let response = try await StytchB2BClient.discovery.createOrganization(
-                    parameters: .init(intermediateSessionToken: token, organizationName: orgName)
+                    parameters: .init(organizationName: orgName)
                 )
                 presentAlertAndLogMessage(description: "create organization success!", object: response)
             } catch {

--- a/Tests/StytchCoreTests/B2BDiscoveryTestCase.swift
+++ b/Tests/StytchCoreTests/B2BDiscoveryTestCase.swift
@@ -9,13 +9,15 @@ final class B2BDiscoveryTestCase: BaseTestCase {
             StytchB2BClient.Discovery.ListOrganizationsResponse(requestId: "123", statusCode: 200, wrapped: .init(email: "blah@gmail.com", discoveredOrganizations: [.init(organization: .mock, membership: .init(kind: "somethign", details: nil, member: .mock), memberAuthenticated: false)]))
         }
 
-        _ = try await client.listOrganizations(parameters: .init(intermediateSessionToken: "token"))
+        Current.sessionStorage.updateSession(intermediateSessionToken: intermediateSessionToken)
+
+        _ = try await client.listOrganizations()
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
             urlString: "https://web.stytch.com/sdk/v1/b2b/discovery/organizations",
             method: .post([
-                "intermediate_session_token": "token",
+                "intermediate_session_token": JSON.string(intermediateSessionToken),
             ])
         )
     }
@@ -26,13 +28,15 @@ final class B2BDiscoveryTestCase: BaseTestCase {
         }
         Current.timer = { _, _, _ in .init() }
 
-        _ = try await client.exchangeIntermediateSession(parameters: .init(intermediateSessionToken: "asdf", organizationId: Organization.mock.id))
+        Current.sessionStorage.updateSession(intermediateSessionToken: intermediateSessionToken)
+
+        _ = try await client.exchangeIntermediateSession(parameters: .init(organizationId: Organization.mock.id))
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
             urlString: "https://web.stytch.com/sdk/v1/b2b/discovery/intermediate_sessions/exchange",
             method: .post([
-                "intermediate_session_token": "asdf",
+                "intermediate_session_token": JSON.string(intermediateSessionToken),
                 "organization_id": "org_123",
                 "session_duration_minutes": 30,
             ])
@@ -40,12 +44,26 @@ final class B2BDiscoveryTestCase: BaseTestCase {
     }
 
     func testCreateOrganization() async throws {
-        networkInterceptor.responses { StytchB2BClient.Discovery.CreateOrganizationResponse(requestId: "req", statusCode: 200, wrapped: .init(memberId: Member.mock.id, memberSession: .mock, sessionToken: "asdf", sessionJwt: "zxcv", member: .mock, organization: .mock)) }
+        networkInterceptor.responses {
+            StytchB2BClient.Discovery.CreateOrganizationResponse(
+                requestId: "req",
+                statusCode: 200,
+                wrapped: .init(
+                    memberId: Member.mock.id,
+                    memberSession: .mock,
+                    sessionToken: "asdf",
+                    sessionJwt: "zxcv",
+                    member: .mock,
+                    organization: .mock
+                )
+            )
+        }
         Current.timer = { _, _, _ in .init() }
+
+        Current.sessionStorage.updateSession(intermediateSessionToken: intermediateSessionToken)
 
         _ = try await client.createOrganization(
             parameters: .init(
-                intermediateSessionToken: "token",
                 sessionDuration: 12,
                 organizationName: "hello",
                 organizationSlug: "goodbye",
@@ -63,7 +81,7 @@ final class B2BDiscoveryTestCase: BaseTestCase {
             networkInterceptor.requests[0],
             urlString: "https://web.stytch.com/sdk/v1/b2b/discovery/organizations/create",
             method: .post([
-                "intermediate_session_token": "token",
+                "intermediate_session_token": JSON.string(intermediateSessionToken),
                 "session_duration_minutes": 12,
                 "organization_name": "hello",
                 "organization_slug": "goodbye",

--- a/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
@@ -111,6 +111,8 @@ final class B2BMagicLinksTestCase: BaseTestCase {
 
         Current.timer = { _, _, _ in .init() }
 
+        Current.sessionStorage.updateSession(intermediateSessionToken: intermediateSessionToken)
+
         let response = try await StytchB2BClient.magicLinks.authenticate(parameters: parameters)
         XCTAssertEqual(response.statusCode, 200)
         XCTAssertEqual(response.requestId, "req_123")
@@ -126,7 +128,11 @@ final class B2BMagicLinksTestCase: BaseTestCase {
         try XCTAssertRequest(
             networkInterceptor.requests[0],
             urlString: "https://web.stytch.com/sdk/v1/b2b/magic_links/authenticate",
-            method: .post(["magic_links_token": "12345", "session_duration_minutes": 15, "pkce_code_verifier": "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741"])
+            method: .post([
+                "intermediate_session_token": JSON.string(intermediateSessionToken),
+                "magic_links_token": "12345", "session_duration_minutes": 15,
+                "pkce_code_verifier": "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741",
+            ])
         )
     }
 

--- a/Tests/StytchCoreTests/B2BOAuthTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOAuthTestCase.swift
@@ -10,6 +10,8 @@ final class B2BOAuthTestCase: BaseTestCase {
 
         Current.timer = { _, _, _ in .init() }
 
+        Current.sessionStorage.updateSession(intermediateSessionToken: intermediateSessionToken)
+
         _ = try Current.pkcePairManager.generateAndReturnPKCECodePair()
         _ = try await StytchB2BClient.oauth.authenticate(parameters: .init(oauthToken: "i-am-token", sessionDurationMinutes: 12))
 
@@ -17,6 +19,7 @@ final class B2BOAuthTestCase: BaseTestCase {
             networkInterceptor.requests[0],
             urlString: "https://web.stytch.com/sdk/v1/b2b/oauth/authenticate",
             method: .post([
+                "intermediate_session_token": JSON.string(intermediateSessionToken),
                 "session_duration_minutes": 12,
                 "pkce_code_verifier": "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741",
                 "oauth_token": "i-am-token",

--- a/Tests/StytchCoreTests/B2BOTPTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOTPTestCase.swift
@@ -19,12 +19,15 @@ final class B2BOTPTestCase: BaseTestCase {
             locale: locale
         )
 
+        Current.sessionStorage.updateSession(intermediateSessionToken: intermediateSessionToken)
+
         _ = try await StytchB2BClient.otp.send(parameters: parameters)
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
             urlString: "https://web.stytch.com/sdk/v1/b2b/otps/sms/send",
             method: .post([
+                "intermediate_session_token": JSON.string(intermediateSessionToken),
                 "organization_id": JSON.string(organizationId),
                 "member_id": JSON.string(memberId),
                 "mfa_phone_number": JSON.string(mfaPhoneNumber),
@@ -50,12 +53,16 @@ final class B2BOTPTestCase: BaseTestCase {
             memberId: memberId,
             code: code
         )
+
+        Current.sessionStorage.updateSession(intermediateSessionToken: intermediateSessionToken)
+
         _ = try await StytchB2BClient.otp.authenticate(parameters: parameters)
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
             urlString: "https://web.stytch.com/sdk/v1/b2b/otps/sms/authenticate",
             method: .post([
+                "intermediate_session_token": JSON.string(intermediateSessionToken),
                 "session_duration_minutes": JSON.number(30),
                 "organization_id": JSON.string(organizationId),
                 "member_id": JSON.string(memberId),

--- a/Tests/StytchCoreTests/B2BPasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BPasswordsTestCase.swift
@@ -13,12 +13,16 @@ final class B2BPasswordsTestCase: BaseTestCase {
         )
         networkInterceptor.responses { B2BMFAAuthenticateResponse.mock }
         Current.timer = { _, _, _ in .init() }
+
+        Current.sessionStorage.updateSession(intermediateSessionToken: intermediateSessionToken)
+
         _ = try await client.authenticate(parameters: authParams)
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
             urlString: "https://web.stytch.com/sdk/v1/b2b/passwords/authenticate",
             method: .post([
+                "intermediate_session_token": JSON.string(intermediateSessionToken),
                 "email_address": "user@stytch.com",
                 "session_duration_minutes": 26,
                 "password": "password123",
@@ -53,6 +57,9 @@ final class B2BPasswordsTestCase: BaseTestCase {
             BasicResponse(requestId: "123", statusCode: 200)
             B2BMFAAuthenticateResponse.mock
         }
+
+        Current.sessionStorage.updateSession(intermediateSessionToken: intermediateSessionToken)
+
         _ = try await client.resetByEmailStart(
             parameters: .init(organizationId: "org123", email: "user@stytch.com", loginUrl: nil, resetPasswordUrl: XCTUnwrap(URL(string: "https://stytch.com/reset")), resetPasswordExpiration: 15, resetPasswordTemplateId: "one-two-buckle-my-shoe")
         )
@@ -79,6 +86,7 @@ final class B2BPasswordsTestCase: BaseTestCase {
             networkInterceptor.requests[1],
             urlString: "https://web.stytch.com/sdk/v1/b2b/passwords/email/reset",
             method: .post([
+                "intermediate_session_token": JSON.string(intermediateSessionToken),
                 "password_reset_token": "12345",
                 "code_verifier": "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741",
                 "session_duration_minutes": 30,
@@ -91,12 +99,15 @@ final class B2BPasswordsTestCase: BaseTestCase {
         networkInterceptor.responses { B2BAuthenticateResponse.mock }
         Current.timer = { _, _, _ in .init() }
 
+        Current.sessionStorage.updateSession(intermediateSessionToken: intermediateSessionToken)
+
         _ = try await client.resetByExistingPassword(parameters: .init(organizationId: "org123", email: "jobe@bluth.com", existingPassword: "magicIsFun", newPassword: "buster_is_trouble"))
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
             urlString: "https://web.stytch.com/sdk/v1/b2b/passwords/existing_password/reset",
             method: .post([
+                "intermediate_session_token": JSON.string(intermediateSessionToken),
                 "organization_id": "org123",
                 "email_address": "jobe@bluth.com",
                 "existing_password": "magicIsFun",

--- a/Tests/StytchCoreTests/B2BSSOTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSSOTestCase.swift
@@ -44,6 +44,9 @@ final class B2BSSOTestCase: BaseTestCase {
             try await StytchB2BClient.sso.authenticate(parameters: .init(token: "i-am-token", sessionDuration: 12)),
             StytchSDKError.missingPKCE
         )
+
+        Current.sessionStorage.updateSession(intermediateSessionToken: intermediateSessionToken)
+
         _ = try Current.pkcePairManager.generateAndReturnPKCECodePair()
         _ = try await StytchB2BClient.sso.authenticate(parameters: .init(token: "i-am-token", sessionDuration: 12))
 
@@ -51,6 +54,7 @@ final class B2BSSOTestCase: BaseTestCase {
             networkInterceptor.requests[0],
             urlString: "https://web.stytch.com/sdk/v1/b2b/sso/authenticate",
             method: .post([
+                "intermediate_session_token": JSON.string(intermediateSessionToken),
                 "session_duration_minutes": 12,
                 "pkce_code_verifier": "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741",
                 "sso_token": "i-am-token",

--- a/Tests/StytchCoreTests/B2BTOTPTestCase.swift
+++ b/Tests/StytchCoreTests/B2BTOTPTestCase.swift
@@ -19,12 +19,16 @@ final class B2BTOTPTestCase: BaseTestCase {
             memberId: memberId,
             expirationMinutes: .defaultSessionDuration
         )
+
+        Current.sessionStorage.updateSession(intermediateSessionToken: intermediateSessionToken)
+
         _ = try await StytchB2BClient.totp.create(parameters: parameters)
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
             urlString: "https://web.stytch.com/sdk/v1/b2b/totp",
             method: .post([
+                "intermediate_session_token": JSON.string(intermediateSessionToken),
                 "expiration_minutes": JSON.number(30),
                 "organization_id": JSON.string(organizationId),
                 "member_id": JSON.string(memberId),
@@ -49,12 +53,16 @@ final class B2BTOTPTestCase: BaseTestCase {
             memberId: memberId,
             code: code
         )
+
+        Current.sessionStorage.updateSession(intermediateSessionToken: intermediateSessionToken)
+
         _ = try await StytchB2BClient.totp.authenticate(parameters: parameters)
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
             urlString: "https://web.stytch.com/sdk/v1/b2b/totp/authenticate",
             method: .post([
+                "intermediate_session_token": JSON.string(intermediateSessionToken),
                 "session_duration_minutes": JSON.number(30),
                 "organization_id": JSON.string(organizationId),
                 "member_id": JSON.string(memberId),

--- a/Tests/StytchCoreTests/BaseTestCase.swift
+++ b/Tests/StytchCoreTests/BaseTestCase.swift
@@ -1,9 +1,12 @@
 import XCTest
 @testable import StytchCore
 
+// swiftlint:disable test_case_accessibility
+
 class BaseTestCase: XCTestCase {
-    // swiftlint:disable:next test_case_accessibility
     var networkInterceptor: NetworkingClientInterceptor = .init()
+
+    let intermediateSessionToken = "intermediateSessionToken_asdfg"
 
     override func setUpWithError() throws {
         try super.setUpWithError()


### PR DESCRIPTION
Linear Ticket: [[SDK-1833] - [iOS] Support MFA in B2B - All Discovery and Discovery OAuth Flows](https://linear.app/stytch/issue/SDK-1833/[ios]-support-mfa-in-b2b-all-discovery-and-discovery-oauth-flows)

## Changes:

1. Modified the discovery flows so that they no longer take an IST in the callers parameters. But instead it is added to the call within the internal implementation.
2. Within `NetworkingRouter` parse out the discovery return types that conform to the newly created `DiscoveryIntermediateSessionTokenDataType` so we can cache the IST separately from the MFA flow.
3. Create a new parameter type `IntermediateSessionTokenParametersWithNoWrappedValue` for when we need to the pass the IST to networking calls that take no other params.
4. Update unit tests to test the internal logic to the public methods to ensure that we add the IST to the request JSON when present.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A