### PR TITLE
Adding New B2B OAuth Providers

### DIFF
--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
@@ -146,6 +146,9 @@ extension StytchB2BClient.OAuth.ThirdParty {
     enum Provider: String, CaseIterable, Codable {
         case google
         case microsoft
+        case hubspot
+        case slack
+        case github
     }
 }
 #endif

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
@@ -91,5 +91,20 @@ public extension StytchB2BClient.OAuth {
     var microsoft: ThirdParty {
         .init(provider: .microsoft)
     }
+
+    /// The interface for authenticating a user with Hubspot.
+    var hubspot: ThirdParty {
+        .init(provider: .hubspot)
+    }
+
+    /// The interface for authenticating a user with Slack.
+    var slack: ThirdParty {
+        .init(provider: .slack)
+    }
+
+    /// The interface for authenticating a user with Github.
+    var github: ThirdParty {
+        .init(provider: .github)
+    }
 }
 #endif


### PR DESCRIPTION
[SDK-2040 - [iOS] Slack B2B OAuth](https://linear.app/stytch/issue/SDK-2040/[ios]-slack-b2b-oauth)
[SDK-2039 - [iOS] Hubspot B2B OAuth](https://linear.app/stytch/issue/SDK-2039/[ios]-hubspot-b2b-oauth)
[SDK-2037 - [iOS] Github B2B OAuth](https://linear.app/stytch/issue/SDK-2037/[ios]-github-b2b-oauth)

## Changes:

1. Expand the `StytchB2BClient.OAuth.ThirdParty.Provider` enum to include the new types.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
