### PR TITLE
[SDK-1918] Inline documentation audit

### DIFF
--- a/Sources/StytchCore/StytchB2BClient/Models/Member.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/Member.swift
@@ -4,14 +4,23 @@ import Foundation
 public struct Member: Codable {
     public typealias ID = Identifier<Self, String>
 
+    /// Globally unique UUID that identifies a specific Member. The member_id is critical to perform operations on a Member, so be sure to preserve this value.
     public var id: ID { memberId }
+    /// Globally unique UUID that identifies a specific Organization. The organization_id is critical to perform operations on an Organization, so be sure to preserve this value.
     public let organizationId: Organization.ID
+    /// The email address of the Member.
     public let emailAddress: String
+    /// The status of the Member. The possible values are: pending, invited, active, or deleted.
     public let status: Status
+    /// The name of the Member.
     public let name: String
+    /// An array of registered SAML Connection or OIDC Connection objects the Member has authenticated with.
     public let ssoRegistrations: [SSORegistration]
+    /// An arbitrary JSON object for storing application-specific data or identity-provider-specific data.
     public let trustedMetadata: JSON
+    /// An arbitrary JSON object of application-specific data. These fields can be edited directly by the frontend SDK, and should not be used to store critical information. See the Metadata resource (https://stytch.com/docs/b2b/api/metadata) for complete field behavior details.
     public let untrustedMetadata: JSON
+    /// Globally unique UUID that identifies a Member's password.
     public let memberPasswordId: String
 
     let memberId: ID
@@ -43,9 +52,13 @@ public extension Member {
 public struct SSORegistration: Codable {
     public typealias ID = Identifier<Self, String>
 
+    /// The unique ID of an SSO Registration.
     public var id: ID { registrationId }
+    /// Globally unique UUID that identifies a specific SSO connection_id for a Member.
     public let connectionId: String
+    /// The ID of the member given by the identity provider.
     public let externalId: String
+    /// An object for storing SSO attributes brought over from the identity provider.
     public let ssoAttributes: JSON
 
     let registrationId: ID

--- a/Sources/StytchCore/StytchB2BClient/Models/MemberSession.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/MemberSession.swift
@@ -4,14 +4,23 @@ import Foundation
 public struct MemberSession: Codable {
     public typealias ID = Identifier<Self, String>
 
+    /// Globally unique UUID that identifies a specific Session in the Stytch API. The member_session_id is critical to perform operations on an Session, so be sure to preserve this value.
     public var id: ID { memberSessionId }
+    /// Globally unique UUID that identifies a specific Organization. The organization_id is critical to perform operations on an Organization, so be sure to preserve this value.
     public let organizationId: Organization.ID
+    /// Globally unique UUID that identifies a specific Member. The member_id is critical to perform operations on a Member, so be sure to preserve this value.
     public let memberId: Member.ID
+    /// The timestamp when the Session started.
     public let startedAt: Date
+    /// The timestamp when the Session was last accessed.
     public let lastAccessedAt: Date
+    /// The timestamp when the Session will expire.
     public let expiresAt: Date
+    /// An array of different authentication factors that comprise a Session.
     public let authenticationFactors: [AuthenticationFactor]
+    /// A custom claims map for the Session being authenticated. Claims will be included on the Session object and in the JWT. iss, sub, aud, exp, nbf, iat, jti are reserved claims. Total custom claims size cannot exceed four kilobytes.
     public let customClaims: JSON?
+    /// A list of the Roles explicitly or implicitly assigned to this Member that are valid for this Member Session. This may differ from the Roles you see on the Member object - Roles that are implicitly assigned by SSO connection or SSO group will only be valid for a Member Session if there is at least one authentication factor on the Member Session from the specified SSO connection.
     public let roles: [String]?
 
     let memberSessionId: ID

--- a/Sources/StytchCore/StytchB2BClient/Models/Organization.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/Organization.swift
@@ -12,10 +12,15 @@ public struct Organization: Codable {
         case trustedMetadata
     }
 
+    /// Globally unique UUID that identifies a specific Organization. The organization_id is critical to perform operations on an Organization, so be sure to preserve this value.
     public var id: ID { organizationId }
+    /// The name of the Organization. Must be between 1 and 128 characters in length.
     public let name: String
+    /// The unique URL slug of the Organization. The slug only accepts alphanumeric characters and the following reserved characters: - . _ ~. Must be between 2 and 128 characters in length.
     public let slug: String
+    /// The image URL of the Organization logo.
     public let logoUrl: URL?
+    /// An arbitrary JSON object for storing application-specific data or identity-provider-specific data.
     public let trustedMetadata: JSON
     let organizationId: ID
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Bootstrap.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Bootstrap.swift
@@ -17,7 +17,7 @@ extension StytchB2BClient {
         @Dependency(\.networkingClient) private var networkingClient
         @Dependency(\.localStorage) private var localStorage
 
-        public func fetch() async throws {
+        func fetch() async throws {
             guard let publicToken = StytchB2BClient.instance.configuration?.publicToken else {
                 throw StytchSDKError.B2BSDKNotConfigured
             }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
@@ -3,28 +3,43 @@ import Foundation
 // swiftlint:disable identifier_name
 
 public extension StytchB2BClient {
+    /// The authentication setting that controls the JIT provisioning of Members when authenticating via SSO.
     enum SsoJitProvisioning: String, Codable {
+        /// New Members will be automatically provisioned upon successful authentication via any of the Organization's sso_active_connections.
         case ALL_ALLOWED
+        /// Only new Members with SSO logins that comply with sso_jit_provisioning_allowed_connections can be provisioned upon authentication.
         case RESTRICTED
+        /// Disable JIT provisioning via SSO.
         case NOT_ALLOWED
     }
 
+    /// The authentication setting that controls how a new Member can be provisioned by authenticating via Email Magic Link or OAuth.
     enum EmailJitProvisioning: String, Codable {
+        /// Only new Members with verified emails that comply with email_allowed_domains can be provisioned upon authentication via Email Magic Link or OAuth.
         case RESTRICTED
+        /// Disable JIT provisioning via Email Magic Link and OAuth.
         case NOT_ALLOWED
     }
 
+    /// The authentication setting that controls how a new Member can be invited to an organization by email.
     enum EmailInvites: String, Codable {
+        /// Any new Member can be invited to join via email.
         case ALL_ALLOWED
+        /// Only new Members with verified emails that comply with email_allowed_domains can be invited via email.
         case RESTRICTED
+        /// Disable email invites.
         case NOT_ALLOWED
     }
 
+    /// The setting that controls which authentication methods can be used by Members of an Organization.
     enum AuthMethods: String, Codable {
+        /// The default setting which allows all authentication methods to be used.
         case ALL_ALLOWED
+        /// Only methods that comply with allowed_auth_methods can be used for authentication. This setting does not apply to Members with is_breakglass set to true.
         case RESTRICTED
     }
 
+    /// An array of allowed authentication methods. This list is enforced when auth_methods is set to RESTRICTED. The list's accepted values are: sso, magic_link, password, google_oauth, and microsoft_oauth.
     enum AllowedAuthMethods: String, Codable {
         case SSO = "sso"
         case MAGIC_LINK = "magic_link"
@@ -33,40 +48,65 @@ public extension StytchB2BClient {
         case MICROSOFT_OAUTH = "microsoft_oauth"
     }
 
+    /// The setting that controls which MFA methods can be used by Members of an Organization.
     enum MfaMethods: String, Codable {
+        /// The default setting which allows all authentication methods to be used.
         case ALL_ALLOWED
+        /// Only methods that comply with allowed_mfa_methods can be used for authentication. This setting does not apply to Members with is_breakglass set to true.
         case RESTRICTED
     }
 
+    /// An array of allowed MFA authentication methods. This list is enforced when mfa_methods is set to RESTRICTED. The list's accepted values are: sms_otp and totp.
+    /// If this field is provided and a session header is passed into the request, the Member Session must have permission to perform the update.settings.allowed-mfa-methods action on the stytch.organization Resource.
     enum MfaMethod: String, Codable {
         case SMS = "sms_otp"
         case TOTP = "totp"
     }
 
+    /// The setting that controls the MFA policy for all Members in the Organization.
     enum MfaPolicy: String, Codable {
+        /// All Members within the Organization will be required to complete MFA every time they wish to log in. However, any active Session that existed prior to this setting change will remain valid.
         case REQUIRED_FOR_ALL
+        /// The default value. The Organization does not require MFA by default for all Members. Members will be required to complete MFA only if their mfa_enrolled status is set to true.
         case OPTIONAL
     }
 
+    /// Sets the Member’s MFA enrollment status upon a successful authentication.
+    /// If the Organization’s MFA policy is REQUIRED_FOR_ALL, this field will be ignored.
+    /// If this field is not passed in, the Member’s mfa_enrolled boolean will not be affected.
     enum MFAEnrollment: String, Codable {
+        /// Sets the Member's mfa_enrolled boolean to true. The Member will be required to complete an MFA step upon subsequent logins to the Organization.
         case enroll
+        /// Sets the Member's mfa_enrolled boolean to false. The Member will no longer be required to complete MFA steps when logging in to the Organization.
         case unenroll
     }
 
+    /// Implicit role assignments based off of email domains.
+    /// For each domain-Role pair, all Members whose email addresses have the specified email domain will be granted the associated Role, regardless of their login method.
+    /// See the RBAC guide for more information about role assignment (https://stytch.com/docs/b2b/guides/rbac/role-assignment).
     struct RBACEmailImplicitRoleAssignments: Codable {
         let roleId: String
         let domain: String
 
+        /// - Parameters:
+        ///   - roleId: The unique identifier of the RBAC Role, provided by the developer and intended to be human-readable.
+        ///     Reserved role_ids that are predefined by Stytch include: stytch_member, stytch_admin
+        ///     Check out the guide on Stytch default Roles for a more detailed explanation (https://stytch.com/docs/b2b/guides/rbac/stytch-default).
+        ///   - domain: Email domain that grants the specified Role.
         public init(roleId: String, domain: String) {
             self.roleId = roleId
             self.domain = domain
         }
     }
 
+    // Information about an active SSO connection
     struct SSOActiveConnection: Codable {
         let connectionId: String
         let displayName: String
 
+        /// - Parameters:
+        ///   - connectionId: The id of the connection.
+        ///   - displayName: The human readable display name of the connection.
         init(connectionId: String, displayName: String) {
             self.connectionId = connectionId
             self.displayName = displayName
@@ -75,11 +115,11 @@ public extension StytchB2BClient {
 
     /// A discovered organization.
     struct DiscoveredOrganization: Codable {
-        /// The organization.
+        /// The Organization object.
         public let organization: Organization
-        /// The membership and associated details.
+        /// Information about the membership.
         public let membership: Membership
-        /// A boolean describing the member's authentication status.
+        /// Indicates whether the Member has all of the factors needed to fully authenticate to this Organization. If false, the Member may need to complete an MFA step or complete a different primary authentication flow. See the primary_required and mfa_required fields for more details on each.
         public let memberAuthenticated: Bool
     }
 

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Members.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Members.swift
@@ -90,6 +90,21 @@ public extension StytchB2BClient.Members {
         let mfaPhoneNumber: String?
         let defaultMfaMethod: String?
 
+        /// - Parameters:
+        ///   - name: The name of the Member. If this field is provided and a session header is passed into the request, the Member Session must have permission to perform the update.info.name action on the stytch.member Resource.
+        ///     Alternatively, if the Member Session matches the Member associated with the member_id passed in the request, the authorization check will also allow a Member Session that has permission to perform the update.info.name action on the stytch.self Resource.
+        ///   - untrustedMetadata: An arbitrary JSON object of application-specific data. These fields can be edited directly by the frontend SDK, and should not be used to store critical information. See the Metadata resource for complete field behavior details.
+        ///     If this field is provided and a session header is passed into the request, the Member Session must have permission to perform the update.info.untrusted-metadata action on the stytch.member Resource.
+        ///     Alternatively, if the Member Session matches the Member associated with the member_id passed in the request, the authorization check will also allow a Member Session that has permission to perform the update.info.untrusted-metadata action on the stytch.self Resource.
+        ///   - mfaEnrolled: Sets whether the Member is enrolled in MFA. If true, the Member must complete an MFA step whenever they wish to log in to their Organization. If false, the Member only needs to complete an MFA step if the Organization's MFA policy is set to REQUIRED_FOR_ALL.
+        ///     If this field is provided and a session header is passed into the request, the Member Session must have permission to perform the update.settings.mfa-enrolled action on the stytch.member Resource.
+        ///     Alternatively, if the Member Session matches the Member associated with the member_id passed in the request, the authorization check will also allow a Member Session that has permission to perform the update.settings.mfa-enrolled action on the stytch.self Resource.
+        ///   - mfaPhoneNumber: Sets the Member's phone number. Throws an error if the Member already has a phone number. To change the Member's phone number, use the Delete member phone number endpoint to delete the Member's existing phone number first.
+        ///     If this field is provided and a session header is passed into the request, the Member Session must have permission to perform the update.info.mfa-phone action on the stytch.member Resource.
+        ///     Alternatively, if the Member Session matches the Member associated with the member_id passed in the request, the authorization check will also allow a Member Session that has permission to perform the update.info.mfa-phone action on the stytch.self Resource.
+        ///   - defaultMfaMethod: Sets whether the Member is enrolled in MFA. If true, the Member must complete an MFA step whenever they wish to log in to their Organization. If false, the Member only needs to complete an MFA step if the Organization's MFA policy is set to REQUIRED_FOR_ALL.
+        ///     If this field is provided and a session header is passed into the request, the Member Session must have permission to perform the update.settings.default-mfa-method action on the stytch.member Resource.
+        ///     Alternatively, if the Member Session matches the Member associated with the member_id passed in the request, the authorization check will also allow a Member Session that has permission to perform the update.settings.default-mfa-method action on the stytch.self Resource.
         public init(
             name: String? = nil,
             untrustedMetadata: JSON? = nil,

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+Discovery.swift
@@ -58,8 +58,21 @@ public extension StytchB2BClient.OAuth.Discovery {
     typealias DiscoveryAuthenticateResponse = Response<DiscoveryAuthenticateResponseData>
 
     struct DiscoveryAuthenticateResponseData: DiscoveryIntermediateSessionTokenDataType, Codable {
+        /// The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but represents a bag of factors that may be converted to a member session.
+        /// The token can be used with the OTP SMS Authenticate endpoint, TOTP Authenticate endpoint, or Recovery Codes Recover endpoint to complete an MFA flow and log in to the Organization.
+        /// It can also be used with the Exchange Intermediate Session endpoint to join a specific Organization that allows the factors represented by the intermediate session token;
+        /// or the Create Organization via Discovery endpoint to create a new Organization and Member.
         public let intermediateSessionToken: String
+        /// The email address.
         public let emailAddress: String
+        /// An array of discovered_organization objects tied to the intermediate_session_token, session_token, or session_jwt. See the Discovered Organization Object for complete details.
+        /// Note that Organizations will only appear here under any of the following conditions:
+        /// The end user is already a Member of the Organization.
+        /// The end user is invited to the Organization.
+        /// The end user can join the Organization because:
+        /// a) The Organization allows JIT provisioning.
+        /// b) The Organizations' allowed domains list contains the Member's email domain.
+        /// c) The Organization has at least one other Member with a verified email address with the same domain as the end user (to prevent phishing attacks).
         public let discoveredOrganizations: [StytchB2BClient.DiscoveredOrganization]
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
@@ -142,7 +142,7 @@ public extension StytchB2BClient.OAuth.ThirdParty {
     }
 }
 
-public extension StytchB2BClient.OAuth.ThirdParty {
+extension StytchB2BClient.OAuth.ThirdParty {
     enum Provider: String, CaseIterable, Codable {
         case google
         case microsoft

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
@@ -58,6 +58,16 @@ public extension StytchB2BClient.OAuth {
         let sessionDurationMinutes: Minutes
         let locale: String?
 
+        /// - Parameters:
+        ///   - oauthToken: The token to authenticate.
+        ///   - sessionDurationMinutes: Set the session lifetime to be this many minutes from now. This will start a new session if one doesn't already exist, returning both an opaque session_token and session_jwt for this session. Remember that the session_jwt will have a fixed lifetime of five minutes regardless of the underlying session duration, and will need to be refreshed over time.
+        ///     This value must be a minimum of 5 and a maximum of 527040 minutes (366 days).
+        ///     If a session_token or session_jwt is provided then a successful authentication will continue to extend the session this many minutes.
+        ///     If the session_duration_minutes parameter is not specified, a Stytch session will be created with a 60 minute duration. If you don't want to use the Stytch session product, you can ignore the session fields in the response.
+        ///   - locale: If the Member needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a one-time passcode (OTP) to the Member's phone number. The locale argument will be used to determine which language to use when sending the passcode.
+        ///     Parameter is a IETF BCP 47 language tag, e.g. "en".
+        ///     Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
+        ///     Request support for additional languages here (https://docs.google.com/forms/d/e/1FAIpQLScZSpAu_m2AmLXRT3F3kap-s_mcV6UTBitYn6CdyWP0-o7YjQ/viewform?usp=sf_link%22)!
         public init(
             oauthToken: String,
             sessionDurationMinutes: Minutes = .defaultSessionDuration,

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP.swift
@@ -43,11 +43,11 @@ public extension StytchB2BClient {
 
 public extension StytchB2BClient.OTP {
     struct SendParameters: Codable {
-        public let organizationId: String
-        public let memberId: String
-        public let mfaPhoneNumber: String?
-        public let locale: String?
-        public let enableAutofill: Bool
+        let organizationId: String
+        let memberId: String
+        let mfaPhoneNumber: String?
+        let locale: String?
+        let enableAutofill: Bool
 
         /// - Parameters:
         ///   - organizationId: The ID of the organization the member belongs to

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/StytchB2BClient+Organizations+SearchParameters.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/StytchB2BClient+Organizations+SearchParameters.swift
@@ -168,18 +168,3 @@ public extension StytchB2BClient.Organizations.SearchParameters {
         }
     }
 }
-
-public extension StytchB2BClient.Organizations {
-    typealias SearchMembersResponse = Response<SearchResponseData>
-
-    struct SearchResponseData: Codable {
-        public let members: [Member]
-        public let resultsMetadata: SearchResponseResultsMetadata
-        public let organizations: [String: Organization]
-    }
-
-    struct SearchResponseResultsMetadata: Codable {
-        public let total: Int
-        public let nextCursor: String?
-    }
-}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/StytchB2BClient+Organizations.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/StytchB2BClient+Organizations.swift
@@ -83,3 +83,23 @@ public extension StytchB2BClient.Organizations {
         public let organizationId: String
     }
 }
+
+public extension StytchB2BClient.Organizations {
+    typealias SearchMembersResponse = Response<SearchResponseData>
+
+    struct SearchResponseData: Codable {
+        // An array of Member objects.
+        public let members: [Member]
+        // The search results_metadata object contains metadata relevant to your specific query like total and next_cursor.
+        public let resultsMetadata: SearchResponseResultsMetadata
+        // A map from organization_id to Organization object. The map only contains the Organizations that the Members belongs to.
+        public let organizations: [String: Organization]
+    }
+
+    struct SearchResponseResultsMetadata: Codable {
+        // The total number of results returned by your search query.
+        public let total: Int
+        // The next_cursor string is returned when your search result contains more than one page of results. This value is passed into your next search call in the cursor field.
+        public let nextCursor: String?
+    }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Passwords.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Passwords.swift
@@ -159,13 +159,13 @@ public extension StytchB2BClient.Passwords {
             case locale
         }
 
-        public let organizationId: Organization.ID
-        public let email: String
-        public let loginUrl: URL?
-        public let resetPasswordUrl: URL?
-        public let resetPasswordExpiration: Minutes?
-        public let resetPasswordTemplateId: String?
-        public let locale: String?
+        let organizationId: Organization.ID
+        let email: String
+        let loginUrl: URL?
+        let resetPasswordUrl: URL?
+        let resetPasswordExpiration: Minutes?
+        let resetPasswordTemplateId: String?
+        let locale: String?
 
         /// - Parameters:
         ///   - organizationId: The ID of the intended organization.
@@ -204,9 +204,9 @@ public extension StytchB2BClient.Passwords {
             case sessionDuration = "sessionDurationMinutes"
         }
 
-        public let token: String
-        public let password: String
-        public let sessionDuration: Minutes
+        let token: String
+        let password: String
+        let sessionDuration: Minutes
 
         /// - Parameters:
         ///   - token: The reset token as parsed from the resulting reset deeplink. NOTE: - You must parse this manually.
@@ -231,11 +231,11 @@ public extension StytchB2BClient.Passwords {
             case sessionDuration = "sessionDurationMinutes"
         }
 
-        public let organizationId: Organization.ID
-        public let email: String
-        public let existingPassword: String
-        public let newPassword: String
-        public let sessionDuration: Minutes
+        let organizationId: Organization.ID
+        let email: String
+        let existingPassword: String
+        let newPassword: String
+        let sessionDuration: Minutes
 
         /// - Parameters:
         ///   - organizationId: The ID of the intended organization.
@@ -275,8 +275,8 @@ public extension StytchB2BClient.Passwords {
 
     /// The dedicated parameters type for passwords `resetBySession` calls.
     struct ResetBySessionParameters: Encodable {
-        public let organizationId: Organization.ID
-        public let password: String
+        let organizationId: Organization.ID
+        let password: String
 
         /// - Parameters:
         ///   - organizationId: The ID of the intended organization.
@@ -311,25 +311,38 @@ public extension StytchB2BClient.Passwords {
         public let validPassword: Bool
         /// A score from 0-4 to indicate the strength of a password. Useful for progress bars.
         public let score: Double
+        /// Returns true if the password has been breached. Powered by HaveIBeenPwned (https://haveibeenpwned.com).
         public let breachedPassword: Bool
+        /// The strength policy type enforced, either zxcvbn or luds.
         public let strengthPolicy: String
+        /// Will return true if breach detection will be evaluated. By default this option is enabled. This option can be disabled by contacting support@stytch.com. If this value is false then breached_password will always be false as well.
         public let breachDetectionOnCreate: Bool
+        /// Feedback for how to improve the password's strength using zxcvbn.
         public let zxcvbnFeedback: ZxcvbnFeedback?
+        /// Feedback for how to improve the password's strength using luds.
         public let ludsFeedback: LudsFeedback?
 
         /// A warning and collection of suggestions for improving the strength of a given password.
         public struct ZxcvbnFeedback: Codable {
+            /// For zxcvbn validation, contains end user consumable suggestions on how to improve the strength of the password.
             public let suggestions: [String]
+            /// For zxcvbn validation, contains an end user consumable warning if the password is valid but not strong enough.
             public let warning: String
         }
 
         /// LUDS-specific password feedback.
         public struct LudsFeedback: Codable {
+            /// For LUDS validation, whether the password contains at least one lowercase letter.
             public let hasLowerCase: Bool
+            /// For LUDS validation, whether the password contains at least one uppercase letter.
             public let hasUpperCase: Bool
+            /// For LUDS validation, whether the password contains at least one digit.
             public let hasDigit: Bool
+            /// For LUDS validation, whether the password contains at least one symbol. Any UTF8 character outside of a-z or A-Z may count as a valid symbol.
             public let hasSymbol: Bool
+            /// For LUDS validation, the number of complexity requirements that are missing from the password. Check the complexity fields to see which requirements are missing.
             public let missingComplexity: Int
+            /// For LUDS validation, this is the required length of the password that you've set minus the length of the password being checked. The user will need to add this many characters to the password to make it valid.
             public let missingCharacters: Int
         }
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO.swift
@@ -164,7 +164,9 @@ public extension StytchB2BClient.SSO {
     typealias GetConnectionsResponse = Response<GetConnectionsResponseData>
 
     struct GetConnectionsResponseData: Codable {
+        /// The list of SAML Connections owned by this organization.
         public let samlConnections: [SAML.SAMLConnection]
+        /// The list of OIDC Connections owned by this organization.
         public let oidcConnections: [OIDC.OIDCConnection]
     }
 }
@@ -173,6 +175,7 @@ public extension StytchB2BClient.SSO {
     typealias DeleteConnectionResponse = Response<DeleteConnectionResponseData>
 
     struct DeleteConnectionResponseData: Codable {
+        /// The connection_id that was deleted as part of the delete request.
         public let connectionId: String
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SearchManager.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SearchManager.swift
@@ -29,9 +29,12 @@ public extension StytchB2BClient {
 
 public extension StytchB2BClient.SearchManager {
     struct SearchMemberParameters: Codable {
-        public let emailAddress: String
-        public let organizationId: String
+        let emailAddress: String
+        let organizationId: String
 
+        /// - Parameters:
+        ///   - emailAddress: The email address of the member to search for.
+        ///   - organizationId: The id of the organization the member belongs to.
         public init(emailAddress: String, organizationId: String) {
             self.emailAddress = emailAddress
             self.organizationId = organizationId
@@ -43,6 +46,7 @@ public extension StytchB2BClient.SearchManager {
     typealias SearchMemberResponse = Response<SearchMemberResponseData>
 
     struct SearchMemberResponseData: Codable {
+        /// The matching member.
         public let member: MemberSearchResponse
     }
 
@@ -55,8 +59,9 @@ public extension StytchB2BClient.SearchManager {
 
 public extension StytchB2BClient.SearchManager {
     struct SearchOrganizationParameters: Codable {
-        public let organizationSlug: String
+        let organizationSlug: String
 
+        /// - Parameter organizationSlug: The URL slug of the Organization to get.
         public init(organizationSlug: String) {
             self.organizationSlug = organizationSlug
         }
@@ -67,19 +72,32 @@ public extension StytchB2BClient.SearchManager {
     typealias SearchOrganizationResponse = Response<SearchOrganizationResponseData>
 
     struct SearchOrganizationResponseData: Codable {
+        /// The matching organization.
         public let organization: OrganizationSearchResponse
     }
 
     struct OrganizationSearchResponse: Codable {
+        /// Globally unique UUID that identifies an organization in the Stytch API.
         public let organizationId: String
+        /// The name of the organization.
         public let organizationName: String
+        /// A URL of the organization's logo.
         public let organizationLogoUrl: String?
+        /// An array of active SSO Connection references.
         public let ssoActiveConnections: [StytchB2BClient.SSOActiveConnection]?
+        /// The default connection used for SSO when there are multiple active connections.
         public let ssoDefaultConnectionId: String?
+        /// An array of email domains that allow invites or JIT provisioning for new Members.
+        /// This list is enforced when either email_invites or email_jit_provisioning is set to RESTRICTED.
+        /// Common domains such as gmail.com are not allowed.
         public let emailAllowedDomains: [String]?
+        /// The authentication setting that controls how a new Member can be provisioned by authenticating via Email Magic Link.
         public let emailJitProvisioning: StytchB2BClient.EmailJitProvisioning?
+        /// The authentication setting that controls how a new Member can be invited to an organization by email.
         public let emailInvites: StytchB2BClient.EmailInvites?
+        /// The setting that controls which authentication methods can be used by Members of an Organization.
         public let authMethods: StytchB2BClient.AuthMethods?
+        /// An array of allowed authentication methods. This list is enforced when auth_methods is set to RESTRICTED.
         public let allowedAuthMethods: [StytchB2BClient.AllowedAuthMethods]?
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -103,6 +103,7 @@ public struct StytchB2BClient: StytchClientType {
         }
     }
 
+    /// Retrieve the most recently created PKCE code pair from the device, if available
     public static func getPKCECodePair() -> PKCECodePair? {
         Self.instance.pkcePairManager.getPKCECodePair()
     }

--- a/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-// FIXME: - move this code to the extracted client file
 #if !os(tvOS) && !os(watchOS)
 import LocalAuthentication
 public extension StytchClient.Biometrics {
@@ -34,8 +33,8 @@ public extension StytchClient {
         }
 
         #if !os(tvOS) && !os(watchOS)
+        /// Indicates if biometrics are available
         public var availability: Availability {
-            // FIXME: - wrap this in a client of some kind (BiometricsAvailabilityClient) and extract it
             let context = LAContext()
             var error: NSError?
             switch (context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error), registrationAvailable) {

--- a/Sources/StytchCore/StytchClient/Bootstrap/StytchClient+Bootstrap.swift
+++ b/Sources/StytchCore/StytchClient/Bootstrap/StytchClient+Bootstrap.swift
@@ -8,7 +8,7 @@ extension StytchClient {
         @Dependency(\.networkingClient) private var networkingClient
         @Dependency(\.localStorage) private var localStorage
 
-        public func fetch() async throws {
+        func fetch() async throws {
             guard let publicToken = StytchClient.instance.configuration?.publicToken else {
                 throw StytchSDKError.consumerSDKNotConfigured
             }

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -21,8 +21,12 @@ public struct StytchClient: StytchClientType {
 
     static let appSessionId: String = UUID().uuidString
 
-    public static var bootStrapData: BootstrapResponseData? {
+    static var bootStrapData: BootstrapResponseData? {
         Self.instance.localStorage.bootstrapData
+    }
+
+    public static var disableSdkWatermark: Bool {
+        bootStrapData?.disableSdkWatermark ?? true
     }
 
     private init() {
@@ -96,6 +100,7 @@ public struct StytchClient: StytchClientType {
         }
     }
 
+    /// Retrieve the most recently created PKCE code pair from the device, if available
     public static func getPKCECodePair() -> PKCECodePair? {
         Self.instance.pkcePairManager.getPKCECodePair()
     }

--- a/Sources/StytchCore/StytchClientCommon/Models/BootstrapResponse.swift
+++ b/Sources/StytchCore/StytchClientCommon/Models/BootstrapResponse.swift
@@ -1,11 +1,11 @@
 /// The concrete response type for `bootstrap` calls.
-public typealias BootstrapResponse = Response<BootstrapResponseData>
+typealias BootstrapResponse = Response<BootstrapResponseData>
 
 /// Represents the interface of responses for `bootstrap` calls.
-public typealias BootstrapResponseType = BasicResponseType & BootstrapResponseDataType
+typealias BootstrapResponseType = BasicResponseType & BootstrapResponseDataType
 
 /// The interface which a data type must conform to for all underlying data in `bootstrap` responses.
-public protocol BootstrapResponseDataType {
+protocol BootstrapResponseDataType {
     var disableSdkWatermark: Bool { get }
     var cnameDomain: String? { get }
     var emailDomains: [String] { get }
@@ -22,28 +22,28 @@ public protocol BootstrapResponseDataType {
 }
 
 /// The underlying data for `bootstrap` calls.
-public struct BootstrapResponseData: Codable, BootstrapResponseDataType {
-    public let disableSdkWatermark: Bool
-    public let cnameDomain: String?
-    public let emailDomains: [String]
-    public let captchaSettings: CaptchaSettings
-    public let pkceRequiredForEmailMagicLinks: Bool
-    public let pkceRequiredForPasswordResets: Bool
-    public let pkceRequiredForOauth: Bool
-    public let pkceRequiredForSso: Bool
-    public let slugPattern: String?
-    public let createOrganizationEnabled: Bool
-    public let dfpProtectedAuthEnabled: Bool
-    public let dfpProtectedAuthMode: DFPProtectedAuthMode?
-    public let rbacPolicy: RBACPolicy?
+struct BootstrapResponseData: Codable, BootstrapResponseDataType {
+    let disableSdkWatermark: Bool
+    let cnameDomain: String?
+    let emailDomains: [String]
+    let captchaSettings: CaptchaSettings
+    let pkceRequiredForEmailMagicLinks: Bool
+    let pkceRequiredForPasswordResets: Bool
+    let pkceRequiredForOauth: Bool
+    let pkceRequiredForSso: Bool
+    let slugPattern: String?
+    let createOrganizationEnabled: Bool
+    let dfpProtectedAuthEnabled: Bool
+    let dfpProtectedAuthMode: DFPProtectedAuthMode?
+    let rbacPolicy: RBACPolicy?
 }
 
-public struct CaptchaSettings: Codable {
-    public let enabled: Bool
-    public let siteKey: String?
+struct CaptchaSettings: Codable {
+    let enabled: Bool
+    let siteKey: String?
 }
 
-public enum DFPProtectedAuthMode: String, Codable {
+enum DFPProtectedAuthMode: String, Codable {
     case observation = "OBSERVATION"
     case decisioning = "DECISIONING"
 }

--- a/Sources/StytchCore/StytchClientCommon/Models/RBACPolicy.swift
+++ b/Sources/StytchCore/StytchClientCommon/Models/RBACPolicy.swift
@@ -1,7 +1,11 @@
 import Foundation
 
+/// The RBAC Policy document that contains all defined Roles and Resources – which are managed in the Dashboard (https://stytch.com/dashboard/rbac).
+/// Read more about these entities and how they work in our RBAC overview (https://stytch.com/docs/b2b/guides/rbac/overview).
 public struct RBACPolicy: Codable {
+    /// An array of Role objects.
     public let roles: [RBACPolicyRole]
+    /// An array of Resource objects.
     public let resources: [RBACPolicyResource]
 
     private var rolesByID: [String: RBACPolicyRole] {
@@ -20,7 +24,7 @@ public struct RBACPolicy: Codable {
             .flatMap(\.permissions)
     }
 
-    public func callerIsAuthorized(
+    internal func callerIsAuthorized(
         memberRoles: [String],
         resourceId: String,
         action: String
@@ -36,7 +40,7 @@ public struct RBACPolicy: Codable {
         return permission != nil
     }
 
-    public func allPermissionsForCaller(memberRoles: [String]) -> [String: [String: Bool]] {
+    internal func allPermissionsForCaller(memberRoles: [String]) -> [String: [String: Bool]] {
         var allPermissions = [String: [String: Bool]]()
 
         for resource in resources {
@@ -51,11 +55,18 @@ public struct RBACPolicy: Codable {
     }
 }
 
+/// A list of permissions that link a Resource to a list of actions.
 public struct RBACPermission: Codable {
+    /// A unique identifier of the RBAC Resource, provided by the developer and intended to be human-readable.
+    /// A resource_id is not allowed to start with stytch, which is a special prefix used for Stytch default Resources with reserved resource_ids.
+    /// These include: stytch.organization, stytch.member, stytch.sso, stytch.self
+    /// Check out the guide on Stytch default Resources for a more detailed explanation (https://stytch.com/docs/b2b/guides/rbac/stytch-default).
     public let resourceId: String
+    /// A list of permitted actions the Role is authorized to take with the provided Resource.
+    /// You can use * as a wildcard to grant a Role permission to use all possible actions related to the Resource.
     public let actions: [String]
 
-    public func permission(resourceId: String, action: String) -> Bool {
+    func permission(resourceId: String, action: String) -> Bool {
         if self.resourceId == resourceId {
             return actions.contains(action) || actions.contains("*")
         } else {
@@ -64,14 +75,36 @@ public struct RBACPermission: Codable {
     }
 }
 
+/// A Role is a named collection of permissions that links actions to a Resource.
+/// Roles are assigned to Members, either explicitly by direct assignment or implicitly by matching attributes or conditions, which grants them permissions.
+/// Role assignment can be programmatically managed through certain Stytch API endpoints.
+/// Refer to this guide for details on controls for delegating Roles to Members (https://stytch.com/docs/b2b/guides/rbac/role-assignment).
+/// All Roles are stored in your Project's RBAC Policy. You can create, manage, and assign Roles in the Dashboard (https://stytch.com/dashboard).
+/// Check out the RBAC overview to learn more about Stytch's RBAC permissioning model (https://stytch.com/docs/b2b/guides/rbac/overview).
 public struct RBACPolicyRole: Codable {
+    /// The unique identifier of the RBAC Role, provided by the developer and intended to be human-readable.
+    /// Reserved role_ids that are predefined by Stytch include: stytch_member, stytch_admin
+    /// Check out the guide on Stytch default Roles for a more detailed explanation (https://stytch.com/docs/b2b/guides/rbac/stytch-default).
     public let roleId: String
+    /// The description of the RBAC Role.
     public let description: String
+    /// A list of permissions that link a Resource to a list of actions.
     public let permissions: [RBACPermission]
 }
 
+/// A Resource is an entity with an associated list of actions.
+/// The actions list enumerates all the valid operations that can be performed upon the Resource.
+/// All Resources are stored in your Project's RBAC Policy. You can create and manage Resources in the Dashboard (https://stytch.com/dashboard).
+/// Check out the RBAC overview to learn more about Stytch's RBAC permissioning model (https://stytch.com/docs/b2b/guides/rbac/overview).
 public struct RBACPolicyResource: Codable {
+    /// A unique identifier of the RBAC Resource, provided by the developer and intended to be human-readable.
+    /// A resource_id is not allowed to start with stytch, which is a special prefix used for Stytch default
+    /// Resources with reserved resource_ids. These include: stytch.organization, stytch.member, stytch.sso, stytch.self
+    /// Check out the guide on Stytch default Resources for a more detailed explanation (https://stytch.com/docs/b2b/guides/rbac/stytch-default).
     public let resourceId: String
+    /// The description of the RBAC Role.
     public let description: String
+    /// A list of permitted actions the Role is authorized to take with the provided Resource.
+    /// You can use * as a wildcard to grant a Role permission to use all possible actions related to the Resource.
     public let actions: [String]
 }

--- a/Sources/StytchCore/StytchClientCommon/Models/SessionToken.swift
+++ b/Sources/StytchCore/StytchClientCommon/Models/SessionToken.swift
@@ -75,6 +75,10 @@ public struct SessionTokens {
     internal let jwt: SessionToken
     internal let opaque: SessionToken
 
+    /// A nullable initializer that requires the caller to pass at least one non-nil instance of each token type.
+    /// - Parameters:
+    ///   - jwt: An instance of `SessionToken` with a `type` of `.jwt`
+    ///   - opaque: An instance of `SessionToken` with a `type` of `.opaque`
     public init?(jwt: SessionToken, opaque: SessionToken) {
         if jwt.kind != .jwt, opaque.kind != .opaque {
             return nil

--- a/Sources/StytchCore/StytchClientCommon/StytchClientType.swift
+++ b/Sources/StytchCore/StytchClientCommon/StytchClientType.swift
@@ -47,6 +47,8 @@ extension StytchClientType {
 
     var pkcePairManager: PKCEPairManager { Current.pkcePairManager }
 
+    /// An instance of `InitializationState` that wraps a publisher `isInitialized` that alerts the caller when the bootstrap call has completed successfully.
+    /// NOTE: It does not represent if the Stytch iOS SDK is ready to use or not. That is currently solely determined by the SDK having a valid public token.
     public var initializationState: InitializationState { Current.initializationState }
 
     // swiftlint:disable:next identifier_name

--- a/Sources/StytchUI/ViewControllers/AuthHomeViewController.swift
+++ b/Sources/StytchUI/ViewControllers/AuthHomeViewController.swift
@@ -82,7 +82,7 @@ final class AuthHomeViewController: BaseViewController<AuthHomeState, AuthHomeVi
             stackView.addArrangedSubview(inputController.view)
             constraints.append(inputController.view.widthAnchor.constraint(equalTo: stackView.widthAnchor))
         }
-        if let disableSdkWatermark = StytchClient.bootStrapData?.disableSdkWatermark, !disableSdkWatermark {
+        if StytchClient.disableSdkWatermark == false {
             stackView.addArrangedSubview(poweredByStytch)
         }
         stackView.addArrangedSubview(SpacerView())


### PR DESCRIPTION
[[SDK-1918] Inline documentation audit](https://linear.app/stytch/issue/SDK-1918/[ios]-inline-documentation-audit)

## Changes:

1. Went through all the properties and methods of the SDK and determined which ones needed to be public and which ones could be internal only.
2. Then for all the needed public APIs I made sure they had comments on them.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
