### PR TITLE
Add provider params to the B2C OAuth client

### DIFF
--- a/Sources/StytchCore/Extensions/URL+Stytch.swift
+++ b/Sources/StytchCore/Extensions/URL+Stytch.swift
@@ -1,38 +1,10 @@
 import Foundation
 
-extension URL {
-    /// Filters the queryParameters to remove any tuple pairs with a nil secondary value.
-    /// Turning it from an array of [(String, String?)] to an array of [(String, String)].
-    private func filteredQueryParameters(_ queryParameters: [(String, String?)]) -> [(String, String)] {
-        var filteredQueryParameters = [(String, String)]()
-        queryParameters.forEach { name, value in
-            guard let value = value else {
-                return
-            }
-            filteredQueryParameters.append((name, value))
-        }
-        return filteredQueryParameters
-    }
-
-    func appending(queryParameters: [(name: String, value: String?)]) -> URL {
-        let filteredQueryParamters = filteredQueryParameters(queryParameters)
-        guard filteredQueryParamters.isEmpty == false, var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
-            return self
-        }
-
-        var queryItems = urlComponents.queryItems ?? []
-        queryItems.append(contentsOf: filteredQueryParamters.map(URLQueryItem.init(name:value:)))
-        urlComponents.queryItems = queryItems
-        return urlComponents.url ?? self
-    }
-}
-
 extension Dictionary where Key == String, Value == String {
     func toURLParameters() -> String {
         let urlComponents = map { key, value in
-            let escapedKey = key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
             let escapedValue = value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-            return "\(escapedKey)=\(escapedValue)"
+            return "\(key)=\(escapedValue)"
         }
         return urlComponents.joined(separator: "&")
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty+Discovery.swift
@@ -70,16 +70,25 @@ public extension StytchB2BClient.OAuth.ThirdParty.Discovery {
                 throw StytchSDKError.consumerSDKNotConfigured
             }
 
-            let queryParameters: [(String, String?)] = [
-                ("pkce_code_challenge", try pkcePairManager.generateAndReturnPKCECodePair().codeChallenge),
-                ("public_token", publicToken),
-                ("custom_scopes", customScopes?.joined(separator: " ")),
-                ("provider_params", providerParams?.toURLParameters()),
-                ("discovery_redirect_url", discoveryRedirectUrl?.absoluteString),
+            var queryParameters: [String: String] = [
+                "pkce_code_challenge": try pkcePairManager.generateAndReturnPKCECodePair().codeChallenge,
+                "public_token": publicToken,
             ]
 
+            if let customScopes = customScopes?.joined(separator: " ") {
+                queryParameters["custom_scopes"] = customScopes
+            }
+
+            if let providerParams = providerParams?.toURLParameters() {
+                queryParameters["provider_params"] = providerParams
+            }
+
+            if let discoveryRedirectUrl = discoveryRedirectUrl?.absoluteString {
+                queryParameters["discovery_redirect_url"] = discoveryRedirectUrl
+            }
+
             let domain = Current.localStorage.stytchDomain(publicToken)
-            guard let url = URL(string: "https://\(domain)/v1/b2b/public/oauth/\(providerName)/discovery/start")?.appending(queryParameters: queryParameters) else {
+            guard let url = URL(string: "https://\(domain)/v1/b2b/public/oauth/\(providerName)/discovery/start?\(queryParameters.toURLParameters())") else {
                 throw StytchSDKError.invalidStartURL
             }
 

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
@@ -96,19 +96,37 @@ public extension StytchB2BClient.OAuth.ThirdParty {
                 throw StytchSDKError.consumerSDKNotConfigured
             }
 
-            let queryParameters: [(String, String?)] = [
-                ("pkce_code_challenge", try pkcePairManager.generateAndReturnPKCECodePair().codeChallenge),
-                ("public_token", publicToken),
-                ("organization_id", organizationId),
-                ("slug", organizationSlug),
-                ("custom_scopes", customScopes?.joined(separator: " ")),
-                ("provider_params", providerParams?.toURLParameters()),
-                ("login_redirect_url", loginRedirectUrl?.absoluteString),
-                ("signup_redirect_url", signupRedirectUrl?.absoluteString),
+            var queryParameters: [String: String] = [
+                "pkce_code_challenge": try pkcePairManager.generateAndReturnPKCECodePair().codeChallenge,
+                "public_token": publicToken,
             ]
 
+            if let organizationId = organizationId {
+                queryParameters["organization_id"] = organizationId
+            }
+
+            if let organizationSlug = organizationSlug {
+                queryParameters["slug"] = organizationSlug
+            }
+
+            if let customScopes = customScopes?.joined(separator: " ") {
+                queryParameters["custom_scopes"] = customScopes
+            }
+
+            if let providerParams = providerParams?.toURLParameters() {
+                queryParameters["provider_params"] = providerParams
+            }
+
+            if let loginRedirectUrl = loginRedirectUrl?.absoluteString {
+                queryParameters["login_redirect_url"] = loginRedirectUrl
+            }
+
+            if let signupRedirectUrl = signupRedirectUrl?.absoluteString {
+                queryParameters["signup_redirect_url"] = signupRedirectUrl
+            }
+
             let domain = Current.localStorage.stytchDomain(publicToken)
-            guard let url = URL(string: "https://\(domain)/v1/b2b/public/oauth/\(providerName)/start")?.appending(queryParameters: queryParameters) else {
+            guard let url = URL(string: "https://\(domain)/v1/b2b/public/oauth/\(providerName)/start?\(queryParameters.toURLParameters())") else {
                 throw StytchSDKError.invalidStartURL
             }
 

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO.swift
@@ -105,16 +105,25 @@ public extension StytchB2BClient.SSO {
                 throw StytchSDKError.B2BSDKNotConfigured
             }
 
-            let queryParameters: [(String, String?)] = [
-                ("pkce_code_challenge", try pkcePairManager.generateAndReturnPKCECodePair().codeChallenge),
-                ("public_token", publicToken),
-                ("connection_id", connectionId),
-                ("login_redirect_url", loginRedirectUrl?.absoluteString),
-                ("signup_redirect_url", signupRedirectUrl?.absoluteString),
+            var queryParameters: [String: String] = [
+                "pkce_code_challenge": try pkcePairManager.generateAndReturnPKCECodePair().codeChallenge,
+                "public_token": publicToken,
             ]
 
+            if let connectionId {
+                queryParameters["connection_id"] = connectionId
+            }
+
+            if let loginRedirectUrl = loginRedirectUrl?.absoluteString {
+                queryParameters["login_redirect_url"] = loginRedirectUrl
+            }
+
+            if let signupRedirectUrl = signupRedirectUrl?.absoluteString {
+                queryParameters["signup_redirect_url"] = signupRedirectUrl
+            }
+
             let domain = Current.localStorage.stytchDomain(publicToken)
-            guard let url = URL(string: "https://\(domain)/v1/public/sso/start")?.appending(queryParameters: queryParameters) else {
+            guard let url = URL(string: "https://\(domain)/v1/public/sso/start?\(queryParameters.toURLParameters())") else {
                 throw StytchSDKError.invalidStartURL
             }
 

--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
@@ -69,17 +69,29 @@ public extension StytchClient.OAuth.ThirdParty {
                 throw StytchSDKError.consumerSDKNotConfigured
             }
 
-            let queryParameters: [(String, String?)] = [
-                ("code_challenge", try pkcePairManager.generateAndReturnPKCECodePair().codeChallenge),
-                ("public_token", publicToken),
-                ("login_redirect_url", loginRedirectUrl?.absoluteString),
-                ("signup_redirect_url", signupRedirectUrl?.absoluteString),
-                ("custom_scopes", customScopes?.joined(separator: " ")),
-                ("provider_params", providerParams?.toURLParameters()),
+            var queryParameters: [String: String] = [
+                "code_challenge": try pkcePairManager.generateAndReturnPKCECodePair().codeChallenge,
+                "public_token": publicToken,
             ]
 
+            if let customScopes = customScopes?.joined(separator: " ") {
+                queryParameters["custom_scopes"] = customScopes
+            }
+
+            if let providerParams = providerParams?.toURLParameters() {
+                queryParameters["provider_params"] = providerParams
+            }
+
+            if let loginRedirectUrl = loginRedirectUrl?.absoluteString {
+                queryParameters["login_redirect_url"] = loginRedirectUrl
+            }
+
+            if let signupRedirectUrl = signupRedirectUrl?.absoluteString {
+                queryParameters["signup_redirect_url"] = signupRedirectUrl
+            }
+
             let domain = Current.localStorage.stytchDomain(publicToken)
-            guard let url = URL(string: "https://\(domain)/v1/public/oauth/\(providerName)/start")?.appending(queryParameters: queryParameters) else {
+            guard let url = URL(string: "https://\(domain)/v1/public/oauth/\(providerName)/start?\(queryParameters.toURLParameters())") else {
                 throw StytchSDKError.invalidStartURL
             }
 

--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
@@ -38,6 +38,7 @@ public extension StytchClient.OAuth.ThirdParty {
         let loginRedirectUrl: URL?
         let signupRedirectUrl: URL?
         let customScopes: [String]?
+        let providerParams: [String: String]?
         public let clientType: ClientType = .consumer
         @Dependency(\.pkcePairManager) private var pkcePairManager
 
@@ -50,14 +51,17 @@ public extension StytchClient.OAuth.ThirdParty {
         ///   - loginRedirectUrl: The url an existing user is redirected to after authenticating with the identity provider. This url **must** use a custom scheme and be added to your Stytch Dashboard.
         ///   - signupRedirectUrl: The url a new user is redirected to after authenticating with the identity provider. This url **must** use a custom scheme and be added to your Stytch Dashboard.
         ///   - customScopes: Any additional scopes to be requested from the identity provider.
+        ///   - providerParams: An optional mapping of provider specific values to pass through to the OAuth provider
         public init(
             loginRedirectUrl: URL? = nil,
             signupRedirectUrl: URL? = nil,
-            customScopes: [String]? = nil
+            customScopes: [String]? = nil,
+            providerParams: [String: String]? = nil
         ) {
             self.loginRedirectUrl = loginRedirectUrl
             self.signupRedirectUrl = signupRedirectUrl
             self.customScopes = customScopes
+            self.providerParams = providerParams
         }
 
         public func startUrl(_ providerName: String) throws -> URL {
@@ -71,6 +75,7 @@ public extension StytchClient.OAuth.ThirdParty {
                 ("login_redirect_url", loginRedirectUrl?.absoluteString),
                 ("signup_redirect_url", signupRedirectUrl?.absoluteString),
                 ("custom_scopes", customScopes?.joined(separator: " ")),
+                ("provider_params", providerParams?.toURLParameters()),
             ]
 
             let domain = Current.localStorage.stytchDomain(publicToken)


### PR DESCRIPTION
[Add support for provider_[parameter] parameter](https://linear.app/stytch/issue/SDK-1882/rn-sdk-[maybe-other-mobile-sdks]-add-support-for-provider-[parameter])

## Changes:

1. Update oauth b2c client to add missing param for providerParams.
2. Refactor the way we create the url parameters for the various start urls to remove some awkward code around url parameter generation.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
