### PR TITLE
[SDK-2105] Refactor publishing of initial object state

### DIFF
--- a/Sources/StytchCore/StytchClientType.swift
+++ b/Sources/StytchCore/StytchClientType.swift
@@ -61,8 +61,6 @@ extension StytchClientType {
             // only run this in non-test environments
             start()
         }
-
-        publishCachedValuesIfNeededForStartup()
     }
 
     // swiftlint:disable:next identifier_name
@@ -76,15 +74,6 @@ extension StytchClientType {
             return nil
         }
         return (tokenType: type, token)
-    }
-
-    // TODO: We should remove this and make "publish" private within ObjectStorage
-    private func publishCachedValuesIfNeededForStartup() {
-        Current.sessionStorage.publish()
-        Current.memberSessionStorage.publish()
-        Current.userStorage.publish()
-        Current.memberStorage.publish()
-        Current.organizationStorage.publish()
     }
 
     // To be called after configuration


### PR DESCRIPTION
[[iOS] Refactor publishing of initial object state](https://linear.app/stytch/issue/SDK-2105/[ios]-refactor-publishing-of-initial-object-state)

## Changes:

1. Rather than force publishing the values of the core object types from outside of `ObjectStorage` make the `publish` method private and have each `ObjectStorage` instance observe the first event in the `StartupClient.isInitialized` publisher and then publish from within the class.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
