### PR TITLE
[SDK-1725] Add “Sendable” confromance

### DIFF
--- a/Sources/StytchCore/ClientType.swift
+++ b/Sources/StytchCore/ClientType.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum ClientType {
+public enum ClientType: Sendable {
     case consumer
     case b2b
 }

--- a/Sources/StytchCore/DeeplinkHandledStatus.swift
+++ b/Sources/StytchCore/DeeplinkHandledStatus.swift
@@ -2,7 +2,7 @@
  Represents whether a deeplink was able to be handled
  Session-related information when appropriate.
  */
-public enum DeeplinkHandledStatus<AuthenticateResponse, DeeplinkTokenType> {
+public enum DeeplinkHandledStatus<AuthenticateResponse: Sendable, DeeplinkTokenType: Sendable>: Sendable {
     /// The handler was successfully able to handle the given item.
     case handled(response: AuthenticateResponse)
     /// The handler was unable to handle the given item.

--- a/Sources/StytchCore/EventsClient.swift
+++ b/Sources/StytchCore/EventsClient.swift
@@ -41,7 +41,7 @@ public enum EventsClient {
 }
 
 public extension EventsClient {
-    struct Parameters {
+    struct Parameters: Sendable {
         let eventName: String
         let details: [String: String]?
         let error: Error?

--- a/Sources/StytchCore/Identifier.swift
+++ b/Sources/StytchCore/Identifier.swift
@@ -1,5 +1,5 @@
 /// A generic type which enables type-safety for string-based identifiers.
-public struct Identifier<T, RawValue> {
+public struct Identifier<T, RawValue: Sendable>: Sendable {
     public let rawValue: RawValue
 
     public init(rawValue: RawValue) {

--- a/Sources/StytchCore/JSON.swift
+++ b/Sources/StytchCore/JSON.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A simple type representing valid JSON values which includes several convenience accessors.
-public enum JSON: Hashable, Equatable {
+public enum JSON: Hashable, Equatable, Sendable {
     case array([JSON])
     case object([String: JSON?])
     case string(String)

--- a/Sources/StytchCore/Minutes.swift
+++ b/Sources/StytchCore/Minutes.swift
@@ -1,5 +1,5 @@
 /// A dedicated type which represents the minutes unit of time.
-public struct Minutes: Codable, Equatable {
+public struct Minutes: Codable, Equatable, Sendable {
     let rawValue: UInt
 
     public init(rawValue: UInt) {

--- a/Sources/StytchCore/OAuthProviderValues.swift
+++ b/Sources/StytchCore/OAuthProviderValues.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct OAuthProviderValues: Codable {
+public struct OAuthProviderValues: Codable, Sendable {
     /// The access_token that you may use to access the User's data in the provider's API.
     public let accessToken: String
     /// The id_token returned by the OAuth provider. ID Tokens are JWTs that contain structured information about a user. The exact content of each ID Token varies from provider to provider.

--- a/Sources/StytchCore/PKCE/PKCEPairManager.swift
+++ b/Sources/StytchCore/PKCE/PKCEPairManager.swift
@@ -1,6 +1,6 @@
 /// A data class representing the most recent PKCE code pair generated on this device. You may find this useful if you
 /// use a hybrid (frontend and backend) authentication flow, where you need to complete a PKCE flow on the backend
-public struct PKCECodePair {
+public struct PKCECodePair: Sendable {
     let codeChallenge: String
     let codeVerifier: String
     let method: String

--- a/Sources/StytchCore/PasskeysClient/PasskeysClient+Live.swift
+++ b/Sources/StytchCore/PasskeysClient/PasskeysClient+Live.swift
@@ -12,19 +12,20 @@ extension PasskeysClient {
                 name: username, // We likely want to enforce this to be an email or phone number (if acct exists, must also be in active session during registration)
                 userID: .init(userId.rawValue.utf8) // WebAuthN backend currently relies on session auth, so isn't a pending user id
             )
+
             let controller = ASAuthorizationController(authorizationRequests: [request])
             let delegate = Delegate()
             controller.delegate = delegate
-            //            controller.presentationContextProvider = parameters.presentationContextProvider // TODO: consider passing this in as optional param
+            // controller.presentationContextProvider = parameters.presentationContextProvider // TODO: consider passing this in as optional param
 
             let credential: ASAuthorizationCredential = try await withCheckedThrowingContinuation { continuation in
                 delegate.continuation = continuation
                 controller.performRequests()
             }
 
-            guard
-                let credential = credential as? ASAuthorizationPublicKeyCredentialRegistration
-            else { throw StytchSDKError.invalidCredentialType }
+            guard let credential = credential as? ASAuthorizationPublicKeyCredentialRegistration else {
+                throw StytchSDKError.invalidCredentialType
+            }
 
             return credential
         },
@@ -52,9 +53,9 @@ extension PasskeysClient {
                 }
             }
 
-            guard
-                let credential = credential as? ASAuthorizationPublicKeyCredentialAssertion
-            else { throw StytchSDKError.invalidCredentialType }
+            guard let credential = credential as? ASAuthorizationPublicKeyCredentialAssertion else {
+                throw StytchSDKError.invalidCredentialType
+            }
 
             return credential
         }

--- a/Sources/StytchCore/SharedModels/AuthenticationFactor.swift
+++ b/Sources/StytchCore/SharedModels/AuthenticationFactor.swift
@@ -5,7 +5,7 @@ import Foundation
  E.g. An email which was used to log in, or a phone which was used
  via SMS as an OTP second factor.
  */
-public struct AuthenticationFactor: Hashable {
+public struct AuthenticationFactor: Hashable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case lastAuthenticatedAt
         case kind = "type"

--- a/Sources/StytchCore/SharedModels/BootstrapResponse.swift
+++ b/Sources/StytchCore/SharedModels/BootstrapResponse.swift
@@ -23,7 +23,7 @@ protocol BootstrapResponseDataType {
 }
 
 /// The underlying data for `bootstrap` calls.
-struct BootstrapResponseData: Codable, BootstrapResponseDataType {
+struct BootstrapResponseData: Codable, Sendable, BootstrapResponseDataType {
     let disableSdkWatermark: Bool
     let cnameDomain: String?
     let emailDomains: [String]

--- a/Sources/StytchCore/SharedModels/RBACPolicy.swift
+++ b/Sources/StytchCore/SharedModels/RBACPolicy.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// The RBAC Policy document that contains all defined Roles and Resources – which are managed in the Dashboard (https://stytch.com/dashboard/rbac).
 /// Read more about these entities and how they work in our RBAC overview (https://stytch.com/docs/b2b/guides/rbac/overview).
-public struct RBACPolicy: Codable {
+public struct RBACPolicy: Codable, Sendable {
     /// An array of Role objects.
     public let roles: [RBACPolicyRole]
     /// An array of Resource objects.
@@ -56,7 +56,7 @@ public struct RBACPolicy: Codable {
 }
 
 /// A list of permissions that link a Resource to a list of actions.
-public struct RBACPermission: Codable {
+public struct RBACPermission: Codable, Sendable {
     /// A unique identifier of the RBAC Resource, provided by the developer and intended to be human-readable.
     /// A resource_id is not allowed to start with stytch, which is a special prefix used for Stytch default Resources with reserved resource_ids.
     /// These include: stytch.organization, stytch.member, stytch.sso, stytch.self
@@ -81,7 +81,7 @@ public struct RBACPermission: Codable {
 /// Refer to this guide for details on controls for delegating Roles to Members (https://stytch.com/docs/b2b/guides/rbac/role-assignment).
 /// All Roles are stored in your Project's RBAC Policy. You can create, manage, and assign Roles in the Dashboard (https://stytch.com/dashboard).
 /// Check out the RBAC overview to learn more about Stytch's RBAC permissioning model (https://stytch.com/docs/b2b/guides/rbac/overview).
-public struct RBACPolicyRole: Codable {
+public struct RBACPolicyRole: Codable, Sendable {
     /// The unique identifier of the RBAC Role, provided by the developer and intended to be human-readable.
     /// Reserved role_ids that are predefined by Stytch include: stytch_member, stytch_admin
     /// Check out the guide on Stytch default Roles for a more detailed explanation (https://stytch.com/docs/b2b/guides/rbac/stytch-default).
@@ -96,7 +96,7 @@ public struct RBACPolicyRole: Codable {
 /// The actions list enumerates all the valid operations that can be performed upon the Resource.
 /// All Resources are stored in your Project's RBAC Policy. You can create and manage Resources in the Dashboard (https://stytch.com/dashboard).
 /// Check out the RBAC overview to learn more about Stytch's RBAC permissioning model (https://stytch.com/docs/b2b/guides/rbac/overview).
-public struct RBACPolicyResource: Codable {
+public struct RBACPolicyResource: Codable, Sendable {
     /// A unique identifier of the RBAC Resource, provided by the developer and intended to be human-readable.
     /// A resource_id is not allowed to start with stytch, which is a special prefix used for Stytch default
     /// Resources with reserved resource_ids. These include: stytch.organization, stytch.member, stytch.sso, stytch.self

--- a/Sources/StytchCore/SharedModels/Response.swift
+++ b/Sources/StytchCore/SharedModels/Response.swift
@@ -3,7 +3,7 @@ import Foundation
  A generic type which encompasses the ``requestId`` and ``statusCode``, along with dynamic member accessors for the wrapped type.
  */
 @dynamicMemberLookup
-public struct Response<Wrapped: Decodable>: Decodable {
+public struct Response<Wrapped: Decodable & Sendable>: Decodable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case requestId, statusCode
     }
@@ -44,7 +44,7 @@ public protocol BasicResponseType {
 }
 
 /// An empty type to allow encoding/decoding the absence of a value within various generic Codable types.
-public struct EmptyCodable: Codable {}
+public struct EmptyCodable: Codable, Sendable {}
 
 /// A concrete response type which provides only the `requestId` and `statusCode`.
 public typealias BasicResponse = Response<EmptyCodable>

--- a/Sources/StytchCore/SharedModels/SessionToken.swift
+++ b/Sources/StytchCore/SharedModels/SessionToken.swift
@@ -2,9 +2,9 @@ import Foundation
 
 // TODO: include optional expiration here
 /// Represents one of two kinds of tokens used to represent a session (see ``SessionToken/Kind-swift.enum``, for more info.) These tokens are used to authenticate the current user/member.
-public struct SessionToken: Equatable {
+public struct SessionToken: Equatable, Sendable {
     /// A type representing the different kinds of session tokens available.
-    public enum Kind: CaseIterable {
+    public enum Kind: CaseIterable, Sendable {
         /// An token which is an opaque string, simply representing the session.
         case opaque
         /// A JWT representing the session, which contains signed and serialized information about the session.
@@ -71,7 +71,7 @@ public struct SessionToken: Equatable {
 }
 
 /// A public interface to require the caller to explicitly pass one of each type of non nil token in order to update a session.
-public struct SessionTokens {
+public struct SessionTokens: Sendable {
     internal let jwt: SessionToken
     internal let opaque: SessionToken
 

--- a/Sources/StytchCore/StytchB2BClient/Models/B2BAuthenticateResponse.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/B2BAuthenticateResponse.swift
@@ -7,7 +7,7 @@ public typealias B2BAuthenticateResponse = Response<B2BAuthenticateResponseData>
 public typealias B2BAuthenticateResponseType = BasicResponseType & B2BAuthenticateResponseDataType
 
 /// The underlying data for B2B `authenticate` calls.
-public struct B2BAuthenticateResponseData: Codable, B2BAuthenticateResponseDataType {
+public struct B2BAuthenticateResponseData: Codable, Sendable, B2BAuthenticateResponseDataType {
     /// The ``MemberSession`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
     public let memberSession: MemberSession
     /// The current member object.

--- a/Sources/StytchCore/StytchB2BClient/Models/B2BMFAAuthenticateResponse.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/B2BMFAAuthenticateResponse.swift
@@ -7,7 +7,7 @@ public typealias B2BMFAAuthenticateResponse = Response<B2BMFAAuthenticateRespons
 public typealias B2BMFAAuthenticateResponseType = BasicResponseType & B2BMFAAuthenticateResponseDataType
 
 /// The underlying data for B2B MFA `authenticate` calls.
-public struct B2BMFAAuthenticateResponseData: Codable, B2BMFAAuthenticateResponseDataType {
+public struct B2BMFAAuthenticateResponseData: Codable, Sendable, B2BMFAAuthenticateResponseDataType {
     /// The ``MemberSession`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
     public let memberSession: MemberSession?
     /// The current member's ID.
@@ -56,7 +56,7 @@ public protocol DiscoveryIntermediateSessionTokenDataType {
     var intermediateSessionToken: String { get }
 }
 
-public struct MFARequired: Codable {
+public struct MFARequired: Codable, Sendable {
     /// Information about the Member's options for completing MFA.
     public let memberOptions: MemberOptions?
     /// If null, indicates that no secondary authentication has been initiated.
@@ -65,7 +65,7 @@ public struct MFARequired: Codable {
     public let secondaryAuthInitiated: String?
 }
 
-public struct MemberOptions: Codable {
+public struct MemberOptions: Codable, Sendable {
     /// The Member's MFA phone number.
     public let mfaPhoneNumber: String
     /// The Member's MFA TOTP registration ID.

--- a/Sources/StytchCore/StytchB2BClient/Models/Member.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/Member.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A type defining an organization member; including information about their name, status, the auth factors associated with them, and more.
-public struct Member: Codable {
+public struct Member: Codable, Sendable {
     public typealias ID = Identifier<Self, String>
 
     /// Globally unique UUID that identifies a specific Member. The member_id is critical to perform operations on a Member, so be sure to preserve this value.
@@ -41,7 +41,7 @@ extension Member: Equatable {
 }
 
 public extension Member {
-    enum Status: String, Codable {
+    enum Status: String, Codable, Sendable {
         case pending
         case active
         case deleted
@@ -63,7 +63,7 @@ public extension Member {
 }
 
 /// A type representing a specific SSO registration.
-public struct SSORegistration: Codable, Equatable {
+public struct SSORegistration: Codable, Equatable, Sendable {
     public typealias ID = Identifier<Self, String>
 
     /// The unique ID of an SSO Registration.

--- a/Sources/StytchCore/StytchB2BClient/Models/MemberSession.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/MemberSession.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A type defining a member's session; including information about its validity, expiry, factors associated with this session, and more.
-public struct MemberSession: Codable {
+public struct MemberSession: Codable, Sendable {
     public typealias ID = Identifier<Self, String>
 
     /// Globally unique UUID that identifies a specific Session in the Stytch API. The member_session_id is critical to perform operations on an Session, so be sure to preserve this value.

--- a/Sources/StytchCore/StytchB2BClient/Models/Organization.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/Organization.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A data type representing an organization of which a member may belong to.
-public struct Organization: Codable {
+public struct Organization: Codable, Sendable {
     public typealias ID = Identifier<Self, String>
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
@@ -4,7 +4,7 @@ import Foundation
 
 public extension StytchB2BClient {
     /// The authentication setting that controls the JIT provisioning of Members when authenticating via SSO.
-    enum SsoJitProvisioning: String, Codable {
+    enum SsoJitProvisioning: String, Codable, Sendable {
         /// New Members will be automatically provisioned upon successful authentication via any of the Organization's sso_active_connections.
         case ALL_ALLOWED
         /// Only new Members with SSO logins that comply with sso_jit_provisioning_allowed_connections can be provisioned upon authentication.
@@ -14,7 +14,7 @@ public extension StytchB2BClient {
     }
 
     /// The authentication setting that controls how a new Member can be provisioned by authenticating via Email Magic Link or OAuth.
-    enum EmailJitProvisioning: String, Codable {
+    enum EmailJitProvisioning: String, Codable, Sendable {
         /// Only new Members with verified emails that comply with email_allowed_domains can be provisioned upon authentication via Email Magic Link or OAuth.
         case RESTRICTED
         /// Disable JIT provisioning via Email Magic Link and OAuth.
@@ -22,7 +22,7 @@ public extension StytchB2BClient {
     }
 
     /// The authentication setting that controls how a new Member can be invited to an organization by email.
-    enum EmailInvites: String, Codable {
+    enum EmailInvites: String, Codable, Sendable {
         /// Any new Member can be invited to join via email.
         case ALL_ALLOWED
         /// Only new Members with verified emails that comply with email_allowed_domains can be invited via email.
@@ -32,7 +32,7 @@ public extension StytchB2BClient {
     }
 
     /// The setting that controls which authentication methods can be used by Members of an Organization.
-    enum AuthMethods: String, Codable {
+    enum AuthMethods: String, Codable, Sendable {
         /// The default setting which allows all authentication methods to be used.
         case ALL_ALLOWED
         /// Only methods that comply with allowed_auth_methods can be used for authentication. This setting does not apply to Members with is_breakglass set to true.
@@ -40,7 +40,7 @@ public extension StytchB2BClient {
     }
 
     /// An array of allowed authentication methods. This list is enforced when auth_methods is set to RESTRICTED. The list's accepted values are: sso, magic_link, password, google_oauth, and microsoft_oauth.
-    enum AllowedAuthMethods: String, Codable {
+    enum AllowedAuthMethods: String, Codable, Sendable {
         case SSO = "sso"
         case MAGIC_LINK = "magic_link"
         case PASSWORD = "password"
@@ -49,7 +49,7 @@ public extension StytchB2BClient {
     }
 
     /// The setting that controls which MFA methods can be used by Members of an Organization.
-    enum MfaMethods: String, Codable {
+    enum MfaMethods: String, Codable, Sendable {
         /// The default setting which allows all authentication methods to be used.
         case ALL_ALLOWED
         /// Only methods that comply with allowed_mfa_methods can be used for authentication. This setting does not apply to Members with is_breakglass set to true.
@@ -58,13 +58,13 @@ public extension StytchB2BClient {
 
     /// An array of allowed MFA authentication methods. This list is enforced when mfa_methods is set to RESTRICTED. The list's accepted values are: sms_otp and totp.
     /// If this field is provided and a session header is passed into the request, the Member Session must have permission to perform the update.settings.allowed-mfa-methods action on the stytch.organization Resource.
-    enum MfaMethod: String, Codable {
+    enum MfaMethod: String, Codable, Sendable {
         case SMS = "sms_otp"
         case TOTP = "totp"
     }
 
     /// The setting that controls the MFA policy for all Members in the Organization.
-    enum MfaPolicy: String, Codable {
+    enum MfaPolicy: String, Codable, Sendable {
         /// All Members within the Organization will be required to complete MFA every time they wish to log in. However, any active Session that existed prior to this setting change will remain valid.
         case REQUIRED_FOR_ALL
         /// The default value. The Organization does not require MFA by default for all Members. Members will be required to complete MFA only if their mfa_enrolled status is set to true.
@@ -74,7 +74,7 @@ public extension StytchB2BClient {
     /// Sets the Member’s MFA enrollment status upon a successful authentication.
     /// If the Organization’s MFA policy is REQUIRED_FOR_ALL, this field will be ignored.
     /// If this field is not passed in, the Member’s mfa_enrolled boolean will not be affected.
-    enum MFAEnrollment: String, Codable {
+    enum MFAEnrollment: String, Codable, Sendable {
         /// Sets the Member's mfa_enrolled boolean to true. The Member will be required to complete an MFA step upon subsequent logins to the Organization.
         case enroll
         /// Sets the Member's mfa_enrolled boolean to false. The Member will no longer be required to complete MFA steps when logging in to the Organization.
@@ -84,7 +84,7 @@ public extension StytchB2BClient {
     /// Implicit role assignments based off of email domains.
     /// For each domain-Role pair, all Members whose email addresses have the specified email domain will be granted the associated Role, regardless of their login method.
     /// See the RBAC guide for more information about role assignment (https://stytch.com/docs/b2b/guides/rbac/role-assignment).
-    struct RBACEmailImplicitRoleAssignments: Codable {
+    struct RBACEmailImplicitRoleAssignments: Codable, Sendable {
         let roleId: String
         let domain: String
 
@@ -100,7 +100,7 @@ public extension StytchB2BClient {
     }
 
     // Information about an active SSO connection
-    struct SSOActiveConnection: Codable {
+    struct SSOActiveConnection: Codable, Sendable {
         let connectionId: String
         let displayName: String
 
@@ -114,7 +114,7 @@ public extension StytchB2BClient {
     }
 
     /// A discovered organization.
-    struct DiscoveredOrganization: Codable {
+    struct DiscoveredOrganization: Codable, Sendable {
         /// The Organization object.
         public let organization: Organization
         /// Information about the membership.
@@ -124,7 +124,7 @@ public extension StytchB2BClient {
     }
 
     /// A struct describing a membership and its details.
-    struct Membership: Codable {
+    struct Membership: Codable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case kind = "type"
             case details

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Discovery.swift
@@ -62,7 +62,7 @@ public extension StytchB2BClient.Discovery {
     typealias ListOrganizationsResponse = Response<ListOrganizationsResponseData>
 
     /// The underlying data for `ListOrganizationsResponse`
-    struct ListOrganizationsResponseData: Codable {
+    struct ListOrganizationsResponseData: Codable, Sendable {
         /// The member's email address.
         public let emailAddress: String
         /// A list of discovered organizations.
@@ -72,7 +72,7 @@ public extension StytchB2BClient.Discovery {
 
 public extension StytchB2BClient.Discovery {
     /// The dedicated parameters type for Discovery `exchangeIntermediateSession` calls.
-    struct ExchangeIntermediateSessionParameters: Encodable {
+    struct ExchangeIntermediateSessionParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case organizationId
             case sessionDuration = "sessionDurationMinutes"
@@ -93,7 +93,7 @@ public extension StytchB2BClient.Discovery {
 
 public extension StytchB2BClient.Discovery {
     /// A dedicated parameters type for Discovery `createOrganization` calls.
-    struct CreateOrganizationParameters: Codable {
+    struct CreateOrganizationParameters: Codable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case sessionDuration = "sessionDurationMinutes"
             case organizationName

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+MagicLinks.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+MagicLinks.swift
@@ -276,7 +276,7 @@ public extension StytchB2BClient.MagicLinks {
     typealias DiscoveryAuthenticateResponse = Response<DiscoveryAuthenticateResponseData>
 
     /// The underlying data for the DiscoveryAuthenticateResponse type.
-    struct DiscoveryAuthenticateResponseData: DiscoveryIntermediateSessionTokenDataType, Codable {
+    struct DiscoveryAuthenticateResponseData: DiscoveryIntermediateSessionTokenDataType, Codable, Sendable {
         /// The discovered organizations.
         public let discoveredOrganizations: [StytchB2BClient.DiscoveredOrganization]
         /// The intermediate session token.

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Members.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Members.swift
@@ -69,7 +69,7 @@ public extension StytchB2BClient.Members {
     typealias MemberResponse = Response<MemberResponseData>
 
     /// The underlying data for the MemberResponse type.
-    struct MemberResponseData: Codable {
+    struct MemberResponseData: Codable, Sendable {
         /// The current member's member id.
         public let memberId: String?
 
@@ -83,7 +83,7 @@ public extension StytchB2BClient.Members {
 
 public extension StytchB2BClient.Members {
     /// The dedicated parameters type for the update member call.
-    struct UpdateParameters: Codable {
+    struct UpdateParameters: Codable, Sendable {
         let name: String?
         let untrustedMetadata: JSON?
         let mfaEnrolled: Bool?

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+Discovery.swift
@@ -43,7 +43,7 @@ public extension StytchB2BClient.OAuth {
 }
 
 public extension StytchB2BClient.OAuth.Discovery {
-    struct DiscoveryAuthenticateParameters: Codable {
+    struct DiscoveryAuthenticateParameters: Codable, Sendable {
         let discoveryOauthToken: String
 
         /// A data class wrapping the parameters necessary to authenticate an OAuth Discovery flow
@@ -57,7 +57,7 @@ public extension StytchB2BClient.OAuth.Discovery {
 public extension StytchB2BClient.OAuth.Discovery {
     typealias DiscoveryAuthenticateResponse = Response<DiscoveryAuthenticateResponseData>
 
-    struct DiscoveryAuthenticateResponseData: DiscoveryIntermediateSessionTokenDataType, Codable {
+    struct DiscoveryAuthenticateResponseData: DiscoveryIntermediateSessionTokenDataType, Codable, Sendable {
         /// The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but represents a bag of factors that may be converted to a member session.
         /// The token can be used with the OTP SMS Authenticate endpoint, TOTP Authenticate endpoint, or Recovery Codes Recover endpoint to complete an MFA flow and log in to the Organization.
         /// It can also be used with the Exchange Intermediate Session endpoint to join a specific Organization that allows the factors represented by the intermediate session token;

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
@@ -143,7 +143,7 @@ public extension StytchB2BClient.OAuth.ThirdParty {
 }
 
 extension StytchB2BClient.OAuth.ThirdParty {
-    enum Provider: String, CaseIterable, Codable {
+    enum Provider: String, CaseIterable, Codable, Sendable {
         case google
         case microsoft
         case hubspot

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
@@ -53,7 +53,7 @@ public extension StytchB2BClient {
 }
 
 public extension StytchB2BClient.OAuth {
-    struct AuthenticateParameters: Encodable {
+    struct AuthenticateParameters: Encodable, Sendable {
         let oauthToken: String
         let sessionDurationMinutes: Minutes
         let locale: StytchLocale?
@@ -84,7 +84,7 @@ public extension StytchB2BClient.OAuth {
     /// The concrete response type for B2B OAuth `authenticate` calls.
     typealias OAuthAuthenticateResponse = Response<OAuthAuthenticateResponseData>
 
-    struct OAuthAuthenticateResponseData: Codable, B2BMFAAuthenticateResponseDataType {
+    struct OAuthAuthenticateResponseData: Codable, Sendable, B2BMFAAuthenticateResponseDataType {
         /// The ``MemberSession`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
         public let memberSession: MemberSession?
         /// The current member's ID.

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP.swift
@@ -42,7 +42,7 @@ public extension StytchB2BClient {
 }
 
 public extension StytchB2BClient.OTP {
-    struct SendParameters: Codable {
+    struct SendParameters: Codable, Sendable {
         let organizationId: String
         let memberId: String
         let mfaPhoneNumber: String?
@@ -68,7 +68,7 @@ public extension StytchB2BClient.OTP {
 }
 
 public extension StytchB2BClient.OTP {
-    struct AuthenticateParameters: Codable {
+    struct AuthenticateParameters: Codable, Sendable {
         let sessionDurationMinutes: Minutes
         let organizationId: String
         let memberId: String

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/Organization Members/StytchB2BClient+Organizations+Members+CreateParameters.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/Organization Members/StytchB2BClient+Organizations+Members+CreateParameters.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public extension StytchB2BClient.Organizations.Members {
-    struct CreateParameters: Codable {
+    struct CreateParameters: Codable, Sendable {
         let emailAddress: String
         let name: String?
         let untrustedMetadata: JSON?

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/Organization Members/StytchB2BClient+Organizations+Members+UpdateParameters.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/Organization Members/StytchB2BClient+Organizations+Members+UpdateParameters.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public extension StytchB2BClient.Organizations.Members {
-    struct UpdateParameters: Codable {
+    struct UpdateParameters: Codable, Sendable {
         let memberId: String
         let name: String?
         let untrustedMetadata: JSON?

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/Organization Members/StytchB2BClient+Organizations+Members.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/Organization Members/StytchB2BClient+Organizations+Members.swift
@@ -58,7 +58,7 @@ public extension StytchB2BClient.Organizations.Members {
     typealias OrganizationMemberResponse = Response<OrganizationMemberResponseData>
 
     /// The underlying data for the MemberResponse type.
-    struct OrganizationMemberResponseData: Codable {
+    struct OrganizationMemberResponseData: Codable, Sendable {
         /// The current member's member id.
         public let memberId: String?
 
@@ -75,7 +75,7 @@ public extension StytchB2BClient.Organizations.Members {
     typealias OrganizationMemberDeleteResponse = Response<OrganizationMemberDeleteResponseData>
 
     /// The underlying data for the OrganizationMemberDeleteResponse type.
-    struct OrganizationMemberDeleteResponseData: Codable {
+    struct OrganizationMemberDeleteResponseData: Codable, Sendable {
         /// The current member id that was deleted.
         public let memberId: String
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/StytchB2BClient+Organizations+SearchParameters.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/StytchB2BClient+Organizations+SearchParameters.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public extension StytchB2BClient.Organizations {
-    struct SearchParameters: Codable {
+    struct SearchParameters: Codable, Sendable {
         let query: SearchQuery
         let cursor: String?
         let limit: String?
@@ -34,7 +34,7 @@ public extension StytchB2BClient.Organizations {
 }
 
 public extension StytchB2BClient.Organizations.SearchParameters {
-    struct SearchQuery: Codable {
+    struct SearchQuery: Codable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case searchOperator = "operator"
             case searchOperandsJSON = "operands"
@@ -54,7 +54,7 @@ public extension StytchB2BClient.Organizations.SearchParameters {
 }
 
 public extension StytchB2BClient.Organizations.SearchParameters {
-    enum SearchOperator: String, Codable {
+    enum SearchOperator: String, Codable, Sendable {
         // swiftlint:disable:next identifier_name
         case OR
         case AND
@@ -62,7 +62,7 @@ public extension StytchB2BClient.Organizations.SearchParameters {
 }
 
 /// A generic protocol to define operand types generating the JSON needed for a search query.
-public protocol SearchQueryOperand {
+public protocol SearchQueryOperand: Sendable {
     var filterName: String { get }
     var filterValueJSON: JSON { get }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/StytchB2BClient+Organizations.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/StytchB2BClient+Organizations.swift
@@ -67,7 +67,7 @@ public extension StytchB2BClient.Organizations {
     typealias OrganizationResponse = Response<OrganizationResponseData>
 
     /// The underlying data for the OrganizationResponse type.
-    struct OrganizationResponseData: Codable {
+    struct OrganizationResponseData: Codable, Sendable {
         /// The current organization.
         public let organization: Organization
     }
@@ -78,7 +78,7 @@ public extension StytchB2BClient.Organizations {
     typealias OrganizationDeleteResponse = Response<OrganizationDeleteResponseData>
 
     /// The underlying data for the OrganizationDeleteResponse type.
-    struct OrganizationDeleteResponseData: Codable {
+    struct OrganizationDeleteResponseData: Codable, Sendable {
         /// The current organization id that was deleted.
         public let organizationId: String
     }
@@ -87,7 +87,7 @@ public extension StytchB2BClient.Organizations {
 public extension StytchB2BClient.Organizations {
     typealias SearchMembersResponse = Response<SearchResponseData>
 
-    struct SearchResponseData: Codable {
+    struct SearchResponseData: Codable, Sendable {
         // An array of Member objects.
         public let members: [Member]
         // The search results_metadata object contains metadata relevant to your specific query like total and next_cursor.
@@ -96,7 +96,7 @@ public extension StytchB2BClient.Organizations {
         public let organizations: [String: Organization]
     }
 
-    struct SearchResponseResultsMetadata: Codable {
+    struct SearchResponseResultsMetadata: Codable, Sendable {
         // The total number of results returned by your search query.
         public let total: Int
         // The next_cursor string is returned when your search result contains more than one page of results. This value is passed into your next search call in the cursor field.

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Passwords.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Passwords.swift
@@ -119,7 +119,7 @@ public extension StytchB2BClient {
 
 public extension StytchB2BClient.Passwords {
     /// The dedicated parameters type for password `authenticate` calls.
-    struct AuthenticateParameters: Encodable {
+    struct AuthenticateParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case organizationId
             case emailAddress
@@ -158,7 +158,7 @@ public extension StytchB2BClient.Passwords {
 
 public extension StytchB2BClient.Passwords {
     /// The dedicated parameters type for passwords `resetByEmailStart` calls.
-    struct ResetByEmailStartParameters: Encodable {
+    struct ResetByEmailStartParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case organizationId
             case emailAddress
@@ -207,7 +207,7 @@ public extension StytchB2BClient.Passwords {
 
 public extension StytchB2BClient.Passwords {
     /// The dedicated parameters type for passwords `resetByEmail` calls.
-    struct ResetByEmailParameters: Encodable {
+    struct ResetByEmailParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case token = "passwordResetToken"
             case password
@@ -241,7 +241,7 @@ public extension StytchB2BClient.Passwords {
 
 public extension StytchB2BClient.Passwords {
     /// The dedicated parameters type for passwords `resetByExistingPassword` calls.
-    struct ResetByExistingPasswordParameters: Encodable {
+    struct ResetByExistingPasswordParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case organizationId
             case emailAddress
@@ -288,7 +288,7 @@ public extension StytchB2BClient.Passwords {
     typealias ResetBySessionResponse = Response<ResetBySessionResponseData>
 
     /// The underlying data for passwords `resetBySession` calls.
-    struct ResetBySessionResponseData: Codable {
+    struct ResetBySessionResponseData: Codable, Sendable {
         /// The ``MemberSession`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
         public let memberSession: MemberSession
         /// The current member object.
@@ -298,7 +298,7 @@ public extension StytchB2BClient.Passwords {
     }
 
     /// The dedicated parameters type for passwords `resetBySession` calls.
-    struct ResetBySessionParameters: Encodable {
+    struct ResetBySessionParameters: Encodable, Sendable {
         let organizationId: Organization.ID
         let password: String
         let locale: StytchLocale?
@@ -320,7 +320,7 @@ public extension StytchB2BClient.Passwords {
     typealias StrengthCheckResponse = Response<StrengthCheckResponseData>
 
     /// The dedicated parameters type for passwords `strengthCheck` calls.
-    struct StrengthCheckParameters: Encodable {
+    struct StrengthCheckParameters: Encodable, Sendable {
         let emailAddress: String?
         let password: String
 
@@ -334,7 +334,7 @@ public extension StytchB2BClient.Passwords {
     }
 
     /// The underlying data for passwords `strengthCheck` calls.
-    struct StrengthCheckResponseData: Codable {
+    struct StrengthCheckResponseData: Codable, Sendable {
         public let validPassword: Bool
         /// A score from 0-4 to indicate the strength of a password. Useful for progress bars.
         public let score: Double
@@ -350,7 +350,7 @@ public extension StytchB2BClient.Passwords {
         public let ludsFeedback: LudsFeedback?
 
         /// A warning and collection of suggestions for improving the strength of a given password.
-        public struct ZxcvbnFeedback: Codable {
+        public struct ZxcvbnFeedback: Codable, Sendable {
             /// For zxcvbn validation, contains end user consumable suggestions on how to improve the strength of the password.
             public let suggestions: [String]
             /// For zxcvbn validation, contains an end user consumable warning if the password is valid but not strong enough.
@@ -358,7 +358,7 @@ public extension StytchB2BClient.Passwords {
         }
 
         /// LUDS-specific password feedback.
-        public struct LudsFeedback: Codable {
+        public struct LudsFeedback: Codable, Sendable {
             /// For LUDS validation, whether the password contains at least one lowercase letter.
             public let hasLowerCase: Bool
             /// For LUDS validation, whether the password contains at least one uppercase letter.

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+RecoveryCodes.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+RecoveryCodes.swift
@@ -36,14 +36,14 @@ public extension StytchB2BClient {
 public extension StytchB2BClient.RecoveryCodes {
     typealias RecoveryCodesResponse = Response<RecoveryCodesResponseData>
 
-    struct RecoveryCodesResponseData: Codable {
+    struct RecoveryCodesResponseData: Codable, Sendable {
         /// The recovery codes used to authenticate the member in place of a secondary factor.
         public let recoveryCodes: [String]
     }
 }
 
 public extension StytchB2BClient.RecoveryCodes {
-    struct RecoveryCodesRecoverParameters: Codable {
+    struct RecoveryCodesRecoverParameters: Codable, Sendable {
         let sessionDurationMinutes: Minutes
         let organizationId: String
         let memberId: String
@@ -74,7 +74,7 @@ public extension StytchB2BClient.RecoveryCodes {
 public extension StytchB2BClient.RecoveryCodes {
     typealias RecoveryCodesRecoverResponse = Response<RecoveryCodesRecoverResponseData>
 
-    struct RecoveryCodesRecoverResponseData: Codable {
+    struct RecoveryCodesRecoverResponseData: Codable, Sendable {
         /// Number of recovery codes remaining for the member.
         public let recoveryCodesRemaining: Int
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SCIM/StytchB2BClient+SCIM+Parameters.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SCIM/StytchB2BClient+SCIM+Parameters.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public extension StytchB2BClient.SCIM {
-    struct CreateConnectionParameters: Codable {
+    struct CreateConnectionParameters: Codable, Sendable {
         let displayName: String?
         let identityProvider: String?
 
@@ -17,7 +17,7 @@ public extension StytchB2BClient.SCIM {
         }
     }
 
-    struct UpdateConnectionParameters: Codable {
+    struct UpdateConnectionParameters: Codable, Sendable {
         let connectionId: String
         let displayName: String?
         let identityProvider: String?
@@ -41,7 +41,7 @@ public extension StytchB2BClient.SCIM {
         }
     }
 
-    struct GetConnectionGroupsParameters: Codable {
+    struct GetConnectionGroupsParameters: Codable, Sendable {
         let limit: Int?
         let cursor: String?
 
@@ -54,7 +54,7 @@ public extension StytchB2BClient.SCIM {
         }
     }
 
-    struct RotateParameters: Codable {
+    struct RotateParameters: Codable, Sendable {
         let connectionId: String
 
         /// - Parameter connectionId: Globally unique UUID that identifies a specific SCIM Connection.

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SCIM/StytchB2BClient+SCIM+Responses.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SCIM/StytchB2BClient+SCIM+Responses.swift
@@ -12,7 +12,7 @@ public extension StytchB2BClient.SCIM {
 }
 
 public extension StytchB2BClient.SCIM {
-    struct SCIMConnection: Codable {
+    struct SCIMConnection: Codable, Sendable {
         /// Globally unique UUID that identifies a specific Organization.
         public let organizationId: String
         /// Globally unique UUID that identifies a specific SCIM Connection.
@@ -38,7 +38,7 @@ public extension StytchB2BClient.SCIM {
         public let nextBearerTokenExpiresAt: String?
     }
 
-    struct SCIMConnectionWithBearerToken: Codable {
+    struct SCIMConnectionWithBearerToken: Codable, Sendable {
         /// Globally unique UUID that identifies a specific Organization.
         public let organizationId: String
         /// Globally unique UUID that identifies a specific SCIM Connection.
@@ -60,7 +60,7 @@ public extension StytchB2BClient.SCIM {
         public let bearerTokenExpiresAt: String
     }
 
-    struct SCIMConnectionWithNextBearerToken: Codable {
+    struct SCIMConnectionWithNextBearerToken: Codable, Sendable {
         /// Globally unique UUID that identifies a specific Organization.
         public let organizationId: String
         /// Globally unique UUID that identifies a specific SCIM Connection.
@@ -86,14 +86,14 @@ public extension StytchB2BClient.SCIM {
         public let nextBearerTokenExpiresAt: String
     }
 
-    struct SCIMGroupImplicitRoleAssignment: Codable {
+    struct SCIMGroupImplicitRoleAssignment: Codable, Sendable {
         /// The ID of the role.
         public let roleId: String
         /// The ID of the group.
         public let groupId: String
     }
 
-    struct SCIMGroup: Codable {
+    struct SCIMGroup: Codable, Sendable {
         /// Globally unique UUID that identifies a specific Organization.
         public let organizationId: String
         /// Globally unique UUID that identifies a specific SCIM Connection.
@@ -104,44 +104,44 @@ public extension StytchB2BClient.SCIM {
         public let groupName: String
     }
 
-    struct SCIMCreateConnectionResponseData: Codable {
+    struct SCIMCreateConnectionResponseData: Codable, Sendable {
         /// The SCIM Connection object affected by this API call.
         public let connection: SCIMConnectionWithBearerToken
     }
 
-    struct SCIMUpdateConnectionResponseData: Codable {
+    struct SCIMUpdateConnectionResponseData: Codable, Sendable {
         /// The SCIM Connection object affected by this API call.
         public let connection: SCIMConnection
     }
 
-    struct SCIMDeleteConnectionResponseData: Codable {
+    struct SCIMDeleteConnectionResponseData: Codable, Sendable {
         /// lobally unique UUID that identifies a specific SCIM Connection.
         public let connectionId: String
     }
 
-    struct SCIMGetConnectionResponseData: Codable {
+    struct SCIMGetConnectionResponseData: Codable, Sendable {
         /// The SCIM Connection object affected by this API call.
         public let connection: SCIMConnection
     }
 
-    struct SCIMGetConnectionGroupsResponseData: Codable {
+    struct SCIMGetConnectionGroupsResponseData: Codable, Sendable {
         /// List of SCIM Groups for the connection.
         public let scimGroups: [SCIMGroup]?
         /// The cursor to use to get the next page of results.
         public let nextCursor: String?
     }
 
-    struct SCIMRotateStartResponseData: Codable {
+    struct SCIMRotateStartResponseData: Codable, Sendable {
         /// The SCIM Connection object affected by this API call.
         public let connection: SCIMConnectionWithNextBearerToken
     }
 
-    struct SCIMRotateCompleteResponseData: Codable {
+    struct SCIMRotateCompleteResponseData: Codable, Sendable {
         /// The SCIM Connection object affected by this API call.
         public let connection: SCIMConnection
     }
 
-    struct SCIMRotateCancelResponseData: Codable {
+    struct SCIMRotateCancelResponseData: Codable, Sendable {
         /// The SCIM Connection object affected by this API call.
         public let connection: SCIMConnection
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO+OIDC.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO+OIDC.swift
@@ -41,7 +41,7 @@ public extension StytchB2BClient.SSO.OIDC {
 }
 
 public extension StytchB2BClient.SSO.OIDC {
-    struct UpdateConnectionParameters: Codable {
+    struct UpdateConnectionParameters: Codable, Sendable {
         let connectionId: String
         let displayName: String?
         let issuer: String?
@@ -95,7 +95,7 @@ public extension StytchB2BClient.SSO.OIDC {
     typealias OIDCConnectionResponse = Response<OIDCConnectionResponseData>
 
     /// The underlying data for the OIDC connection type.
-    struct OIDCConnectionResponseData: Codable {
+    struct OIDCConnectionResponseData: Codable, Sendable {
         /// The OIDC Connection object affected by this API call.
         public let connection: OIDCConnection
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO+OIDCConnection.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO+OIDCConnection.swift
@@ -2,7 +2,7 @@ import Foundation
 
 #if !os(watchOS)
 public extension StytchB2BClient.SSO.OIDC {
-    struct OIDCConnection: Codable {
+    struct OIDCConnection: Codable, Sendable {
         let organizationId: String
         let connectionId: String
         let status: String

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO+SAML.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO+SAML.swift
@@ -51,7 +51,7 @@ public extension StytchB2BClient.SSO.SAML {
 }
 
 public extension StytchB2BClient.SSO.SAML {
-    struct UpdateConnectionParameters: Codable {
+    struct UpdateConnectionParameters: Codable, Sendable {
         let connectionId: String
         let idpEntityId: String?
         let displayName: String?
@@ -105,7 +105,7 @@ public extension StytchB2BClient.SSO.SAML {
 }
 
 public extension StytchB2BClient.SSO.SAML {
-    struct UpdateConnectionByURLParameters: Codable {
+    struct UpdateConnectionByURLParameters: Codable, Sendable {
         let connectionId: String
         let metadataUrl: String
 
@@ -120,7 +120,7 @@ public extension StytchB2BClient.SSO.SAML {
 }
 
 public extension StytchB2BClient.SSO.SAML {
-    struct DeleteVerificationCertificateParameters: Codable {
+    struct DeleteVerificationCertificateParameters: Codable, Sendable {
         let connectionId: String
         let certificateId: String
 
@@ -139,7 +139,7 @@ public extension StytchB2BClient.SSO.SAML {
     typealias SAMLConnectionResponse = Response<SAMLConnectionResponseData>
 
     /// The underlying data for the SAML connection type.
-    struct SAMLConnectionResponseData: Codable {
+    struct SAMLConnectionResponseData: Codable, Sendable {
         /// The SAML Connection object affected by this API call.
         public let connection: SAMLConnection
     }
@@ -151,7 +151,7 @@ public extension StytchB2BClient.SSO.SAML {
     typealias SAMLDeleteVerificationCertificateResponse = Response<SAMLDeleteVerificationCertificateResponseData>
 
     /// The underlying data for the delete verification certificate type.
-    struct SAMLDeleteVerificationCertificateResponseData: Codable {
+    struct SAMLDeleteVerificationCertificateResponseData: Codable, Sendable {
         /// The ID of the certificate that was deleted.
         public let certificateId: String
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO+SAMLConnection.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO+SAMLConnection.swift
@@ -2,7 +2,7 @@ import Foundation
 
 #if !os(watchOS)
 public extension StytchB2BClient.SSO.SAML {
-    struct SAMLConnection: Codable {
+    struct SAMLConnection: Codable, Sendable {
         let organizationId: String
         let connectionId: String
         let status: String
@@ -77,7 +77,7 @@ public extension StytchB2BClient.SSO.SAML {
 }
 
 public extension StytchB2BClient.SSO.SAML {
-    struct X509Certificate: Codable {
+    struct X509Certificate: Codable, Sendable {
         let certificateId: String
         let certificate: String
         let issuer: String
@@ -99,7 +99,7 @@ public extension StytchB2BClient.SSO.SAML {
         }
     }
 
-    struct ConnectionRoleAssignment: Codable {
+    struct ConnectionRoleAssignment: Codable, Sendable {
         let roleId: String
 
         init(roleId: String) {
@@ -107,7 +107,7 @@ public extension StytchB2BClient.SSO.SAML {
         }
     }
 
-    struct GroupRoleAssignment: Codable {
+    struct GroupRoleAssignment: Codable, Sendable {
         let roleId: String
         let group: String
 

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO.swift
@@ -141,7 +141,7 @@ public extension StytchB2BClient.SSO {
 
 public extension StytchB2BClient.SSO {
     /// A dedicated parameters type for SSO `authenticate` calls.
-    struct AuthenticateParameters: Encodable {
+    struct AuthenticateParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case token = "ssoToken"
             case sessionDuration = "sessionDurationMinutes"
@@ -167,7 +167,7 @@ public extension StytchB2BClient.SSO {
 public extension StytchB2BClient.SSO {
     typealias GetConnectionsResponse = Response<GetConnectionsResponseData>
 
-    struct GetConnectionsResponseData: Codable {
+    struct GetConnectionsResponseData: Codable, Sendable {
         /// The list of SAML Connections owned by this organization.
         public let samlConnections: [SAML.SAMLConnection]
         /// The list of OIDC Connections owned by this organization.
@@ -178,7 +178,7 @@ public extension StytchB2BClient.SSO {
 public extension StytchB2BClient.SSO {
     typealias DeleteConnectionResponse = Response<DeleteConnectionResponseData>
 
-    struct DeleteConnectionResponseData: Codable {
+    struct DeleteConnectionResponseData: Codable, Sendable {
         /// The connection_id that was deleted as part of the delete request.
         public let connectionId: String
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SearchManager.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SearchManager.swift
@@ -28,7 +28,7 @@ public extension StytchB2BClient {
 }
 
 public extension StytchB2BClient.SearchManager {
-    struct SearchMemberParameters: Codable {
+    struct SearchMemberParameters: Codable, Sendable {
         let emailAddress: String
         let organizationId: String
 
@@ -45,12 +45,12 @@ public extension StytchB2BClient.SearchManager {
 public extension StytchB2BClient.SearchManager {
     typealias SearchMemberResponse = Response<SearchMemberResponseData>
 
-    struct SearchMemberResponseData: Codable {
+    struct SearchMemberResponseData: Codable, Sendable {
         /// The matching member.
         public let member: MemberSearchResponse
     }
 
-    struct MemberSearchResponse: Codable {
+    struct MemberSearchResponse: Codable, Sendable {
         public let status: String
         public let name: String
         public let memberPasswordId: String
@@ -58,7 +58,7 @@ public extension StytchB2BClient.SearchManager {
 }
 
 public extension StytchB2BClient.SearchManager {
-    struct SearchOrganizationParameters: Codable {
+    struct SearchOrganizationParameters: Codable, Sendable {
         let organizationSlug: String
 
         /// - Parameter organizationSlug: The URL slug of the Organization to get.
@@ -71,12 +71,12 @@ public extension StytchB2BClient.SearchManager {
 public extension StytchB2BClient.SearchManager {
     typealias SearchOrganizationResponse = Response<SearchOrganizationResponseData>
 
-    struct SearchOrganizationResponseData: Codable {
+    struct SearchOrganizationResponseData: Codable, Sendable {
         /// The matching organization.
         public let organization: OrganizationSearchResponse
     }
 
-    struct OrganizationSearchResponse: Codable {
+    struct OrganizationSearchResponse: Codable, Sendable {
         /// Globally unique UUID that identifies an organization in the Stytch API.
         public let organizationId: String
         /// The name of the organization.

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Sessions.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Sessions.swift
@@ -69,7 +69,7 @@ public extension StytchB2BClient {
 
 public extension StytchB2BClient.Sessions {
     /// The dedicated parameters type for sessions `authenticate` calls.
-    struct AuthenticateParameters: Encodable {
+    struct AuthenticateParameters: Encodable, Sendable {
         let sessionDurationMinutes: Minutes?
 
         /// - Parameter sessionDurationMinutes: The duration, in minutes, of the requested session.
@@ -91,7 +91,7 @@ public extension StytchB2BClient.Sessions {
     }
 
     /// The dedicated parameters type for session `exchange` calls.
-    struct ExchangeParameters: Codable {
+    struct ExchangeParameters: Codable, Sendable {
         /// The ID of the organization that the new session should belong to.
         public let organizationID: String
         /// The duration, in minutes, for the requested session. Defaults to 5 minutes.

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+TOTP.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+TOTP.swift
@@ -42,7 +42,7 @@ public extension StytchB2BClient {
 }
 
 public extension StytchB2BClient.TOTP {
-    struct CreateParameters: Codable {
+    struct CreateParameters: Codable, Sendable {
         let organizationId: String
         let memberId: String
         let expirationMinutes: Minutes
@@ -64,7 +64,7 @@ public extension StytchB2BClient.TOTP {
 public extension StytchB2BClient.TOTP {
     typealias CreateResponse = Response<CreateResponseData>
 
-    struct CreateResponseData: Codable {
+    struct CreateResponseData: Codable, Sendable {
         /// Globally unique UUID that identifies a specific TOTP registration in the Stytch API.
         public let totpRegistrationId: String
 
@@ -80,7 +80,7 @@ public extension StytchB2BClient.TOTP {
 }
 
 public extension StytchB2BClient.TOTP {
-    struct AuthenticateParameters: Codable {
+    struct AuthenticateParameters: Codable, Sendable {
         let sessionDurationMinutes: Minutes
         let organizationId: String
         let memberId: String

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -64,7 +64,7 @@ public extension StytchB2BClient {
 
 public extension StytchB2BClient {
     /// Represents the type of deeplink token which has been parsed. e.g. `discovery` or `sso`.
-    enum DeeplinkTokenType: String {
+    enum DeeplinkTokenType: String, Sendable {
         case discovery
         case multiTenantMagicLinks = "multi_tenant_magic_links"
         case multiTenantPasswords = "multi_tenant_passwords"
@@ -76,7 +76,7 @@ public extension StytchB2BClient {
     }
 
     /// Wrapper around the possible types returned from the `handle(url:sessionDuration:)` function.
-    enum DeeplinkResponse {
+    enum DeeplinkResponse: Sendable {
         case auth(B2BAuthenticateResponse)
         case mfauth(B2BMFAAuthenticateResponse)
         case mfaOAuth(StytchB2BClient.OAuth.OAuthAuthenticateResponse)

--- a/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
@@ -147,7 +147,7 @@ public extension StytchClient.Biometrics {
     typealias RegisterCompleteResponse = Response<RegisterCompleteResponseData>
 
     /// A dedicated parameters type for biometrics `authenticate` calls.
-    struct AuthenticateParameters {
+    struct AuthenticateParameters: Sendable {
         let sessionDuration: Minutes
 
         /// Initializes the parameters struct
@@ -158,7 +158,7 @@ public extension StytchClient.Biometrics {
     }
 
     /// A dedicated parameters type for biometrics `register` calls.
-    struct RegisterParameters {
+    struct RegisterParameters: Sendable {
         let identifier: String
         let accessPolicy: AccessPolicy
         let sessionDuration: Minutes
@@ -179,7 +179,7 @@ public extension StytchClient.Biometrics {
         }
     }
 
-    struct RegisterCompleteResponseData: Codable, AuthenticateResponseDataType {
+    struct RegisterCompleteResponseData: Codable, Sendable, AuthenticateResponseDataType {
         public let biometricRegistrationId: User.BiometricRegistration.ID
         public let user: User
         public let session: Session
@@ -190,7 +190,7 @@ public extension StytchClient.Biometrics {
 
 public extension StytchClient.Biometrics.RegisterParameters {
     /// Defines the policy as to how the user must confirm their device ownership.
-    enum AccessPolicy {
+    enum AccessPolicy: Sendable {
         /// The device will first try to confirm access rights via biometrics and will fall back to device passcode.
         case deviceOwnerAuthentication
         /// The device will try to confirm access rights via biometrics.
@@ -217,31 +217,31 @@ public extension StytchClient.Biometrics.RegisterParameters {
 
 // Internal/private parameters and keys
 extension StytchClient.Biometrics {
-    struct AuthenticateStartParameters: Encodable {
+    struct AuthenticateStartParameters: Encodable, Sendable {
         let publicKey: Data
     }
 
-    struct AuthenticateStartResponse: Codable {
+    struct AuthenticateStartResponse: Codable, Sendable {
         let challenge: Data
         let biometricRegistrationId: User.BiometricRegistration.ID
     }
 
-    struct AuthenticateCompleteParameters: Codable {
+    struct AuthenticateCompleteParameters: Codable, Sendable {
         let signature: Data
         let biometricRegistrationId: User.BiometricRegistration.ID
         let sessionDurationMinutes: Minutes
     }
 
-    private struct RegisterStartParameters: Encodable {
+    private struct RegisterStartParameters: Encodable, Sendable {
         let publicKey: Data
     }
 
-    struct RegisterStartResponse: Codable {
+    struct RegisterStartResponse: Codable, Sendable {
         let biometricRegistrationId: User.BiometricRegistration.ID
         let challenge: Data
     }
 
-    private struct RegisterFinishParameters: Encodable {
+    private struct RegisterFinishParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case biometricRegistrationId, signature, sessionDuration = "sessionDurationMinutes"
         }

--- a/Sources/StytchCore/StytchClient/CryptoWallets/StytchClient+CryptoWallets.swift
+++ b/Sources/StytchCore/StytchClient/CryptoWallets/StytchClient+CryptoWallets.swift
@@ -29,13 +29,13 @@ public extension StytchClient {
 
 public extension StytchClient.CryptoWallets {
     /// The type of crypto wallet. Currently `ethereum` and `solana` are supported. Wallets for any EVM-compatible chains (such as Polygon or BSC) are also supported and are grouped under the `ethereum` type.
-    enum WalletType: String, Codable {
+    enum WalletType: String, Codable, Sendable {
         case ethereum
         case solana
     }
 
     /// The dedicated parameters type for crypto wallets `authenticateStart` calls.
-    struct AuthenticateStartParameters: Encodable {
+    struct AuthenticateStartParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case cryptoWalletType
             case cryptoWalletAddress
@@ -54,7 +54,7 @@ public extension StytchClient.CryptoWallets {
     }
 
     /// The dedicated parameters type for crypto wallets `authenticate` calls.
-    struct AuthenticateParameters: Encodable {
+    struct AuthenticateParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case cryptoWalletType
             case cryptoWalletAddress
@@ -82,7 +82,7 @@ public extension StytchClient.CryptoWallets {
     typealias AuthenticateStartResponse = Response<CryptoWalletsAuthenticateResponseData>
 
     /// The underlying data for crypto wallets `authenticateStart` calls.
-    struct CryptoWalletsAuthenticateResponseData: Codable {
+    struct CryptoWalletsAuthenticateResponseData: Codable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case challenge
         }

--- a/Sources/StytchCore/StytchClient/MagicLinks/StytchClient+MagicLinks.swift
+++ b/Sources/StytchCore/StytchClient/MagicLinks/StytchClient+MagicLinks.swift
@@ -31,7 +31,7 @@ public extension StytchClient {
 
 public extension StytchClient.MagicLinks {
     /// A dedicated parameters type for magic links `authenticate` calls.
-    struct AuthenticateParameters: Encodable {
+    struct AuthenticateParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case token
             case sessionDuration = "sessionDurationMinutes"

--- a/Sources/StytchCore/StytchClient/MagicLinks/StytchClient.MagicLinks+Email.swift
+++ b/Sources/StytchCore/StytchClient/MagicLinks/StytchClient.MagicLinks+Email.swift
@@ -46,7 +46,7 @@ public extension StytchClient.MagicLinks {
 
 public extension StytchClient.MagicLinks.Email {
     /// The dedicated parameters type for ``StytchClient/MagicLinks-swift.struct/Email-swift.struct/loginOrCreate(parameters:)-9n8i5`` and ``StytchClient/MagicLinks-swift.struct/Email-swift.struct/send(parameters:)-2i2l1`` calls.
-    struct Parameters: Encodable, Equatable {
+    struct Parameters: Encodable, Equatable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case email
             case loginMagicLinkUrl

--- a/Sources/StytchCore/StytchClient/Models/AuthenticateResponse.swift
+++ b/Sources/StytchCore/StytchClient/Models/AuthenticateResponse.swift
@@ -17,7 +17,7 @@ public protocol AuthenticateResponseDataType {
 }
 
 /// The underlying data for `authenticate` calls.
-public struct AuthenticateResponseData: Codable, AuthenticateResponseDataType {
+public struct AuthenticateResponseData: Codable, Sendable, AuthenticateResponseDataType {
     /// The current user object.
     public let user: User
     /// The opaque token for the session. Can be used by your server to verify the validity of your session by confirming with Stytch's servers on each request.

--- a/Sources/StytchCore/StytchClient/Models/Session.swift
+++ b/Sources/StytchCore/StytchClient/Models/Session.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  A type defining a session; including information about its validity, expiry, factors associated with this session, and more.
  */
-public struct Session {
+public struct Session: Sendable {
     public typealias ID = Identifier<Self, String>
 
     private enum CodingKeys: String, CodingKey {
@@ -66,7 +66,7 @@ public extension Session {
     /**
      A type which contains metadata relating to a session.
      */
-    struct Attributes: Codable, Equatable {
+    struct Attributes: Codable, Equatable, Sendable {
         /// The IP Address associated with a session.
         public let ipAddress: String
         /// The user agent associated with a session.

--- a/Sources/StytchCore/StytchClient/Models/User.swift
+++ b/Sources/StytchCore/StytchClient/Models/User.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A type defining a user; including information about their name, status, the auth factors associated with them, and more.
-public struct User {
+public struct User: Sendable {
     public typealias ID = Identifier<Self, String>
 
     /// The date the user was originally created.
@@ -75,7 +75,7 @@ extension User: Codable {
 }
 
 public extension User {
-    struct Password: Codable, Equatable {
+    struct Password: Codable, Equatable, Sendable {
         public typealias ID = Identifier<Self, String>
 
         public var id: ID { passwordId }
@@ -88,7 +88,7 @@ public extension User {
         }
     }
 
-    struct CryptoWallet: Codable, Equatable {
+    struct CryptoWallet: Codable, Equatable, Sendable {
         public typealias ID = Identifier<Self, String>
         /// The id of the crypto wallet.
         public var id: ID { cryptoWalletId }
@@ -110,7 +110,7 @@ public extension User {
         }
     }
 
-    struct Email: Codable, Equatable {
+    struct Email: Codable, Equatable, Sendable {
         public typealias ID = Identifier<Self, String>
         /// The email address.
         public let email: String
@@ -127,7 +127,7 @@ public extension User {
         }
     }
 
-    struct Name: Codable, Equatable {
+    struct Name: Codable, Equatable, Sendable {
         /// The user's first name.
         public let firstName: String?
         /// The user's last name.
@@ -148,7 +148,7 @@ public extension User {
         }
     }
 
-    struct Provider: Codable, Equatable {
+    struct Provider: Codable, Equatable, Sendable {
         public typealias ID = Identifier<Self, String>
         /// The subject of the provider.
         public let providerSubject: String
@@ -168,7 +168,7 @@ public extension User {
         }
     }
 
-    struct PhoneNumber: Codable, Equatable {
+    struct PhoneNumber: Codable, Equatable, Sendable {
         public typealias ID = Identifier<Self, String>
         /// The phone number.
         public let phoneNumber: String
@@ -185,14 +185,14 @@ public extension User {
         }
     }
 
-    enum UserStatus: String, Codable {
+    enum UserStatus: String, Codable, Sendable {
         /// The user is an active user.
         case active
         /// The user is still in a pending status.
         case pending
     }
 
-    struct TOTP: Codable, Equatable {
+    struct TOTP: Codable, Equatable, Sendable {
         public typealias ID = Identifier<Self, String>
         /// The id of the TOTP.
         public var id: ID { totpId }
@@ -206,7 +206,7 @@ public extension User {
         }
     }
 
-    struct WebAuthNRegistration: Codable, Equatable {
+    struct WebAuthNRegistration: Codable, Equatable, Sendable {
         public typealias ID = Identifier<Self, String>
         /// The domain of the WebAuthN registration.
         public let domain: String
@@ -226,7 +226,7 @@ public extension User {
         }
     }
 
-    struct BiometricRegistration: Codable, Equatable {
+    struct BiometricRegistration: Codable, Equatable, Sendable {
         public typealias ID = Identifier<Self, String>
         /// The verification status of the registration.
         public let verified: Bool

--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+Apple.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+Apple.swift
@@ -60,7 +60,7 @@ public extension StytchClient.OAuth.Apple {
     typealias AuthenticateResponse = Response<AuthenticateResponseData>
 
     /// The underlying data for Sign In With Apple `authenticate` calls.
-    struct AuthenticateResponseData: Codable, AuthenticateResponseDataType {
+    struct AuthenticateResponseData: Codable, Sendable, AuthenticateResponseDataType {
         /// The current user object.
         public let user: User
         /// The opaque token for the session. Can be used by your server to verify the validity of your session by confirming with Stytch's servers on each request.
@@ -102,13 +102,13 @@ public extension StytchClient.OAuth.Apple {
 }
 
 extension StytchClient.OAuth.Apple {
-    struct AuthenticateParameters: Codable {
+    struct AuthenticateParameters: Codable, Sendable {
         let idToken: String
         let nonce: String
         let sessionDurationMinutes: Minutes
     }
 
-    struct Name: Codable {
+    struct Name: Codable, Sendable {
         let firstName: String?
         let lastName: String?
     }

--- a/Sources/StytchCore/StytchClient/OAuth/StytchClient+OAuth.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/StytchClient+OAuth.swift
@@ -112,7 +112,7 @@ public extension StytchClient.OAuth {
 
 public extension StytchClient.OAuth {
     /// The dedicated parameters type for ``authenticate(parameters:)-3tjwd`` calls.
-    struct AuthenticateParameters: Encodable {
+    struct AuthenticateParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey { case token, sessionDuration = "sessionDurationMinutes" }
 
         let token: String
@@ -135,7 +135,7 @@ public extension StytchClient.OAuth {
     /// The concrete response type for OAuth `authenticate` calls.
     typealias OAuthAuthenticateResponse = Response<OAuthAuthenticateResponseData>
 
-    struct OAuthAuthenticateResponseData: Codable, AuthenticateResponseDataType {
+    struct OAuthAuthenticateResponseData: Codable, Sendable, AuthenticateResponseDataType {
         /// The current user object.
         public let user: User
         /// The opaque token for the session. Can be used by your server to verify the validity of your session by confirming with Stytch's servers on each request.

--- a/Sources/StytchCore/StytchClient/OTP/SytchClient+OTP.swift
+++ b/Sources/StytchCore/StytchClient/OTP/SytchClient+OTP.swift
@@ -41,7 +41,7 @@ public extension StytchClient {
 
 public extension StytchClient.OTP {
     /// The dedicated parameters type for OTP `authenticate` calls.
-    struct AuthenticateParameters: Encodable {
+    struct AuthenticateParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey { case code = "token", methodId, sessionDuration = "sessionDurationMinutes" }
 
         let code: String
@@ -62,7 +62,7 @@ public extension StytchClient.OTP {
 
 public extension StytchClient.OTP {
     /// The dedicated parameters type for OTP `loginOrCreate` and `send` calls.
-    struct Parameters: Encodable {
+    struct Parameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case phoneNumber
             case email
@@ -111,12 +111,12 @@ public extension StytchClient.OTP {
     typealias OTPResponse = Response<OTPResponseData>
 
     /// The underlying data for OTP `loginOrCreate` and `send` responses.
-    struct OTPResponseData: Codable {
+    struct OTPResponseData: Codable, Sendable {
         public let methodId: String
     }
 
     /// The mechanism use to deliver one-time passcodes.
-    enum DeliveryMethod {
+    enum DeliveryMethod: Sendable {
         /// The phone number of the user to send a one-time passcode. The phone number should be in E.164 format (i.e. +1XXXXXXXXXX), and a boolean to indicate whether the SMS message should include autofill metadata
         case sms(phoneNumber: String, enableAutofill: Bool = false)
         /// The phone number of the user to send a one-time passcode. The phone number should be in E.164 format (i.e. +1XXXXXXXXXX)

--- a/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
+++ b/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
@@ -105,7 +105,7 @@ public extension StytchClient {
 @available(macOS 12.0, iOS 16.0, tvOS 16.0, *)
 public extension StytchClient.Passkeys {
     /// A dedicated parameters type for passkeys `register` calls.
-    struct RegisterParameters: Encodable {
+    struct RegisterParameters: Encodable, Sendable {
         let domain: String
         let returnPasskeyCredentialOptions: Bool = true
 
@@ -117,10 +117,10 @@ public extension StytchClient.Passkeys {
     }
 
     /// A dedicated parameters type for passkeys `authenticate` calls.
-    struct AuthenticateParameters {
+    struct AuthenticateParameters: Sendable {
         // swiftlint:disable duplicate_enum_cases
         /// A type representing the desired request behavior
-        public enum RequestBehavior {
+        public enum RequestBehavior: Sendable {
             #if os(iOS)
             /// Uses the default request behavior with a boolean flag to determine whether credentials are limited to those local on device or whether a passkey on a nearby device can be used
             case `default`(preferLocalCredentials: Bool)
@@ -160,7 +160,7 @@ public extension StytchClient.Passkeys {
     }
 
     /// A dedicated parameters type for passkeys `update` calls.
-    struct UpdateParameters: Encodable {
+    struct UpdateParameters: Encodable, Sendable {
         let id: User.WebAuthNRegistration.ID
         let name: String
         /// - Parameters:
@@ -175,16 +175,16 @@ public extension StytchClient.Passkeys {
 
 @available(macOS 12.0, iOS 16.0, tvOS 16.0, *)
 extension StytchClient.Passkeys {
-    struct StartParameters: Encodable {
+    struct StartParameters: Encodable, Sendable {
         let domain: String
         let returnPasskeyCredentialOptions: Bool = true
     }
 
-    struct PasskeysUser: Codable {
+    struct PasskeysUser: Codable, Sendable {
         let displayName: String
     }
 
-    private struct CredentialCreationOptions: Codable {
+    private struct CredentialCreationOptions: Codable, Sendable {
         enum CodingKeys: CodingKey {
             case challenge
             case user
@@ -218,7 +218,7 @@ extension StytchClient.Passkeys {
         }
     }
 
-    private struct CredentialOptions: Codable {
+    private struct CredentialOptions: Codable, Sendable {
         enum CodingKeys: CodingKey {
             case challenge
         }
@@ -246,7 +246,7 @@ extension StytchClient.Passkeys {
         }
     }
 
-    struct RegisterStartResponseData: Codable {
+    struct RegisterStartResponseData: Codable, Sendable {
         private enum CodingKeys: CodingKey {
             case userId
             case publicKeyCredentialCreationOptions
@@ -279,7 +279,7 @@ extension StytchClient.Passkeys {
         }
     }
 
-    struct AuthenticateStartResponseData: Codable {
+    struct AuthenticateStartResponseData: Codable, Sendable {
         private enum CodingKeys: CodingKey {
             case userId
             case publicKeyCredentialRequestOptions
@@ -310,7 +310,7 @@ extension StytchClient.Passkeys {
     }
 }
 
-public struct PasskeysUpdateResponseData: Codable {
+public struct PasskeysUpdateResponseData: Codable, Sendable {
     private enum CodingKeys: CodingKey {
         case webauthnRegistrationId
     }
@@ -332,7 +332,7 @@ public struct PasskeysUpdateResponseData: Codable {
     }
 }
 
-public struct PasskeysUpdateRequest: Codable {
+public struct PasskeysUpdateRequest: Codable, Sendable {
     private enum CodingKeys: CodingKey {
         case name
     }
@@ -348,7 +348,7 @@ public typealias PasskeysUpdateResponse = Response<PasskeysUpdateResponseData>
 
 @available(macOS 12.0, iOS 16.0, tvOS 16.0, *)
 private extension StytchClient.Passkeys {
-    struct Credential<Response: CredentialResponse>: Encodable {
+    struct Credential<Response: CredentialResponse & Sendable>: Encodable, Sendable {
         private enum CodingKeys: CodingKey {
             case type
             case id
@@ -379,7 +379,7 @@ private extension StytchClient.Passkeys {
         }
     }
 
-    struct AttestationResponse: CredentialResponse {
+    struct AttestationResponse: CredentialResponse, Sendable {
         let clientDataJSON: Data
         let attestationObject: Data
 
@@ -395,7 +395,7 @@ private extension StytchClient.Passkeys {
         }
     }
 
-    struct AssertionResponse: CredentialResponse {
+    struct AssertionResponse: CredentialResponse, Sendable {
         let clientDataJSON: Data
         let authenticatorData: Data
         let signature: Data
@@ -418,5 +418,5 @@ private extension StytchClient.Passkeys {
     }
 }
 
-private protocol CredentialResponse: Encodable {}
+private protocol CredentialResponse: Encodable, Sendable {}
 #endif

--- a/Sources/StytchCore/StytchClient/Passwords/StytchClient+Passwords.swift
+++ b/Sources/StytchCore/StytchClient/Passwords/StytchClient+Passwords.swift
@@ -116,7 +116,7 @@ public extension StytchClient.Passwords {
     typealias CreateResponse = Response<CreateResponseData>
 
     /// The underlying data for passwords `create` calls.
-    struct CreateResponseData: Decodable, AuthenticateResponseDataType {
+    struct CreateResponseData: Decodable, Sendable, AuthenticateResponseDataType {
         public let emailId: User.Email.ID
         public let userId: User.ID
         public let user: User
@@ -126,7 +126,7 @@ public extension StytchClient.Passwords {
     }
 
     /// The dedicated parameters type for password `create` and `authenticate` calls.
-    struct PasswordParameters: Encodable {
+    struct PasswordParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey { case email, password, sessionDuration = "sessionDurationMinutes" }
 
         let email: String
@@ -147,7 +147,7 @@ public extension StytchClient.Passwords {
 
 public extension StytchClient.Passwords {
     /// The dedicated parameters type for passwords `resetByEmailStart` calls.
-    struct ResetByEmailStartParameters: Encodable, Equatable {
+    struct ResetByEmailStartParameters: Encodable, Equatable, Sendable {
         public static func == (
             lhs: ResetByEmailStartParameters,
             rhs: ResetByEmailStartParameters
@@ -206,7 +206,7 @@ public extension StytchClient.Passwords {
     }
 
     /// The dedicated parameters type for passwords `resetByEmail` calls.
-    struct ResetByEmailParameters: Encodable {
+    struct ResetByEmailParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey { case token, password, sessionDuration = "sessionDurationMinutes" }
 
         public let token: String
@@ -227,7 +227,7 @@ public extension StytchClient.Passwords {
 
 public extension StytchClient.Passwords {
     /// The dedicated parameters type for passwords `resetBySession` calls
-    struct ResetBySessionParameters: Encodable {
+    struct ResetBySessionParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey { case password, sessionDuration = "sessionDurationMinutes" }
 
         public let password: String
@@ -245,7 +245,7 @@ public extension StytchClient.Passwords {
 
 public extension StytchClient.Passwords {
     /// The dedicated parameters type for passwords `resetByExistingPassword` calls.
-    struct ResetByExistingPasswordParameters: Encodable {
+    struct ResetByExistingPasswordParameters: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case emailAddress
             case existingPassword
@@ -282,7 +282,7 @@ public extension StytchClient.Passwords {
     typealias StrengthCheckResponse = Response<StrengthCheckResponseData>
 
     /// The dedicated parameters type for passwords `strengthCheck` calls.
-    struct StrengthCheckParameters: Encodable {
+    struct StrengthCheckParameters: Encodable, Sendable {
         let email: String?
         let password: String
 
@@ -296,7 +296,7 @@ public extension StytchClient.Passwords {
     }
 
     /// The underlying data for passwords `strengthCheck` calls.
-    struct StrengthCheckResponseData: Codable {
+    struct StrengthCheckResponseData: Codable, Sendable {
         public let validPassword: Bool
         /// A score from 0-4 to indicate the strength of a password. Useful for progress bars.
         public let score: Double
@@ -304,14 +304,14 @@ public extension StytchClient.Passwords {
         public let feedback: Feedback?
 
         /// A warning and collection of suggestions for improving the strength of a given password.
-        public struct Feedback: Codable {
+        public struct Feedback: Codable, Sendable {
             public let suggestions: [String]
             public let warning: String
             public let ludsRequirements: LudsRequirement?
         }
 
         /// An explanation of how a given password passes or fails a LUDS check
-        public struct LudsRequirement: Codable {
+        public struct LudsRequirement: Codable, Sendable {
             public let hasLowerCase: Bool
             public let hasUpperCase: Bool
             public let hasDigit: Bool

--- a/Sources/StytchCore/StytchClient/StytchClient+Sessions.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient+Sessions.swift
@@ -73,7 +73,7 @@ public extension StytchClient {
 
 public extension StytchClient.Sessions {
     /// The dedicated parameters type for sessions `authenticate` calls.
-    struct AuthenticateParameters: Encodable {
+    struct AuthenticateParameters: Encodable, Sendable {
         let sessionDurationMinutes: Minutes?
 
         /// - Parameter sessionDurationMinutes: The duration, in minutes, of the requested session.
@@ -85,7 +85,7 @@ public extension StytchClient.Sessions {
     }
 
     /// The dedicated parameters type for session `revoke` calls.
-    struct RevokeParameters {
+    struct RevokeParameters: Sendable {
         let forceClear: Bool
 
         /// - Parameter forceClear: In the event of an error received from the network, setting this value to true will ensure the local session state is cleared.

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -71,14 +71,14 @@ public extension StytchClient {
 
 public extension StytchClient {
     /// Represents the type of deeplink token which has been parsed. e.g. `magicLinks` or `passwordReset`.
-    enum DeeplinkTokenType: String {
+    enum DeeplinkTokenType: String, Sendable {
         case magicLinks = "magic_links"
         case oauth
         case passwordReset = "reset_password"
     }
 
     /// Wrapper around the possible types returned from the `handle(url:sessionDuration:)` function.
-    enum DeeplinkResponse {
+    enum DeeplinkResponse: Sendable {
         case auth(AuthenticateResponse)
         case oauth(StytchClient.OAuth.OAuthAuthenticateResponse)
     }

--- a/Sources/StytchCore/StytchClient/TOTP/StytchClient+TOTP.swift
+++ b/Sources/StytchCore/StytchClient/TOTP/StytchClient+TOTP.swift
@@ -36,7 +36,7 @@ public extension StytchClient {
 
 public extension StytchClient.TOTP {
     /// A dedicated parameters type for TOTP ``StytchClient/TOTP/create(parameters:)-437r4`` calls.
-    struct CreateParameters: Encodable {
+    struct CreateParameters: Encodable, Sendable {
         enum CodingKeys: String, CodingKey {
             case expiration = "expirationMinutes"
         }
@@ -50,7 +50,7 @@ public extension StytchClient.TOTP {
     }
 
     /// A dedicated parameters type for TOTP ``StytchClient/TOTP/authenticate(parameters:)-2ck6w`` calls.
-    struct AuthenticateParameters: Encodable {
+    struct AuthenticateParameters: Encodable, Sendable {
         enum CodingKeys: String, CodingKey {
             case totpCode
             case sessionDuration = "sessionDurationMinutes"
@@ -69,7 +69,7 @@ public extension StytchClient.TOTP {
     }
 
     /// A dedicated parameters type for TOTP ``StytchClient/TOTP/recover(parameters:)-9swfk`` calls.
-    struct RecoverParameters: Encodable {
+    struct RecoverParameters: Encodable, Sendable {
         enum CodingKeys: String, CodingKey {
             case recoveryCode
             case sessionDuration = "sessionDurationMinutes"
@@ -97,7 +97,7 @@ public extension StytchClient.TOTP {
     typealias RecoveryCodesResponse = Response<RecoveryCodesResponseData>
 
     /// The underlying data for TOTP ``StytchClient/TOTP/create(parameters:)-437r4`` responses.
-    struct CreateResponseData: Codable {
+    struct CreateResponseData: Codable, Sendable {
         public let totpId: User.TOTP.ID
         public let secret: String
         public let qrCode: String
@@ -107,7 +107,7 @@ public extension StytchClient.TOTP {
     }
 
     /// The underlying data for TOTP ``StytchClient/TOTP/recover(parameters:)-9swfk`` responses.
-    struct RecoverResponseData: Codable, AuthenticateResponseDataType {
+    struct RecoverResponseData: Codable, Sendable, AuthenticateResponseDataType {
         public let userId: User.ID
         public let totpId: User.TOTP.ID
         public let user: User
@@ -117,13 +117,13 @@ public extension StytchClient.TOTP {
     }
 
     /// The underlying data for TOTP ``StytchClient/TOTP/recoveryCodes()-mbxc`` responses.
-    struct RecoveryCodesResponseData: Codable {
+    struct RecoveryCodesResponseData: Codable, Sendable {
         public let userId: User.ID
         public let totps: [Union<User.TOTP, RecoveryCodes>]
     }
 
     /// Additional data unioned to the ``User`` type.
-    struct RecoveryCodes: Codable {
+    struct RecoveryCodes: Codable, Sendable {
         public let recoveryCodes: [String]
     }
 }

--- a/Sources/StytchCore/StytchClient/User/StytchClient+User.swift
+++ b/Sources/StytchCore/StytchClient/User/StytchClient+User.swift
@@ -71,7 +71,7 @@ public extension StytchClient {
     static var user: UserManagement { .init(router: router.scopedRouter { $0.users }) }
 }
 
-public struct UserResponseData: Codable {
+public struct UserResponseData: Codable, Sendable {
     /// The current user object.
     public let user: User
 }
@@ -83,7 +83,7 @@ public typealias NestedUserResponse = Response<UserResponseData>
 
 public extension StytchClient.UserManagement {
     /// The authentication factors which are able to be managed via user-management calls.
-    enum AuthenticationFactor {
+    enum AuthenticationFactor: Sendable {
         case biometricRegistration(id: User.BiometricRegistration.ID)
         case cryptoWallet(id: User.CryptoWallet.ID)
         case email(id: User.Email.ID)
@@ -93,7 +93,7 @@ public extension StytchClient.UserManagement {
         case oauth(id: User.Provider.ID)
     }
 
-    struct UpdateParameters: Encodable {
+    struct UpdateParameters: Encodable, Sendable {
         let name: User.Name?
         let untrustedMetadata: JSON?
 

--- a/Sources/StytchCore/StytchLocale.swift
+++ b/Sources/StytchCore/StytchLocale.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// Used to determine which language to use when sending the user this delivery method. Parameter is a IETF BCP 47 language tag, e.g. "en".
 /// https://www.w3.org/International/articles/language-tags/
-public enum StytchLocale: String, Codable {
+public enum StytchLocale: String, Codable, Sendable {
     case en
     case es
     case ptbr = "pt-br"

--- a/Sources/StytchCore/Union.swift
+++ b/Sources/StytchCore/Union.swift
@@ -1,6 +1,6 @@
 /// A simple, generic, wrapper type which combines two values and provides dynamic-member-access to the underlying wrapped values.
 @dynamicMemberLookup
-public struct Union<LHS, RHS> {
+public struct Union<LHS: Sendable, RHS: Sendable>: Sendable {
     let lhs: LHS
     let rhs: RHS
 


### PR DESCRIPTION
[[iOS] Concurrency warnings in the iOS code base](https://linear.app/stytch/issue/SDK-1725/[ios]-concurrency-warnings-in-the-ios-code-base)

Article explaining `Sendable`: https://www.avanderlee.com/swift/sendable-protocol-closures/

## Changes:

1. `Sendable` tells the compiler that this object is safe for concurrency and won't be mutable across contexts. Since all out response types, parameter types and pretty much all public and private objects in the Stytch iOS SDK are only made of `let` properties, all the work that needed to happen was to mark everything as conforming to `Sendable`.
2. This silenced most every warning in the iOS code base and in the sample apps.
3. This also gets us one step closer to Swift 6 should we want to make that leap, these warnings would be errors in Swift 6.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
