### PR TITLE
Make Sessions Read-Only From Clients

### DIFF
--- a/Sources/StytchCore/Documentation.docc/StytchCore.md
+++ b/Sources/StytchCore/Documentation.docc/StytchCore.md
@@ -4,7 +4,9 @@ Provides native iOS access to the Stytch SDK methods for ultimate flexibility.
 
 The iOS SDK provides methods that communicate directly with the Stytch API. These help you get up and running with Stytch faster by removing the need to create endpoints on your backend to make requests to [Stytch](https://stytch.com).
 
-In addition to StytchCore we have a seperate dependency for our pre build UI framework, [StytchUI](https://stytchauth.github.io/stytch-ios/latest/StytchUI/documentation/stytchui/), which provides a out of the box solution for using Stytch. 
+In addition to StytchCore we have a seperate dependency for our pre built UI framework, [StytchUI](https://stytchauth.github.io/stytch-ios/latest/StytchUI/documentation/stytchui/), which provides a out of the box solution for using Stytch. 
+
+[Stytch iOS Github Repo](https://github.com/stytchauth/stytch-ios)
 
 ## Using Stytch
 

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Sessions.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Sessions.swift
@@ -15,12 +15,7 @@ public extension StytchB2BClient {
         @Dependency(\.localStorage) var localStorage
 
         public var memberSession: MemberSession? {
-            get {
-                localStorage.memberSession
-            }
-            set {
-                localStorage.memberSession = newValue
-            }
+            localStorage.memberSession
         }
 
         /// An opaque token representing your session, which your servers can check with Stytch's servers to verify your session status.

--- a/Sources/StytchCore/StytchClient/StytchClient+Sessions.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient+Sessions.swift
@@ -25,12 +25,7 @@ public extension StytchClient {
 
         /// If logged in, returns the cached session object.
         public var session: Session? {
-            get {
-                localStorage.session
-            }
-            set {
-                localStorage.session = newValue
-            }
+            localStorage.session
         }
 
         /// An opaque token representing your session, which your servers can check with Stytch's servers to verify your session status.


### PR DESCRIPTION
- Remove the ability to publicly set the session object from the clients.
- Add GitHub repo link to docs.