### PR TITLE
Rename session objects now that they are namespace

### DIFF
--- a/Sources/StytchCore/Documentation.docc/StytchCore.md
+++ b/Sources/StytchCore/Documentation.docc/StytchCore.md
@@ -21,7 +21,7 @@ Property | Methods
 ``StytchClient/OAuth-swift.struct/ThirdParty`` | ``StytchClient/OAuth-swift.struct/ThirdParty/start(configuration:)``, ``StytchClient/OAuth-swift.struct/authenticate(parameters:)-3tjwd``
 ``StytchClient/OAuth-swift.struct/Apple-swift.struct`` | ``StytchClient/OAuth-swift.struct/Apple-swift.struct/start(parameters:)-5rxqg``
 ``StytchClient/TOTP`` | ``StytchClient/TOTP/create(parameters:)-437r4``, ``StytchClient/TOTP/authenticate(parameters:)-2ck6w``, ``StytchClient/TOTP/recoveryCodes()-mbxc``, ``StytchClient/TOTP/recover(parameters:)-9swfk``
-``StytchClient/StytchClientSessions`` | ``StytchClient/StytchClientSessions/revoke(parameters:)-7lw27``, ``StytchClient/StytchClientSessions/authenticate(parameters:)-7gegg``
+``StytchClient/Sessions`` | ``StytchClient/Sessions/revoke(parameters:)-7lw27``, ``StytchClient/Sessions/authenticate(parameters:)-7gegg``
 ``StytchClient/UserManagement`` | ``StytchClient/UserManagement/getSync()``, ``StytchClient/UserManagement/get()-57gt5``, ``StytchClient/UserManagement/deleteFactor(_:)-5nh6h``
 ``StytchClient/CryptoWallets-swift.struct`` | ``StytchClient/CryptoWallets-swift.struct/authenticateStart(parameters:)-23wt7``, ``StytchClient/CryptoWallets-swift.struct/authenticate(parameters:)-8ea9t``
 
@@ -32,7 +32,7 @@ Property | Methods
 ``StytchB2BClient/MagicLinks-swift.struct`` | ``StytchB2BClient/MagicLinks-swift.struct/Email-swift.struct/loginOrSignup(parameters:)-6rrup``, ``StytchB2BClient/MagicLinks-swift.struct/authenticate(parameters:)-9bkrj``, ``StytchB2BClient/MagicLinks-swift.struct/Email-swift.struct/discoverySend(parameters:)-1opgc``, ``StytchB2BClient/MagicLinks-swift.struct/discoveryAuthenticate(parameters:)-4vo9v``
 ``StytchB2BClient/Discovery-swift.struct`` | ``StytchB2BClient/Discovery-swift.struct/createOrganization(parameters:)-7hypb``, ``StytchB2BClient/Discovery-swift.struct/listOrganizations(parameters:)-4yarj``, ``StytchB2BClient/Discovery-swift.struct/exchangeIntermediateSession(parameters:)-8uvs8``
 ``StytchB2BClient/SSO-swift.struct`` | ``StytchB2BClient/SSO-swift.struct/start(parameters:)-6ik51``, ``StytchB2BClient/SSO-swift.struct/authenticate(parameters:)-1ncp1``
-``StytchB2BClient/StytchB2BClientSessions`` | ``StytchB2BClient/StytchB2BClientSessions/revoke(parameters:)-7lw27``, ``StytchB2BClient/StytchB2BClientSessions/authenticate(parameters:)-7gegg``
+``StytchB2BClient/Sessions`` | ``StytchB2BClient/Sessions/revoke(parameters:)-7lw27``, ``StytchB2BClient/Sessions/authenticate(parameters:)-7gegg``
 ``StytchB2BClient/Members`` | ``StytchB2BClient/Members/getSync()``, ``StytchB2BClient/Members/get()-7fdhf``
 ``StytchB2BClient/Organizations-swift.struct`` | ``StytchB2BClient/Organizations/getSync()``, ``StytchB2BClient/Organizations/get()-2esfw``
 ``StytchB2BClient/OAuth-swift.struct`` | ``StytchB2BClient/OAuth-swift.struct/ThirdParty/start(configuration:)``, ``StytchB2BClient/OAuth-swift.struct/authenticate(parameters:)-80abl``

