### PR TITLE
[SDK-2085] Allow for optional values in JSON objects

### DIFF
--- a/Sources/StytchCore/JSON.swift
+++ b/Sources/StytchCore/JSON.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A simple type representing valid JSON values which includes several convenience accessors.
 public enum JSON: Hashable, Equatable {
     case array([JSON])
-    case object([String: JSON])
+    case object([String: JSON?])
     case string(String)
     case number(Double)
     case boolean(Bool)
@@ -13,7 +13,7 @@ public enum JSON: Hashable, Equatable {
         return value
     }
 
-    public var objectValue: [String: JSON]? {
+    public var objectValue: [String: JSON?]? {
         guard case let .object(value) = self else { return nil }
         return value
     }
@@ -38,8 +38,15 @@ public enum JSON: Hashable, Equatable {
     }
 
     public subscript(key: String) -> JSON? {
-        guard case let .object(dict) = self else { return nil }
-        return dict[key]
+        guard case let .object(dict) = self else {
+            return nil
+        }
+
+        if let value = dict[key] {
+            return value
+        } else {
+            return nil
+        }
     }
 
     public subscript(_ index: Int) -> JSON? {
@@ -82,7 +89,7 @@ extension JSON: Codable {
                     do {
                         self = .string(try container.decode(String.self))
                     } catch {
-                        self = .object(try container.decode([String: JSON].self))
+                        self = .object(try container.decode([String: JSON?].self))
                     }
                 }
             }

--- a/Tests/StytchCoreTests/JSONTestCase.swift
+++ b/Tests/StytchCoreTests/JSONTestCase.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import StytchCore
+
+// swiftlint:disable type_contents_order
+
+final class JSONTestCase: BaseTestCase {
+    func testNilValueInJSONDictionary() {
+        let jsonString =
+            """
+            {
+                "custom_claims": {
+                    "https://example.co/jwt/claims": {
+                        "can_assume_user": null,
+                        "roles": [
+                            "admin"
+                        ]
+                    }
+                }
+            }
+            """
+
+        guard let data = jsonString.data(using: .utf8) else {
+            XCTFail("Failed to create data from JSON string")
+            return
+        }
+
+        if let object = try? Current.jsonDecoder.decode(ObjectToDecode.self, from: data) {
+            print(object.customClaims)
+        } else {
+            XCTFail("Failed To Parse JSON")
+        }
+    }
+
+    struct ObjectToDecode: Codable {
+        let customClaims: JSON
+    }
+}

--- a/Tests/StytchCoreTests/XCTestHelpers.swift
+++ b/Tests/StytchCoreTests/XCTestHelpers.swift
@@ -81,8 +81,10 @@ private extension JSON {
                 return description
             } else {
                 for key in lhsKeys {
-                    if let description = lhs[key]?.difference(from: rhs[key]) {
-                        return description
+                    if let lhsValue = lhs[key], let rhsValue = rhs[key] {
+                        if let description = lhsValue?.difference(from: rhsValue) {
+                            return description
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Linear Ticket: [[SDK-2085] [iOS] Drop null values from key value pairs in JSON object type](https://linear.app/stytch/issue/SDK-2085/[ios]-drop-null-values-from-key-value-pairs-in-json-object-type)

## Changes:

1. We were having an issue where if the JSON for custom claims had a null value in the key value pair then it would throw an exception. Now that JSON is able to take a key value pair with a null value.
2. It would be worth exploring if we should replace our JSON class with [SwiftyJSON](https://github.com/SwiftyJSON/SwiftyJSON), but that is a greater effort and I feel confident that this will fix the issue.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A
