### PR TITLE
Add missing response types for MFA and OAuth

### DIFF
--- a/Sources/StytchCore/Generated/StytchB2BClient.Discovery.createOrganization+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.Discovery.createOrganization+AsyncVariants.generated.swift
@@ -5,7 +5,7 @@ import Foundation
 
 public extension StytchB2BClient.Discovery {
     /// Wraps Stytch's [create Organization via discovery](https://stytch.com/docs/b2b/api/create-organization-via-discovery) endpoint. This operation consumes the `intermediate_session_token`. If this method succeeds, the Member will be logged in, and granted an active session.
-    func createOrganization(parameters: CreateOrganizationParameters, completion: @escaping Completion<CreateOrganizationResponse>) {
+    func createOrganization(parameters: CreateOrganizationParameters, completion: @escaping Completion<B2BMFAAuthenticateResponseData>) {
         Task {
             do {
                 completion(.success(try await createOrganization(parameters: parameters)))
@@ -16,7 +16,7 @@ public extension StytchB2BClient.Discovery {
     }
 
     /// Wraps Stytch's [create Organization via discovery](https://stytch.com/docs/b2b/api/create-organization-via-discovery) endpoint. This operation consumes the `intermediate_session_token`. If this method succeeds, the Member will be logged in, and granted an active session.
-    func createOrganization(parameters: CreateOrganizationParameters) -> AnyPublisher<CreateOrganizationResponse, Error> {
+    func createOrganization(parameters: CreateOrganizationParameters) -> AnyPublisher<B2BMFAAuthenticateResponseData, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/Generated/StytchB2BClient.Discovery.exchangeIntermediateSession+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.Discovery.exchangeIntermediateSession+AsyncVariants.generated.swift
@@ -5,7 +5,7 @@ import Foundation
 
 public extension StytchB2BClient.Discovery {
     /// Wraps Stytch's [exchange intermediate session](https://stytch.com/docs/b2b/api/exchange-intermediate-session) endpoint. This operation consumes the `intermediate_session_token`. If this method succeeds, the Member will be logged in, and granted an active session.
-    func exchangeIntermediateSession(parameters: ExchangeIntermediateSessionParameters, completion: @escaping Completion<ExchangeIntermediateSessionResponse>) {
+    func exchangeIntermediateSession(parameters: ExchangeIntermediateSessionParameters, completion: @escaping Completion<B2BMFAAuthenticateResponseData>) {
         Task {
             do {
                 completion(.success(try await exchangeIntermediateSession(parameters: parameters)))
@@ -16,7 +16,7 @@ public extension StytchB2BClient.Discovery {
     }
 
     /// Wraps Stytch's [exchange intermediate session](https://stytch.com/docs/b2b/api/exchange-intermediate-session) endpoint. This operation consumes the `intermediate_session_token`. If this method succeeds, the Member will be logged in, and granted an active session.
-    func exchangeIntermediateSession(parameters: ExchangeIntermediateSessionParameters) -> AnyPublisher<ExchangeIntermediateSessionResponse, Error> {
+    func exchangeIntermediateSession(parameters: ExchangeIntermediateSessionParameters) -> AnyPublisher<B2BMFAAuthenticateResponseData, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/Generated/StytchB2BClient.OAuth.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.OAuth.authenticate+AsyncVariants.generated.swift
@@ -5,7 +5,7 @@ import Foundation
 
 public extension StytchB2BClient.OAuth {
     /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
-    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<B2BMFAAuthenticateResponse>) {
+    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<OAuthAuthenticateResponse>) {
         Task {
             do {
                 completion(.success(try await authenticate(parameters: parameters)))
@@ -16,7 +16,7 @@ public extension StytchB2BClient.OAuth {
     }
 
     /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
-    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<B2BMFAAuthenticateResponse, Error> {
+    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<OAuthAuthenticateResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/Generated/StytchClient.OAuth.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.OAuth.authenticate+AsyncVariants.generated.swift
@@ -5,7 +5,7 @@ import Foundation
 
 public extension StytchClient.OAuth {
     /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
-    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<AuthenticateResponse>) {
+    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<OAuthAuthenticateResponse>) {
         Task {
             do {
                 completion(.success(try await authenticate(parameters: parameters)))
@@ -16,7 +16,7 @@ public extension StytchClient.OAuth {
     }
 
     /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
-    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<AuthenticateResponse, Error> {
+    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<OAuthAuthenticateResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/Generated/StytchClient.handle+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.handle+AsyncVariants.generated.swift
@@ -11,7 +11,7 @@ public extension StytchClient {
     ///  - Parameters:
     ///    - url: A `URL` passed to your application as a deeplink.
     ///    - sessionDuration: The duration, in minutes, of the requested session. Defaults to 5 minutes.
-    static func handle(url: URL, sessionDuration: Minutes = .defaultSessionDuration, completion: @escaping Completion<DeeplinkHandledStatus<AuthenticateResponse, DeeplinkTokenType>>) {
+    static func handle(url: URL, sessionDuration: Minutes = .defaultSessionDuration, completion: @escaping Completion<DeeplinkHandledStatus<DeeplinkResponse, DeeplinkTokenType>>) {
         Task {
             do {
                 completion(.success(try await handle(url: url, sessionDuration: sessionDuration)))
@@ -28,7 +28,7 @@ public extension StytchClient {
     ///  - Parameters:
     ///    - url: A `URL` passed to your application as a deeplink.
     ///    - sessionDuration: The duration, in minutes, of the requested session. Defaults to 5 minutes.
-    static func handle(url: URL, sessionDuration: Minutes = .defaultSessionDuration) -> AnyPublisher<DeeplinkHandledStatus<AuthenticateResponse, DeeplinkTokenType>, Error> {
+    static func handle(url: URL, sessionDuration: Minutes = .defaultSessionDuration) -> AnyPublisher<DeeplinkHandledStatus<DeeplinkResponse, DeeplinkTokenType>, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/OAuthProviderValues.swift
+++ b/Sources/StytchCore/OAuthProviderValues.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct OAuthProviderValues: Codable {
+    /// The access_token that you may use to access the User's data in the provider's API.
+    public let accessToken: String
+    /// The id_token returned by the OAuth provider. ID Tokens are JWTs that contain structured information about a user. The exact content of each ID Token varies from provider to provider.
+    /// ID Tokens are returned from OAuth providers that conform to the OpenID Connect specification, which is based on OAuth.
+    public let idToken: String
+    /// The refresh_token that you may use to obtain a new access_token for the User within the provider's API.
+    public let refreshToken: String?
+    /// The OAuth scopes included for a given provider. See each provider's section above to see which scopes are included by default and how to add custom scopes.
+    public let scopes: [String]
+    /// The timestamp when the Session expires. Values conform to the RFC 3339 standard and are expressed in UTC, e.g. 2021-12-29T12:33:09Z.
+    public let expiresAt: Date
+}

--- a/Sources/StytchCore/SharedModels/Response.swift
+++ b/Sources/StytchCore/SharedModels/Response.swift
@@ -92,6 +92,9 @@ extension Response: B2BMFAAuthenticateResponseDataType where Wrapped: B2BMFAAuth
     public var sessionToken: String { wrapped.sessionToken }
     public var sessionJwt: String { wrapped.sessionJwt }
     public var intermediateSessionToken: String? { wrapped.intermediateSessionToken }
+    public var memberId: Member.ID { wrapped.memberId }
+    public var memberAuthenticated: Bool { wrapped.memberAuthenticated }
+    public var mfaRequired: MFARequired? { wrapped.mfaRequired }
 }
 
 extension Response: DiscoveryIntermediateSessionTokenDataType where Wrapped: DiscoveryIntermediateSessionTokenDataType {

--- a/Sources/StytchCore/StytchB2BClient/Models/B2BMFAAuthenticateResponse.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/B2BMFAAuthenticateResponse.swift
@@ -10,6 +10,8 @@ public typealias B2BMFAAuthenticateResponseType = BasicResponseType & B2BMFAAuth
 public struct B2BMFAAuthenticateResponseData: Codable, B2BMFAAuthenticateResponseDataType {
     /// The ``MemberSession`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
     public let memberSession: MemberSession?
+    /// The current member's ID.
+    public let memberId: Member.ID
     /// The current member object.
     public let member: Member
     /// The current organization object.
@@ -20,12 +22,18 @@ public struct B2BMFAAuthenticateResponseData: Codable, B2BMFAAuthenticateRespons
     public let sessionJwt: String
     /// An optional intermediate session token to be returned if multi factor authentication is enabled
     public let intermediateSessionToken: String?
+    /// Indicates whether the Member is fully authenticated. If false, the Member needs to complete an MFA step to log in to the Organization.
+    public let memberAuthenticated: Bool
+    /// Information about the MFA requirements of the Organization and the Member's options for fulfilling MFA.
+    public let mfaRequired: MFARequired?
 }
 
 /// The interface which a data type must conform to for all underlying data in B2B MFA `authenticate` responses.
 public protocol B2BMFAAuthenticateResponseDataType {
     /// The ``MemberSession`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
     var memberSession: MemberSession? { get }
+    /// The current member's ID.
+    var memberId: Member.ID { get }
     /// The current member object.
     var member: Member { get }
     /// The current organization object.
@@ -36,10 +44,30 @@ public protocol B2BMFAAuthenticateResponseDataType {
     var sessionJwt: String { get }
     /// An optional intermediate session token to be returned if multi factor authentication is enabled
     var intermediateSessionToken: String? { get }
+    /// Indicates whether the Member is fully authenticated. If false, the Member needs to complete an MFA step to log in to the Organization.
+    var memberAuthenticated: Bool { get }
+    /// Information about the MFA requirements of the Organization and the Member's options for fulfilling MFA.
+    var mfaRequired: MFARequired? { get }
 }
 
 /// The interface which a data type must conform to for all discovery flows that return a non optional intermediate session token
 public protocol DiscoveryIntermediateSessionTokenDataType {
     /// The non optional intermediate session token returned by discovery flows separate from multi factor authentication
     var intermediateSessionToken: String { get }
+}
+
+public struct MFARequired: Codable {
+    /// Information about the Member's options for completing MFA.
+    public let memberOptions: MemberOptions?
+    /// If null, indicates that no secondary authentication has been initiated.
+    /// If equal to "sms_otp", indicates that the Member has a phone number, and a one time passcode has been sent to the Member's phone number.
+    /// No secondary authentication will be initiated during calls to the discovery authenticate or list organizations endpoints, even if the Member has a phone number.
+    public let secondaryAuthInitiated: String?
+}
+
+public struct MemberOptions: Codable {
+    /// The Member's MFA phone number.
+    public let mfaPhoneNumber: String
+    /// The Member's MFA TOTP registration ID.
+    public let totpRegistrationId: String
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Discovery.swift
@@ -33,7 +33,7 @@ public extension StytchB2BClient {
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's [exchange intermediate session](https://stytch.com/docs/b2b/api/exchange-intermediate-session) endpoint. This operation consumes the `intermediate_session_token`. If this method succeeds, the Member will be logged in, and granted an active session.
-        public func exchangeIntermediateSession(parameters: ExchangeIntermediateSessionParameters) async throws -> ExchangeIntermediateSessionResponse {
+        public func exchangeIntermediateSession(parameters: ExchangeIntermediateSessionParameters) async throws -> B2BMFAAuthenticateResponseData {
             try await router.post(
                 to: .intermediateSessionsExchange,
                 parameters: IntermediateSessionTokenParameters(
@@ -45,7 +45,7 @@ public extension StytchB2BClient {
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's [create Organization via discovery](https://stytch.com/docs/b2b/api/create-organization-via-discovery) endpoint. This operation consumes the `intermediate_session_token`. If this method succeeds, the Member will be logged in, and granted an active session.
-        public func createOrganization(parameters: CreateOrganizationParameters) async throws -> CreateOrganizationResponse {
+        public func createOrganization(parameters: CreateOrganizationParameters) async throws -> B2BMFAAuthenticateResponseData {
             try await router.post(
                 to: .organizationsCreate,
                 parameters: IntermediateSessionTokenParameters(
@@ -71,27 +71,6 @@ public extension StytchB2BClient.Discovery {
 }
 
 public extension StytchB2BClient.Discovery {
-    /// The response type for Discovery `exchangeIntermediateSession` calls.
-    typealias ExchangeIntermediateSessionResponse = Response<ExchangeIntermediateSessionResponseData>
-
-    /// The underlying data for `ExchangeIntermediateSessionResponse`.
-    struct ExchangeIntermediateSessionResponseData: Codable, B2BMFAAuthenticateResponseDataType {
-        /// The current member's ID.
-        public let memberId: Member.ID
-        /// The ``MemberSession`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
-        public let memberSession: MemberSession?
-        /// The opaque token for the session. Can be used by your server to verify the validity of your session by confirming with Stytch's servers on each request.
-        public let sessionToken: String
-        /// The JWT for the session. Can be used by your server to verify the validity of your session either by checking the data included in the JWT, or by verifying with Stytch's servers as needed.
-        public let sessionJwt: String
-        /// The current member object.
-        public let member: Member
-        /// The current organization object.
-        public let organization: Organization
-        /// An optional intermediate session token to be returned if multi factor authentication is enabled
-        public var intermediateSessionToken: String?
-    }
-
     /// The dedicated parameters type for Discovery `exchangeIntermediateSession` calls.
     struct ExchangeIntermediateSessionParameters: Encodable {
         private enum CodingKeys: String, CodingKey {
@@ -113,27 +92,6 @@ public extension StytchB2BClient.Discovery {
 }
 
 public extension StytchB2BClient.Discovery {
-    /// The response type for Discovery `createOrganization` calls.
-    typealias CreateOrganizationResponse = Response<CreateOrganizationResponseData>
-
-    /// The underlying data for `CreateOrganizationResponse`.
-    struct CreateOrganizationResponseData: Codable, B2BMFAAuthenticateResponseDataType {
-        /// The current member's ID.
-        public let memberId: Member.ID
-        /// The ``MemberSession`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
-        public let memberSession: MemberSession?
-        /// The opaque token for the session. Can be used by your server to verify the validity of your session by confirming with Stytch's servers on each request.
-        public let sessionToken: String
-        /// The JWT for the session. Can be used by your server to verify the validity of your session either by checking the data included in the JWT, or by verifying with Stytch's servers as needed.
-        public let sessionJwt: String
-        /// The current member object.
-        public let member: Member
-        /// The current organization object.
-        public let organization: Organization
-        /// An optional intermediate session token to be returned if multi factor authentication is enabled
-        public var intermediateSessionToken: String?
-    }
-
     /// A dedicated parameters type for Discovery `createOrganization` calls.
     struct CreateOrganizationParameters: Codable {
         private enum CodingKeys: String, CodingKey {

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -79,6 +79,7 @@ public extension StytchB2BClient {
     enum DeeplinkResponse {
         case auth(B2BAuthenticateResponse)
         case mfauth(B2BMFAAuthenticateResponse)
+        case mfaOAuth(StytchB2BClient.OAuth.OAuthAuthenticateResponse)
         case discovery(StytchB2BClient.MagicLinks.DiscoveryAuthenticateResponse)
         #if !os(watchOS)
         case discoveryOauth(StytchB2BClient.OAuth.Discovery.DiscoveryAuthenticateResponse)
@@ -132,7 +133,7 @@ public extension StytchB2BClient {
             Task {
                 try? await EventsClient.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))
             }
-            return try await .handled(response: .mfauth(oauth.authenticate(parameters: .init(oauthToken: token, sessionDurationMinutes: sessionDuration))))
+            return try await .handled(response: .mfaOAuth(oauth.authenticate(parameters: .init(oauthToken: token, sessionDurationMinutes: sessionDuration))))
         case .discoveryOauth:
             Task {
                 try? await EventsClient.logEvent(parameters: .init(eventName: "deeplink_handled_success", details: ["token_type": tokenType.rawValue]))

--- a/Sources/StytchUI/StytchUIClient/StytchUIClient.swift
+++ b/Sources/StytchUI/StytchUIClient/StytchUIClient.swift
@@ -54,8 +54,13 @@ public enum StytchUIClient {
     public static func handle(url: URL, from controller: UIViewController? = nil) -> Bool {
         Task { @MainActor in
             switch try await StytchClient.handle(url: url) {
-            case let .handled(response):
-                self.onAuthCallback?(response)
+            case let .handled(responseData):
+                switch responseData {
+                case let .auth(response):
+                    self.onAuthCallback?(response)
+                case let .oauth(response):
+                    self.onAuthCallback?(response)
+                }
             case .notHandled:
                 break
             case let .manualHandlingRequired(_, token):

--- a/Stytch/DemoApps/B2BWorkbench/SceneDelegate.swift
+++ b/Stytch/DemoApps/B2BWorkbench/SceneDelegate.swift
@@ -36,6 +36,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                         print("discovery oauth response: \(authResponse)")
                     case let .mfauth(authResponse):
                         print("mfa response: \(authResponse)")
+                    case let .mfaOAuth(authResponse):
+                        print("mfaOAuth response: \(authResponse)")
                     }
                 case let .manualHandlingRequired(_, token):
                     if let navigationController = window?.rootViewController as? UINavigationController,

--- a/Stytch/DemoApps/ConsumerWorkbench/Shared/StytchDemoApp.swift
+++ b/Stytch/DemoApps/ConsumerWorkbench/Shared/StytchDemoApp.swift
@@ -62,9 +62,15 @@ struct StytchApp: App {
         Task {
             do {
                 switch try await StytchClient.handle(url: url, sessionDuration: 5) {
-                case let .handled(response):
-                    print("handled: \(response.session) - \(response.user)")
-                    self.sessionUser = (response.session, response.user)
+                case let .handled(responseData):
+                    switch responseData {
+                    case let .auth(response):
+                        print("handled: \(response.session) - \(response.user)")
+                        self.sessionUser = (response.session, response.user)
+                    case let .oauth(response):
+                        print("handled: \(response.session) - \(response.user)")
+                        self.sessionUser = (response.session, response.user)
+                    }
                 case .notHandled:
                     print("not handled")
                 case let .manualHandlingRequired(tokenType, token):

--- a/Stytch/DemoApps/StytchDemo/ContentView.swift
+++ b/Stytch/DemoApps/StytchDemo/ContentView.swift
@@ -63,8 +63,13 @@ struct ContentView: View {
         Task {
             do {
                 switch try await StytchClient.handle(url: url, sessionDuration: 5) {
-                case let .handled(response):
-                    print("handled: \(response.session) - \(response.user)")
+                case let .handled(responseData):
+                    switch responseData {
+                    case let .auth(response):
+                        print("handled auth: \(response.session) - \(response.user)")
+                    case let .oauth(response):
+                        print("handled oauth: \(response.session) - \(response.user)")
+                    }
                 case .notHandled:
                     print("not handled")
                 case let .manualHandlingRequired(tokenType, token):

--- a/Stytch/DemoApps/StytchUIDemo/StytchUIDemoApp.swift
+++ b/Stytch/DemoApps/StytchUIDemo/StytchUIDemoApp.swift
@@ -32,8 +32,8 @@ struct StytchUIDemoApp: App {
         products: .init(
             oauth: .init(
                 providers: [.apple, .thirdParty(.google)],
-                loginRedirectUrl: .init(string: "stytch-ui://login")!,
-                signupRedirectUrl: .init(string: "stytch-ui://signup")!
+                loginRedirectUrl: .init(string: "stytch-demo://auth")!,
+                signupRedirectUrl: .init(string: "stytch-demo://auth")!
             ),
             password: .init(),
             magicLink: .init(),

--- a/Tests/StytchCoreTests/B2BDiscoveryTestCase.swift
+++ b/Tests/StytchCoreTests/B2BDiscoveryTestCase.swift
@@ -30,9 +30,7 @@ final class B2BDiscoveryTestCase: BaseTestCase {
     }
 
     func testExchangeIntermediateSession() async throws {
-        networkInterceptor.responses {
-            StytchB2BClient.Discovery.ExchangeIntermediateSessionResponse(requestId: "asdf", statusCode: 200, wrapped: .init(memberId: Member.mock.id, memberSession: .mock, sessionToken: "session_token", sessionJwt: "session_jwt", member: .mock, organization: .mock))
-        }
+        networkInterceptor.responses { B2BMFAAuthenticateResponse.mock }
         Current.timer = { _, _, _ in .init() }
 
         Current.sessionManager.updateSession(intermediateSessionToken: intermediateSessionToken)
@@ -51,20 +49,7 @@ final class B2BDiscoveryTestCase: BaseTestCase {
     }
 
     func testCreateOrganization() async throws {
-        networkInterceptor.responses {
-            StytchB2BClient.Discovery.CreateOrganizationResponse(
-                requestId: "req",
-                statusCode: 200,
-                wrapped: .init(
-                    memberId: Member.mock.id,
-                    memberSession: .mock,
-                    sessionToken: "asdf",
-                    sessionJwt: "zxcv",
-                    member: .mock,
-                    organization: .mock
-                )
-            )
-        }
+        networkInterceptor.responses { B2BMFAAuthenticateResponse.mock }
         Current.timer = { _, _, _ in .init() }
 
         Current.sessionManager.updateSession(intermediateSessionToken: intermediateSessionToken)

--- a/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
@@ -197,11 +197,14 @@ extension B2BMFAAuthenticateResponse {
         statusCode: 200,
         wrapped: .init(
             memberSession: .mock,
+            memberId: "member_id_123",
             member: .mock,
             organization: .mock,
             sessionToken: "xyzasdf",
             sessionJwt: "i'mvalidjson",
-            intermediateSessionToken: "cccccbgkvlhvciffckuevcevtrkjfkeiklvulgrrgvke"
+            intermediateSessionToken: "cccccbgkvlhvciffckuevcevtrkjfkeiklvulgrrgvke",
+            memberAuthenticated: false,
+            mfaRequired: nil
         )
     )
 }

--- a/Tests/StytchCoreTests/B2BOAuthTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOAuthTestCase.swift
@@ -5,7 +5,7 @@ final class B2BOAuthTestCase: BaseTestCase {
     @available(tvOS 16.0, *)
     func testAuthenticate() async throws {
         networkInterceptor.responses {
-            B2BMFAAuthenticateResponse.mock
+            StytchB2BClient.OAuth.OAuthAuthenticateResponse.mock
         }
 
         Current.timer = { _, _, _ in .init() }
@@ -84,4 +84,33 @@ extension StytchB2BClient.OAuth.Discovery.DiscoveryAuthenticateResponseData {
             discoveredOrganizations: []
         )
     }
+}
+
+extension StytchB2BClient.OAuth.OAuthAuthenticateResponse {
+    static let mock: Self = .init(
+        requestId: "req_123",
+        statusCode: 200,
+        wrapped: .init(
+            memberSession: .mock,
+            memberId: "member_id_123",
+            member: .mock,
+            organization: .mock,
+            sessionToken: "xyzasdf",
+            sessionJwt: "i'mvalidjson",
+            intermediateSessionToken: "cccccbgkvlhvciffckuevcevtrkjfkeiklvulgrrgvke",
+            memberAuthenticated: false,
+            mfaRequired: nil,
+            providerValues: .mock
+        )
+    )
+}
+
+extension OAuthProviderValues {
+    static let mock: Self = .init(
+        accessToken: "",
+        idToken: "",
+        refreshToken: nil,
+        scopes: [],
+        expiresAt: Date()
+    )
 }

--- a/Tests/StytchCoreTests/B2BPasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BPasswordsTestCase.swift
@@ -135,7 +135,7 @@ final class B2BPasswordsTestCase: BaseTestCase {
     }
 
     func testResetByExistingPassword() async throws {
-        networkInterceptor.responses { B2BAuthenticateResponse.mock }
+        networkInterceptor.responses { B2BMFAAuthenticateResponse.mock }
         Current.timer = { _, _, _ in .init() }
 
         Current.sessionManager.updateSession(intermediateSessionToken: intermediateSessionToken)

--- a/Tests/StytchCoreTests/B2BSessionsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSessionsTestCase.swift
@@ -70,7 +70,7 @@ final class B2BSessionsTestCase: BaseTestCase {
 
     func testSessionExchange() async throws {
         networkInterceptor.responses {
-            B2BAuthenticateResponse.mock
+            B2BMFAAuthenticateResponse.mock
         }
 
         Current.timer = { _, _, _ in .init() }

--- a/Tests/StytchCoreTests/DeeplinkHandlerTestCase.swift
+++ b/Tests/StytchCoreTests/DeeplinkHandlerTestCase.swift
@@ -28,8 +28,14 @@ final class DeeplinkHandlerTestCase: BaseTestCase {
 
         switch try await StytchClient.handle(url: handledUrl, sessionDuration: 30) {
         case let .handled(response):
-            XCTAssertEqual(response.sessionJwt, "jwt_for_me")
-            XCTAssertEqual(response.session.authenticationFactors.count, 1)
+            switch response {
+            case let .auth(responseData):
+                XCTAssertEqual(responseData.sessionJwt, "jwt_for_me")
+                XCTAssertEqual(responseData.session.authenticationFactors.count, 1)
+            case let .oauth(responseData):
+                XCTAssertEqual(responseData.sessionJwt, "jwt_for_me")
+                XCTAssertEqual(responseData.session.authenticationFactors.count, 1)
+            }
         case .notHandled, .manualHandlingRequired:
             XCTFail("expected to be handled")
         }

--- a/Tests/StytchUIUnitTests/BaseTestCase.swift
+++ b/Tests/StytchUIUnitTests/BaseTestCase.swift
@@ -132,3 +132,30 @@ extension StytchClient.OAuth.Apple.AuthenticateResponse {
         )
     }
 }
+
+extension StytchClient.OAuth.OAuthAuthenticateResponse {
+    static let mock: Self = .init(
+        requestId: "req_123",
+        statusCode: 200,
+        wrapped: .init(
+            user: .mock(userId: "123"),
+            sessionToken: "123",
+            sessionJwt: "123",
+            session: .mock(userId: "123"),
+            oauthUserRegistrationId: "123",
+            providerSubject: "123",
+            providerType: "123",
+            providerValues: .mock
+        )
+    )
+}
+
+extension OAuthProviderValues {
+    static let mock: Self = .init(
+        accessToken: "",
+        idToken: "",
+        refreshToken: nil,
+        scopes: [],
+        expiresAt: Date()
+    )
+}

--- a/Tests/StytchUIUnitTests/Spies.swift
+++ b/Tests/StytchUIUnitTests/Spies.swift
@@ -126,7 +126,7 @@ class OAuthSpy: OAuthProviderProtocol {
         self.callback = callback
     }
 
-    func authenticate(parameters _: StytchClient.OAuth.AuthenticateParameters) async throws -> AuthenticateResponse {
+    func authenticate(parameters _: StytchClient.OAuth.AuthenticateParameters) async throws -> StytchClient.OAuth.OAuthAuthenticateResponse {
         callback(.oauthAuthenticate)
         return .mock
     }

--- a/tutorials/Deeplinks.md
+++ b/tutorials/Deeplinks.md
@@ -55,7 +55,12 @@ func handle(url: URL) {
         do {
             switch try await StytchClient.handle(url: url, sessionDuration: 5) {
             case let .handled(response):
-                print("handled: \(response.session) - \(response.user)")
+                switch responseData {
+                case let .auth(response):
+                    print("handled .auth: \(response.session) - \(response.user)")
+                case let .oauth(response):
+                    print("handled .oauth: \(response.session) - \(response.user)")
+                }
             case .notHandled:
                 print("not handled")
             case let .manualHandlingRequired(tokenType, token):


### PR DESCRIPTION
[[iOS] Missing fields in B2BMFAAuthenticateResponseData](https://linear.app/stytch/issue/SDK-2078/[ios]-missing-fields-in-b2bmfaauthenticateresponsedata)
[[iOS] Update OAuth Response Types To Include Missing Fields](https://linear.app/stytch/issue/SDK-1992/[ios]-update-oauth-response-types-to-include-missing-fields)

## Changes:

1. Add missing fields to `B2BMFAAuthenticateResponseData`
2. Create `MFARequired` object.
3. Add `OAuthAuthenticateResponseData` for consumer and b2b
4. For b2b add additional cases to the `DeeplinkResponse` for the new oauth response type.
5. For consumer create their own `DeeplinkResponse`.
6. Delete some response types that now were just the standard MFA response type with the expanded types.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