--- a/Sources/StytchCore/Generated/StytchB2BClient.Sessions.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.Sessions.authenticate+AsyncVariants.generated.swift
@@ -3,7 +3,7 @@
 import Combine
 import Foundation
 
-public extension StytchB2BClient.StytchB2BClientSessions {
+public extension StytchB2BClient.Sessions {
     /// Wraps Stytch's [authenticate](https://stytch.com/docs/api/session-auth) Session endpoint and validates that the session issued to the user is still valid, returning both an opaque sessionToken and sessionJwt for this session. The sessionJwt will have a fixed lifetime of five minutes regardless of the underlying session duration, though it will be refreshed automatically in the background after a successful authentication.
     func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
         Task {

--- a/Sources/StytchCore/Generated/StytchB2BClient.Sessions.exchange+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.Sessions.exchange+AsyncVariants.generated.swift
@@ -3,7 +3,7 @@
 import Combine
 import Foundation
 
-public extension StytchB2BClient.StytchB2BClientSessions {
+public extension StytchB2BClient.Sessions {
     /// Use this endpoint to exchange a Member's existing session for another session in a different Organization.
     func exchange(parameters: ExchangeParameters, completion: @escaping Completion<B2BMFAAuthenticateResponse>) {
         Task {

--- a/Sources/StytchCore/Generated/StytchB2BClient.Sessions.revoke+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.Sessions.revoke+AsyncVariants.generated.swift
@@ -3,7 +3,7 @@
 import Combine
 import Foundation
 
-public extension StytchB2BClient.StytchB2BClientSessions {
+public extension StytchB2BClient.Sessions {
     /// Wraps Stytch's [revoke](https://stytch.com/docs/api/session-revoke) Session endpoint and revokes the user's current session. This method should be used to log out a user. A successful revocation will terminate session-refresh polling.
     func revoke(parameters: RevokeParameters = .init(), completion: @escaping Completion<BasicResponse>) {
         Task {

--- a/Sources/StytchCore/Generated/StytchClient.Sessions.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.Sessions.authenticate+AsyncVariants.generated.swift
@@ -3,7 +3,7 @@
 import Combine
 import Foundation
 
-public extension StytchClient.StytchClientSessions {
+public extension StytchClient.Sessions {
     /// Wraps Stytch's [authenticate](https://stytch.com/docs/api/session-auth) Session endpoint and validates that the session issued to the user is still valid, returning both an opaque sessionToken and sessionJwt for this session. The sessionJwt will have a fixed lifetime of five minutes regardless of the underlying session duration, though it will be refreshed automatically in the background after a successful authentication.
     func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<AuthenticateResponse>) {
         Task {

--- a/Sources/StytchCore/Generated/StytchClient.Sessions.revoke+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.Sessions.revoke+AsyncVariants.generated.swift
@@ -3,7 +3,7 @@
 import Combine
 import Foundation
 
-public extension StytchClient.StytchClientSessions {
+public extension StytchClient.Sessions {
     /// Wraps Stytch's [revoke](https://stytch.com/docs/api/session-revoke) Session endpoint and revokes the user's current session. This method should be used to log out a user. A successful revocation will terminate session-refresh polling.
     func revoke(parameters: RevokeParameters = .init(), completion: @escaping Completion<BasicResponse>) {
         Task {

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
@@ -4,7 +4,7 @@ extension StytchB2BClient {
         case magicLinks(MagicLinksRoute)
         case organizations(OrganizationsRoute)
         case passwords(PasswordsRoute)
-        case sessions(B2BSessionsRoute)
+        case sessions(SessionsRoute)
         case sso(SSORoute)
         case events(EventsRoute)
         case bootstrap(BootstrapRoute)
@@ -331,7 +331,7 @@ extension StytchB2BClient {
         }
     }
 
-    enum B2BSessionsRoute: String, RouteType {
+    enum SessionsRoute: String, RouteType {
         case authenticate
         case revoke
         case exchange

--- a/Sources/StytchCore/StytchClient/StytchClient+Sessions.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient+Sessions.swift
@@ -1,25 +1,35 @@
 import Combine
 
-public extension StytchB2BClient {
+public extension StytchClient {
     /// The interface for interacting with sessions products.
-    static var sessions: StytchB2BClientSessions {
+    static var sessions: Sessions {
         .init(router: router.scopedRouter { $0.sessions })
     }
 }
 
-public extension StytchB2BClient {
+enum SessionsRoute: String, RouteType {
+    case authenticate
+    case revoke
+
+    var path: Path {
+        .init(rawValue: rawValue)
+    }
+}
+
+public extension StytchClient {
     /// The SDK may be used to check whether a user has a cached session, view the current session, refresh the session, and revoke the session. To authenticate a session on your backend, you must use either the Stytch API or a Stytch server-side library. **NOTE**: - After a successful authentication, the session will be automatically refreshed in the background to ensure the sessionJwt remains valid (it expires after 5 minutes.) Session polling will be stopped after a session is revoked or after an unauthenticated error response is received.
-    struct StytchB2BClientSessions {
-        let router: NetworkingRouter<StytchB2BClient.B2BSessionsRoute>
+    struct Sessions {
+        let router: NetworkingRouter<SessionsRoute>
         @Dependency(\.sessionStorage) var sessionStorage
         @Dependency(\.localStorage) var localStorage
 
-        public var memberSession: MemberSession? {
+        /// If logged in, returns the cached session object.
+        public var session: Session? {
             get {
-                localStorage.memberSession
+                localStorage.session
             }
             set {
-                localStorage.memberSession = newValue
+                localStorage.session = newValue
             }
         }
 
@@ -40,7 +50,7 @@ public extension StytchB2BClient {
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's [authenticate](https://stytch.com/docs/api/session-auth) Session endpoint and validates that the session issued to the user is still valid, returning both an opaque sessionToken and sessionJwt for this session. The sessionJwt will have a fixed lifetime of five minutes regardless of the underlying session duration, though it will be refreshed automatically in the background after a successful authentication.
-        public func authenticate(parameters: AuthenticateParameters) async throws -> B2BAuthenticateResponse {
+        public func authenticate(parameters: AuthenticateParameters) async throws -> AuthenticateResponse {
             try await router.post(to: .authenticate, parameters: parameters)
         }
 
@@ -63,16 +73,10 @@ public extension StytchB2BClient {
                 throw error
             }
         }
-
-        // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
-        /// Use this endpoint to exchange a Member's existing session for another session in a different Organization.
-        public func exchange(parameters: ExchangeParameters) async throws -> B2BMFAAuthenticateResponse {
-            try await router.post(to: .exchange, parameters: parameters)
-        }
     }
 }
 
-public extension StytchB2BClient.StytchB2BClientSessions {
+public extension StytchClient.Sessions {
     /// The dedicated parameters type for sessions `authenticate` calls.
     struct AuthenticateParameters: Encodable {
         let sessionDurationMinutes: Minutes?
@@ -92,22 +96,6 @@ public extension StytchB2BClient.StytchB2BClientSessions {
         /// - Parameter forceClear: In the event of an error received from the network, setting this value to true will ensure the local session state is cleared.
         public init(forceClear: Bool = false) {
             self.forceClear = forceClear
-        }
-    }
-
-    /// The dedicated parameters type for session `exchange` calls.
-    struct ExchangeParameters: Codable {
-        /// The ID of the organization that the new session should belong to.
-        public let organizationID: String
-        /// The duration, in minutes, for the requested session. Defaults to 5 minutes.
-        public let sessionDurationMinutes: Minutes
-        /// The locale will be used if an OTP code is sent to the member's phone number as part of a secondary authentication requirement.
-        public let locale: StytchLocale?
-
-        public init(organizationID: String, sessionDurationMinutes: Minutes = .defaultSessionDuration, locale: StytchLocale? = nil) {
-            self.organizationID = organizationID
-            self.sessionDurationMinutes = sessionDurationMinutes
-            self.locale = locale
         }
     }
 }

--- a/Stytch/DemoApps/B2BWorkbench/ViewControllers/AuthMethodControllers/SessionsViewController.swift
+++ b/Stytch/DemoApps/B2BWorkbench/ViewControllers/AuthMethodControllers/SessionsViewController.swift
@@ -70,7 +70,7 @@ final class SessionsViewController: UIViewController {
         }
         Task {
             do {
-                let parameters = StytchB2BClient.StytchB2BClientSessions.ExchangeParameters(organizationID: organizationID)
+                let parameters = StytchB2BClient.Sessions.ExchangeParameters(organizationID: organizationID)
                 let response = try await StytchB2BClient.sessions.exchange(parameters: parameters)
                 UserDefaults.standard.set(organizationID, forKey: Constants.orgIdDefaultsKey)
                 orgIdTextField.text = ""

--- a/Tests/StytchCoreTests/B2BSessionsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSessionsTestCase.swift
@@ -4,7 +4,7 @@ import XCTest
 final class B2BSessionsTestCase: BaseTestCase {
     func testSessionsAuthenticate() async throws {
         networkInterceptor.responses { B2BAuthenticateResponse.mock }
-        let parameters: StytchB2BClient.StytchB2BClientSessions.AuthenticateParameters = .init(sessionDurationMinutes: 15)
+        let parameters: StytchB2BClient.Sessions.AuthenticateParameters = .init(sessionDurationMinutes: 15)
 
         Current.timer = { _, _, _ in .init() }
 
@@ -71,7 +71,7 @@ final class B2BSessionsTestCase: BaseTestCase {
         Current.timer = { _, _, _ in .init() }
 
         let organizationID = "org_123"
-        let parameters = StytchB2BClient.StytchB2BClientSessions.ExchangeParameters(organizationID: organizationID)
+        let parameters = StytchB2BClient.Sessions.ExchangeParameters(organizationID: organizationID)
         _ = try await StytchB2BClient.sessions.exchange(parameters: parameters)
 
         try XCTAssertRequest(

--- a/Tests/StytchCoreTests/SessionsTestCase.swift
+++ b/Tests/StytchCoreTests/SessionsTestCase.swift
@@ -4,7 +4,7 @@ import XCTest
 final class SessionsTestCase: BaseTestCase {
     func testSessionsAuthenticate() async throws {
         networkInterceptor.responses { AuthenticateResponse.mock }
-        let parameters: StytchClient.StytchClientSessions.AuthenticateParameters = .init(sessionDurationMinutes: 15)
+        let parameters: StytchClient.Sessions.AuthenticateParameters = .init(sessionDurationMinutes: 15)
 
         Current.timer = { _, _, _ in .init() }
 


### PR DESCRIPTION
Rename `StytchB2BClient.StytchB2BClientSessions` to `StytchB2BClient.Sessions`.
Rename `StytchClient.StytchClientSessions` to `StytchClient.Sessions`.

Initially `StytchB2BClientSessions` and `StytchClientSessions` were not namespaces because their predecessor, the shared Sessions object was not namespaced. So when I initially split them apart I failed to namespace them and gave them very verbose names, then they were subsequently namespaced and their names became even more verbose. Now we can shorten it for sake of consistency.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
