### PR TITLE
[SDK-1724] Fix user update

### DIFF
--- a/Sources/StytchCore/Generated/StytchClient.UserManagement.update+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.UserManagement.update+AsyncVariants.generated.swift
@@ -4,7 +4,7 @@ import Combine
 import Foundation
 
 public extension StytchClient.UserManagement {
-    func update(parameters: UpdateParameters, completion: @escaping Completion<UserResponse>) {
+    func update(parameters: UpdateParameters, completion: @escaping Completion<NestedUserResponse>) {
         Task {
             do {
                 completion(.success(try await update(parameters: parameters)))
@@ -14,7 +14,7 @@ public extension StytchClient.UserManagement {
         }
     }
 
-    func update(parameters: UpdateParameters) -> AnyPublisher<UserResponse, Error> {
+    func update(parameters: UpdateParameters) -> AnyPublisher<NestedUserResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/StytchClient/User/StytchClient+User.swift
+++ b/Sources/StytchCore/StytchClient/User/StytchClient+User.swift
@@ -28,10 +28,10 @@ public extension StytchClient {
         }
 
         // sourcery: AsyncVariants
-        public func update(parameters: UpdateParameters) async throws -> UserResponse {
-            try await updatingCachedUser {
-                try await router.put(to: .index, parameters: parameters)
-            }
+        public func update(parameters: UpdateParameters) async throws -> NestedUserResponse {
+            let response: NestedUserResponse = try await router.put(to: .index, parameters: parameters)
+            userStorage.update(response.wrapped.user)
+            return response
         }
 
         // sourcery: AsyncVariants

--- a/Tests/StytchCoreTests/UserManagementTestCase.swift
+++ b/Tests/StytchCoreTests/UserManagementTestCase.swift
@@ -18,11 +18,11 @@ final class UserManagementTestCase: BaseTestCase {
     }
 
     func testUpdate() async throws {
-        networkInterceptor.responses { UserResponse(requestId: "123", statusCode: 200, wrapped: .mock(userId: "mock-user-id-123")) }
+        networkInterceptor.responses { NestedUserResponse(requestId: "123", statusCode: 200, wrapped: UserResponseData(user: .mock(userId: "mock-user-id-123"))) }
         XCTAssertNil(StytchClient.user.getSync())
         let updateUserResponse = try await StytchClient.user.update(parameters: .init(name: .init(firstName: "Dan"), untrustedMetadata: ["blah": 1]))
         XCTAssertNotNil(StytchClient.user.getSync())
-        XCTAssertEqual(updateUserResponse.id, StytchClient.user.getSync()?.id)
+        XCTAssertEqual(updateUserResponse.user.id, StytchClient.user.getSync()?.id)
         try XCTAssertRequest(
             networkInterceptor.requests[0],
             urlString: "https://api.stytch.com/sdk/v1/users/me",


### PR DESCRIPTION
Linear Ticket: [[SDK-1724] [iOS] Error when updating user's name](https://linear.app/stytch/issue/SDK-1724/[ios]-error-when-updating-users-name)

## Changes:

1. The update user call had the wrong return type, it was `UserResponse` but it should have been `NestedUserResponse`

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
