### PR TITLE
Delete local biometric registration if it doesn't exist on the logged in user

### DIFF
--- a/Sources/StytchCore/Routing/NetworkingRouter.swift
+++ b/Sources/StytchCore/Routing/NetworkingRouter.swift
@@ -108,6 +108,7 @@ public extension NetworkingRouter {
             try? keychainClient.removeItem(.privateKeyRegistration)
         }
     }
+
     // swiftlint:disable:next function_body_length
     private func performRequest<Response: Decodable>(
         _ method: NetworkingClient.Method,


### PR DESCRIPTION
Linear Ticket: [SDK-1883](https://linear.app/stytch/issue/SDK-1883)

## Changes:

1. Delete local biometrics registration if it doesn't exist on the logged in user

## Notes:
The other part of this ticket, only deleting a registration if the network delete succeeds, appears to already be working correctly

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
