### PR TITLE
[SDK-1826] Delete PKCE code after each request

### DIFF
--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -106,13 +106,21 @@ struct Environment {
     var dfpClient: DFPProvider = DFPClient()
     var captcha: CaptchaProvider = CaptchaClient()
     #endif
-    var pkcePairManager: PKCEPairManager { PKCEPairManagerImpl(keychainClient: keychainClient, cryptoClient: cryptoClient) }
+
+    var pkcePairManager: PKCEPairManager {
+        PKCEPairManagerImpl(
+            keychainClient: keychainClient,
+            cryptoClient: cryptoClient
+        )
+    }
 
     var date: () -> Date = Date.init
 
     var uuid: () -> UUID = UUID.init
 
-    var asyncAfter: (DispatchQueue, DispatchTime, @escaping () -> Void) -> Void = { $0.asyncAfter(deadline: $1, execute: $2) }
+    var asyncAfter: (DispatchQueue, DispatchTime, @escaping () -> Void) -> Void = {
+        $0.asyncAfter(deadline: $1, execute: $2)
+    }
 
     var timer: (TimeInterval, RunLoop, @escaping () -> Void) -> Timer = { interval, runloop, task in
         let timer = Timer(timeInterval: interval, repeats: true) { _ in task() }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+MagicLinks.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+MagicLinks.swift
@@ -26,6 +26,10 @@ public extension StytchB2BClient {
         /// Wraps the magic link [authenticate](https://stytch.com/docs/b2b/api/authenticate-magic-link) API endpoint which validates the magic link token passed in.
         /// If this method succeeds, the member will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
         public func authenticate(parameters: AuthenticateParameters) async throws -> B2BMFAAuthenticateResponse {
+            defer {
+                try? pkcePairManager.clearPKCECodePair()
+            }
+
             // For authenticating if loginOrSignup was called
             if let codeVerifier = pkcePairManager.getPKCECodePair()?.codeVerifier {
                 let intermediateSessionTokenParameters = IntermediateSessionTokenParameters(
@@ -56,7 +60,13 @@ public extension StytchB2BClient {
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// The Authenticate Discovery Magic Link method wraps the [authenticate](https://stytch.com/docs/b2b/api/send-discovery-email) discovery magic link API endpoint, which validates the discovery magic link token passed in.
         public func discoveryAuthenticate(parameters: DiscoveryAuthenticateParameters) async throws -> DiscoveryAuthenticateResponse {
-            guard let codeVerifier: String = pkcePairManager.getPKCECodePair()?.codeVerifier else { throw StytchSDKError.missingPKCE }
+            defer {
+                try? pkcePairManager.clearPKCECodePair()
+            }
+
+            guard let codeVerifier: String = pkcePairManager.getPKCECodePair()?.codeVerifier else {
+                throw StytchSDKError.missingPKCE
+            }
 
             return try await router.post(
                 to: .discoveryAuthenticate,

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+Discovery.swift
@@ -18,10 +18,15 @@ public extension StytchB2BClient.OAuth {
         // sourcery: AsyncVariants
         /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
         public func authenticate(parameters: DiscoveryAuthenticateParameters) async throws -> DiscoveryAuthenticateResponse {
+            defer {
+                try? pkcePairManager.clearPKCECodePair()
+            }
+
             guard let pkcePair: PKCECodePair = pkcePairManager.getPKCECodePair() else {
                 try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "oauth_failure", error: StytchSDKError.missingPKCE))
                 throw StytchSDKError.missingPKCE
             }
+
             do {
                 let result = try await router.post(
                     to: .authenticate,

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
@@ -19,10 +19,15 @@ public extension StytchB2BClient {
         // sourcery: AsyncVariants
         /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
         public func authenticate(parameters: AuthenticateParameters) async throws -> B2BMFAAuthenticateResponse {
+            defer {
+                try? pkcePairManager.clearPKCECodePair()
+            }
+
             guard let pkcePair: PKCECodePair = pkcePairManager.getPKCECodePair() else {
                 try? await StytchB2BClient.events.logEvent(parameters: .init(eventName: "oauth_failure", error: StytchSDKError.missingPKCE))
                 throw StytchSDKError.missingPKCE
             }
+
             do {
                 let intermediateSessionTokenParameters = IntermediateSessionTokenParameters(
                     intermediateSessionToken: sessionStorage.intermediateSessionToken,

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Passwords.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Passwords.swift
@@ -54,6 +54,10 @@ public extension StytchB2BClient {
         ///
         /// The provided password needs to meet our password strength requirements, which can be checked in advance with the password strength endpoint. If the token and password are accepted, the password is securely stored for future authentication and the member is authenticated.
         public func resetByEmail(parameters: ResetByEmailParameters) async throws -> B2BMFAAuthenticateResponse {
+            defer {
+                try? pkcePairManager.clearPKCECodePair()
+            }
+
             guard let pkcePair: PKCECodePair = pkcePairManager.getPKCECodePair() else {
                 throw StytchSDKError.missingPKCE
             }
@@ -70,8 +74,6 @@ public extension StytchB2BClient {
                 to: .resetByEmail(.complete),
                 parameters: intermediateSessionTokenParameters
             )
-
-            try? pkcePairManager.clearPKCECodePair()
 
             return response
         }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO.swift
@@ -30,6 +30,10 @@ public extension StytchB2BClient {
         /// Authenticate a member given a token. This endpoint verifies that the memeber completed the SSO Authentication flow by
         /// verifying that the token is valid and hasn't expired.
         public func authenticate(parameters: AuthenticateParameters) async throws -> B2BMFAAuthenticateResponse {
+            defer {
+                try? pkcePairManager.clearPKCECodePair()
+            }
+
             guard let pkcePair: PKCECodePair = pkcePairManager.getPKCECodePair() else {
                 throw StytchSDKError.missingPKCE
             }

--- a/Sources/StytchCore/StytchClient/MagicLinks/StytchClient+MagicLinks.swift
+++ b/Sources/StytchCore/StytchClient/MagicLinks/StytchClient+MagicLinks.swift
@@ -8,7 +8,13 @@ public extension StytchClient {
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps the magic link [authenticate](https://stytch.com/docs/api/authenticate-magic-link) API endpoint which validates the magic link token passed in. If this method succeeds, the user will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
         public func authenticate(parameters: AuthenticateParameters) async throws -> AuthenticateResponse {
-            guard let pkcePair: PKCECodePair = pkcePairManager.getPKCECodePair() else { throw StytchSDKError.missingPKCE }
+            defer {
+                try? pkcePairManager.clearPKCECodePair()
+            }
+
+            guard let pkcePair: PKCECodePair = pkcePairManager.getPKCECodePair() else {
+                throw StytchSDKError.missingPKCE
+            }
 
             return try await router.post(
                 to: .authenticate,

--- a/Sources/StytchCore/StytchClient/OAuth/StytchClient+OAuth.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/StytchClient+OAuth.swift
@@ -15,10 +15,15 @@ public extension StytchClient {
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
         public func authenticate(parameters: AuthenticateParameters) async throws -> AuthenticateResponse {
+            defer {
+                try? pkcePairManager.clearPKCECodePair()
+            }
+
             guard let pkcePair: PKCECodePair = pkcePairManager.getPKCECodePair() else {
                 try? await StytchClient.events.logEvent(parameters: .init(eventName: "oauth_failure", error: StytchSDKError.missingPKCE))
                 throw StytchSDKError.missingPKCE
             }
+
             do {
                 let result = try await router.post(
                     to: .authenticate,

--- a/Sources/StytchCore/StytchClient/Passwords/StytchClient+Passwords.swift
+++ b/Sources/StytchCore/StytchClient/Passwords/StytchClient+Passwords.swift
@@ -58,6 +58,10 @@ public extension StytchClient {
         ///
         /// The provided password needs to meet our password strength requirements, which can be checked in advance with the password strength endpoint. If the token and password are accepted, the password is securely stored for future authentication and the user is authenticated.
         public func resetByEmail(parameters: ResetByEmailParameters) async throws -> AuthenticateResponse {
+            defer {
+                try? pkcePairManager.clearPKCECodePair()
+            }
+
             guard let pkcePair: PKCECodePair = pkcePairManager.getPKCECodePair() else {
                 throw StytchSDKError.missingPKCE
             }
@@ -66,8 +70,6 @@ public extension StytchClient {
                 to: .resetByEmail(.complete),
                 parameters: CodeVerifierParameters(codeVerifier: pkcePair.codeVerifier, wrapped: parameters)
             )
-
-            try? pkcePairManager.clearPKCECodePair()
 
             return response
         }

--- a/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
@@ -134,6 +134,8 @@ final class B2BMagicLinksTestCase: BaseTestCase {
                 "pkce_code_verifier": "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741",
             ])
         )
+
+        XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
     }
 
     func testDiscoveryAuthenticate() async throws {
@@ -160,6 +162,8 @@ final class B2BMagicLinksTestCase: BaseTestCase {
             urlString: "https://web.stytch.com/sdk/v1/b2b/magic_links/discovery/authenticate",
             method: .post(["discovery_magic_links_token": "12345", "pkce_code_verifier": "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741"])
         )
+
+        XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
     }
 }
 

--- a/Tests/StytchCoreTests/B2BOAuthTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOAuthTestCase.swift
@@ -13,6 +13,8 @@ final class B2BOAuthTestCase: BaseTestCase {
         Current.sessionStorage.updateSession(intermediateSessionToken: intermediateSessionToken)
 
         _ = try Current.pkcePairManager.generateAndReturnPKCECodePair()
+        XCTAssertNotNil(Current.pkcePairManager.getPKCECodePair())
+
         _ = try await StytchB2BClient.oauth.authenticate(parameters: .init(oauthToken: "i-am-token", sessionDurationMinutes: 12))
 
         try XCTAssertRequest(
@@ -25,6 +27,8 @@ final class B2BOAuthTestCase: BaseTestCase {
                 "oauth_token": "i-am-token",
             ])
         )
+
+        XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
     }
 
     func testAuthenticateFailsWithPKCE() async throws {
@@ -47,6 +51,8 @@ final class B2BOAuthTestCase: BaseTestCase {
         Current.timer = { _, _, _ in .init() }
 
         _ = try Current.pkcePairManager.generateAndReturnPKCECodePair()
+        XCTAssertNotNil(Current.pkcePairManager.getPKCECodePair())
+
         _ = try await StytchB2BClient.oauth.discovery.authenticate(parameters: .init(discoveryOauthToken: "i-am-token"))
 
         try XCTAssertRequest(
@@ -57,6 +63,8 @@ final class B2BOAuthTestCase: BaseTestCase {
                 "discovery_oauth_token": "i-am-token",
             ])
         )
+
+        XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
     }
 
     func testDiscoveryAuthenticateFailsWithPKCE() async throws {

--- a/Tests/StytchCoreTests/B2BPasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BPasswordsTestCase.swift
@@ -79,6 +79,7 @@ final class B2BPasswordsTestCase: BaseTestCase {
         )
 
         Current.timer = { _, _, _ in .init() }
+        XCTAssertNotNil(Current.pkcePairManager.getPKCECodePair())
 
         _ = try await client.resetByEmail(parameters: .init(token: "12345", password: "iAMpasswordHEARmeROAR"))
 
@@ -93,6 +94,8 @@ final class B2BPasswordsTestCase: BaseTestCase {
                 "password": "iAMpasswordHEARmeROAR",
             ])
         )
+
+        XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
     }
 
     func testResetByExistingPassword() async throws {

--- a/Tests/StytchCoreTests/B2BSSOTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSSOTestCase.swift
@@ -48,6 +48,8 @@ final class B2BSSOTestCase: BaseTestCase {
         Current.sessionStorage.updateSession(intermediateSessionToken: intermediateSessionToken)
 
         _ = try Current.pkcePairManager.generateAndReturnPKCECodePair()
+        XCTAssertNotNil(Current.pkcePairManager.getPKCECodePair())
+
         _ = try await StytchB2BClient.sso.authenticate(parameters: .init(token: "i-am-token", sessionDuration: 12))
 
         try XCTAssertRequest(
@@ -60,6 +62,8 @@ final class B2BSSOTestCase: BaseTestCase {
                 "sso_token": "i-am-token",
             ])
         )
+
+        XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
     }
 
     func testGetConnections() async throws {

--- a/Tests/StytchCoreTests/MagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/MagicLinksTestCase.swift
@@ -141,5 +141,7 @@ final class MagicLinksTestCase: BaseTestCase {
             urlString: "https://web.stytch.com/sdk/v1/magic_links/authenticate",
             method: .post(["token": "12345", "session_duration_minutes": 15, "code_verifier": "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741"])
         )
+
+        XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
     }
 }

--- a/Tests/StytchCoreTests/OAuthTestCase.swift
+++ b/Tests/StytchCoreTests/OAuthTestCase.swift
@@ -43,6 +43,7 @@ final class OAuthTestCase: BaseTestCase {
             StytchSDKError.missingPKCE
         )
         _ = try Current.pkcePairManager.generateAndReturnPKCECodePair()
+        XCTAssertNotNil(Current.pkcePairManager.getPKCECodePair())
         _ = try await StytchClient.oauth.authenticate(parameters: .init(token: "i-am-token", sessionDuration: 12))
 
         try XCTAssertRequest(
@@ -54,6 +55,8 @@ final class OAuthTestCase: BaseTestCase {
                 "token": "i-am-token",
             ])
         )
+
+        XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
     }
 }
 

--- a/Tests/StytchCoreTests/PasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/PasswordsTestCase.swift
@@ -98,6 +98,8 @@ final class PasswordsTestCase: BaseTestCase {
 
         Current.timer = { _, _, _ in .init() }
 
+        XCTAssertNotNil(Current.pkcePairManager.getPKCECodePair())
+
         _ = try await StytchClient.passwords.resetByEmail(parameters: .init(token: "12345", password: "iAMpasswordHEARmeROAR"))
 
         try XCTAssertRequest(
@@ -110,6 +112,8 @@ final class PasswordsTestCase: BaseTestCase {
                 "password": "iAMpasswordHEARmeROAR",
             ])
         )
+
+        XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
     }
 
     func testResetBySession() async throws {


### PR DESCRIPTION
Linear Ticket: [[SDK-1826] [iOS] Delete PKCE code after each request](https://linear.app/stytch/issue/SDK-1826/[ios]-delete-pkce-code-after-each-request)

## Changes:

1. When `PKCEPairManager` `generateAndReturnPKCECodePair()` is called it will always be used on the first call in a sequence and `getPKCECodePair()` will be used on the final call in the sequence, therefore every time `getPKCECodePair()` is used from within the SDK we should delete the pair regardless of what the outcome of the call is.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A