### PR TITLE
SDK-2205: B2B Email OTP

### DIFF
--- a/Sources/StytchCore/Generated/StytchB2BClient.OTP.Email.Discovery.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.OTP.Email.Discovery.authenticate+AsyncVariants.generated.swift
@@ -3,9 +3,9 @@
 import Combine
 import Foundation
 
-public extension StytchB2BClient.OAuth.Discovery {
-    /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
-    func authenticate(parameters: DiscoveryAuthenticateParameters, completion: @escaping Completion<StytchB2BClient.DiscoveryAuthenticateResponse>) {
+public extension StytchB2BClient.OTP.Email.Discovery {
+    /// Authenticate a one-time passcode (OTP) sent to a user via email.
+    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<StytchB2BClient.DiscoveryAuthenticateResponse>) {
         Task {
             do {
                 completion(.success(try await authenticate(parameters: parameters)))
@@ -15,8 +15,8 @@ public extension StytchB2BClient.OAuth.Discovery {
         }
     }
 
-    /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
-    func authenticate(parameters: DiscoveryAuthenticateParameters) -> AnyPublisher<StytchB2BClient.DiscoveryAuthenticateResponse, Error> {
+    /// Authenticate a one-time passcode (OTP) sent to a user via email.
+    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<StytchB2BClient.DiscoveryAuthenticateResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/Generated/StytchB2BClient.OTP.Email.Discovery.send+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.OTP.Email.Discovery.send+AsyncVariants.generated.swift
@@ -3,8 +3,8 @@
 import Combine
 import Foundation
 
-public extension StytchB2BClient.OTP {
-    /// Send a one-time passcode (OTP) to a user using their phone number via SMS.
+public extension StytchB2BClient.OTP.Email.Discovery {
+    /// Send a one-time passcode (OTP) to a user using their email address.
     func send(parameters: SendParameters, completion: @escaping Completion<BasicResponse>) {
         Task {
             do {
@@ -15,7 +15,7 @@ public extension StytchB2BClient.OTP {
         }
     }
 
-    /// Send a one-time passcode (OTP) to a user using their phone number via SMS.
+    /// Send a one-time passcode (OTP) to a user using their email address.
     func send(parameters: SendParameters) -> AnyPublisher<BasicResponse, Error> {
         return Deferred {
             Future({ promise in

--- a/Sources/StytchCore/Generated/StytchB2BClient.OTP.Email.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.OTP.Email.authenticate+AsyncVariants.generated.swift
@@ -3,9 +3,9 @@
 import Combine
 import Foundation
 
-public extension StytchB2BClient.OAuth.Discovery {
-    /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
-    func authenticate(parameters: DiscoveryAuthenticateParameters, completion: @escaping Completion<StytchB2BClient.DiscoveryAuthenticateResponse>) {
+public extension StytchB2BClient.OTP.Email {
+    /// Authenticate a one-time passcode (OTP) sent to a user via Email.
+    func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<AuthenticateResponse>) {
         Task {
             do {
                 completion(.success(try await authenticate(parameters: parameters)))
@@ -15,8 +15,8 @@ public extension StytchB2BClient.OAuth.Discovery {
         }
     }
 
-    /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
-    func authenticate(parameters: DiscoveryAuthenticateParameters) -> AnyPublisher<StytchB2BClient.DiscoveryAuthenticateResponse, Error> {
+    /// Authenticate a one-time passcode (OTP) sent to a user via Email.
+    func authenticate(parameters: AuthenticateParameters) -> AnyPublisher<AuthenticateResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/Generated/StytchB2BClient.OTP.Email.loginOrSignup+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.OTP.Email.loginOrSignup+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchB2BClient.OTP.Email {
+    /// Send a one-time passcode (OTP) to a user using email address.
+    func loginOrSignup(parameters: LoginOrSignupParameters, completion: @escaping Completion<BasicResponse>) {
+        Task {
+            do {
+                completion(.success(try await loginOrSignup(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Send a one-time passcode (OTP) to a user using email address.
+    func loginOrSignup(parameters: LoginOrSignupParameters) -> AnyPublisher<BasicResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await loginOrSignup(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/Generated/StytchB2BClient.OTP.SMS.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.OTP.SMS.authenticate+AsyncVariants.generated.swift
@@ -3,7 +3,7 @@
 import Combine
 import Foundation
 
-public extension StytchB2BClient.OTP {
+public extension StytchB2BClient.OTP.SMS {
     /// Authenticate a one-time passcode (OTP) sent to a user via SMS.
     func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<B2BAuthenticateResponse>) {
         Task {

--- a/Sources/StytchCore/Generated/StytchB2BClient.OTP.SMS.send+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.OTP.SMS.send+AsyncVariants.generated.swift
@@ -1,0 +1,33 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Combine
+import Foundation
+
+public extension StytchB2BClient.OTP.SMS {
+    /// Send a one-time passcode (OTP) to a user using their phone number via SMS.
+    func send(parameters: SendParameters, completion: @escaping Completion<BasicResponse>) {
+        Task {
+            do {
+                completion(.success(try await send(parameters: parameters)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Send a one-time passcode (OTP) to a user using their phone number via SMS.
+    func send(parameters: SendParameters) -> AnyPublisher<BasicResponse, Error> {
+        return Deferred {
+            Future({ promise in
+                Task {
+                    do {
+                        promise(.success(try await send(parameters: parameters)))
+                    } catch {
+                        promise(.failure(error))
+                    }
+                }
+            })
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
@@ -139,3 +139,26 @@ public extension StytchB2BClient {
         public let member: Member
     }
 }
+
+public extension StytchB2BClient {
+    typealias DiscoveryAuthenticateResponse = Response<DiscoveryAuthenticateResponseData>
+
+    struct DiscoveryAuthenticateResponseData: DiscoveryIntermediateSessionTokenDataType, Codable, Sendable {
+        /// The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but represents a bag of factors that may be converted to a member session.
+        /// The token can be used with the OTP SMS Authenticate endpoint, TOTP Authenticate endpoint, or Recovery Codes Recover endpoint to complete an MFA flow and log in to the Organization.
+        /// It can also be used with the Exchange Intermediate Session endpoint to join a specific Organization that allows the factors represented by the intermediate session token;
+        /// or the Create Organization via Discovery endpoint to create a new Organization and Member.
+        public let intermediateSessionToken: String
+        /// The email address.
+        public let emailAddress: String
+        /// An array of discovered_organization objects tied to the intermediate_session_token, session_token, or session_jwt. See the Discovered Organization Object for complete details.
+        /// Note that Organizations will only appear here under any of the following conditions:
+        /// The end user is already a Member of the Organization.
+        /// The end user is invited to the Organization.
+        /// The end user can join the Organization because:
+        /// a) The Organization allows JIT provisioning.
+        /// b) The Organizations' allowed domains list contains the Member's email domain.
+        /// c) The Organization has at least one other Member with a verified email address with the same domain as the end user (to prevent phishing attacks).
+        public let discoveredOrganizations: [StytchB2BClient.DiscoveredOrganization]
+    }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+Discovery.swift
@@ -17,7 +17,7 @@ public extension StytchB2BClient.OAuth {
 
         // sourcery: AsyncVariants
         /// After an identity provider confirms the identity of a user, this method authenticates the included token and returns a new session object.
-        public func authenticate(parameters: DiscoveryAuthenticateParameters) async throws -> DiscoveryAuthenticateResponse {
+        public func authenticate(parameters: DiscoveryAuthenticateParameters) async throws -> StytchB2BClient.DiscoveryAuthenticateResponse {
             defer {
                 try? pkcePairManager.clearPKCECodePair()
             }
@@ -32,7 +32,7 @@ public extension StytchB2BClient.OAuth {
                     to: .authenticate,
                     parameters: CodeVerifierParameters(codingPrefix: .pkce, codeVerifier: pkcePair.codeVerifier, wrapped: parameters),
                     useDFPPA: true
-                ) as DiscoveryAuthenticateResponse
+                ) as StytchB2BClient.DiscoveryAuthenticateResponse
                 try? await EventsClient.logEvent(parameters: .init(eventName: "b2b_discovery_oauth_success"))
                 return result
             } catch {
@@ -52,28 +52,5 @@ public extension StytchB2BClient.OAuth.Discovery {
         public init(discoveryOauthToken: String) {
             self.discoveryOauthToken = discoveryOauthToken
         }
-    }
-}
-
-public extension StytchB2BClient.OAuth.Discovery {
-    typealias DiscoveryAuthenticateResponse = Response<DiscoveryAuthenticateResponseData>
-
-    struct DiscoveryAuthenticateResponseData: DiscoveryIntermediateSessionTokenDataType, Codable, Sendable {
-        /// The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but represents a bag of factors that may be converted to a member session.
-        /// The token can be used with the OTP SMS Authenticate endpoint, TOTP Authenticate endpoint, or Recovery Codes Recover endpoint to complete an MFA flow and log in to the Organization.
-        /// It can also be used with the Exchange Intermediate Session endpoint to join a specific Organization that allows the factors represented by the intermediate session token;
-        /// or the Create Organization via Discovery endpoint to create a new Organization and Member.
-        public let intermediateSessionToken: String
-        /// The email address.
-        public let emailAddress: String
-        /// An array of discovered_organization objects tied to the intermediate_session_token, session_token, or session_jwt. See the Discovered Organization Object for complete details.
-        /// Note that Organizations will only appear here under any of the following conditions:
-        /// The end user is already a Member of the Organization.
-        /// The end user is invited to the Organization.
-        /// The end user can join the Organization because:
-        /// a) The Organization allows JIT provisioning.
-        /// b) The Organizations' allowed domains list contains the Member's email domain.
-        /// c) The Organization has at least one other Member with a verified email address with the same domain as the end user (to prevent phishing attacks).
-        public let discoveredOrganizations: [StytchB2BClient.DiscoveredOrganization]
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
@@ -104,7 +104,7 @@ public extension StytchB2BClient.OAuth {
         public let memberAuthenticated: Bool
         /// Information about the MFA requirements of the Organization and the Member's options for fulfilling MFA.
         public let mfaRequired: MFARequired?
-        /// /// The provider_values object lists relevant identifiers, values, and scopes for a given OAuth provider.
+        /// The provider_values object lists relevant identifiers, values, and scopes for a given OAuth provider.
         /// For example this object will include a provider's access_token that you can use to access the provider's API for a given user.
         /// Note that these values will vary based on the OAuth provider in question, e.g. id_token is only returned by OIDC compliant identity providers.
         public let providerValues: OAuthProviderValues

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP+Email+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP+Email+Discovery.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+public extension StytchB2BClient.OTP.Email {
+    /// The interface for interacting with otp email discovery products.
+    var discovery: Discovery {
+        .init(router: router.scopedRouter {
+            $0.discovery
+        })
+    }
+}
+
+public extension StytchB2BClient.OTP.Email {
+    struct Discovery {
+        let router: NetworkingRouter<StytchB2BClient.OTPRoute.EmailRoute.DiscoveryRoute>
+
+        // sourcery: AsyncVariants
+        /// Send a one-time passcode (OTP) to a user using their email address.
+        public func send(parameters: SendParameters) async throws -> BasicResponse {
+            try await router.post(to: .send, parameters: parameters, useDFPPA: true)
+        }
+
+        // sourcery: AsyncVariants
+        /// Authenticate a one-time passcode (OTP) sent to a user via email.
+        public func authenticate(parameters: AuthenticateParameters) async throws -> StytchB2BClient.DiscoveryAuthenticateResponse {
+            try await router.post(to: .authenticate, parameters: parameters, useDFPPA: true)
+        }
+    }
+}
+
+public extension StytchB2BClient.OTP.Email.Discovery {
+    struct SendParameters: Codable, Sendable {
+        /// The email address to send the OTP to.
+        let emailAddress: String
+        /// The email template ID to use for login emails. If not provided, your default email template will be sent.
+        /// If providing a template ID, it must be either a template using Stytch's customizations, or an OTP Login custom HTML template.
+        let loginTemplateId: String?
+        /// The locale is used to determine which language to use in the email. Parameter is a {@link https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag}, e.g. "en".
+        /// Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
+        let locale: StytchLocale?
+
+        public init(
+            emailAddress: String,
+            loginTemplateId: String? = nil,
+            locale: StytchLocale? = nil
+        ) {
+            self.emailAddress = emailAddress
+            self.loginTemplateId = loginTemplateId
+            self.locale = locale
+        }
+    }
+}
+
+public extension StytchB2BClient.OTP.Email.Discovery {
+    struct AuthenticateParameters: Codable, Sendable {
+        /// The OTP to authenticate the user.
+        let code: String
+        /// The email address of the member attempting to authenticate.
+        let emailAddress: String
+
+        public init(
+            code: String,
+            emailAddress: String
+        ) {
+            self.code = code
+            self.emailAddress = emailAddress
+        }
+    }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP+Email.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP+Email.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+public extension StytchB2BClient.OTP {
+    /// The interface for interacting with otp email products.
+    var email: Email {
+        .init(router: router.scopedRouter {
+            $0.email
+        })
+    }
+}
+
+public extension StytchB2BClient.OTP {
+    struct Email {
+        let router: NetworkingRouter<StytchB2BClient.OTPRoute.EmailRoute>
+
+        // sourcery: AsyncVariants
+        /// Send a one-time passcode (OTP) to a user using email address.
+        public func loginOrSignup(parameters: LoginOrSignupParameters) async throws -> BasicResponse {
+            try await router.post(to: .loginOrSignup, parameters: parameters, useDFPPA: true)
+        }
+
+        // sourcery: AsyncVariants
+        /// Authenticate a one-time passcode (OTP) sent to a user via Email.
+        public func authenticate(parameters: AuthenticateParameters) async throws -> AuthenticateResponse {
+            try await router.post(to: .authenticate, parameters: parameters, useDFPPA: true)
+        }
+    }
+}
+
+public extension StytchB2BClient.OTP.Email {
+    struct LoginOrSignupParameters: Codable, Sendable {
+        /// The ID of the organization the member belongs to.
+        let organizationId: String
+        /// The email of the member to send the OTP to.
+        let emailAddress: String
+        /// The email template ID to use for login emails. If not provided, your default email template will be sent.
+        /// If providing a template ID, it must be either a template using Stytch's customizations, or an OTP Login custom HTML template.
+        let loginTemplateId: String?
+        /// The email template ID to use for sign-up emails.
+        /// If not provided, your default email template will be sent. If providing a template ID, it must be either a template using Stytch's customizations,
+        /// or an OTP Sign-up custom HTML template.
+        let signupTemplateId: String?
+        /// The locale is used to determine which language to use in the email. Parameter is a {@link https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag}, e.g. "en".
+        /// Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
+        let locale: StytchLocale?
+
+        public init(
+            organizationId: String,
+            emailAddress: String,
+            loginTemplateId: String? = nil,
+            signupTemplateId: String? = nil,
+            locale: StytchLocale? = nil
+        ) {
+            self.organizationId = organizationId
+            self.emailAddress = emailAddress
+            self.loginTemplateId = loginTemplateId
+            self.signupTemplateId = signupTemplateId
+            self.locale = locale
+        }
+    }
+}
+
+public extension StytchB2BClient.OTP.Email {
+    /// The concrete response type for B2B OTP Email `authenticate` calls.
+    typealias AuthenticateResponse = Response<AuthenticateResponseData>
+
+    struct AuthenticateResponseData: Codable, Sendable, B2BMFAAuthenticateResponseDataType {
+        /// The ``MemberSession`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
+        public let memberSession: MemberSession?
+        /// The current member's ID.
+        public let memberId: Member.ID
+        /// The current member object.
+        public let member: Member
+        /// The current organization object.
+        public let organization: Organization
+        /// The opaque token for the session. Can be used by your server to verify the validity of your session by confirming with Stytch's servers on each request.
+        public let sessionToken: String
+        /// The JWT for the session. Can be used by your server to verify the validity of your session either by checking the data included in the JWT, or by verifying with Stytch's servers as needed.
+        public let sessionJwt: String
+        /// An optional intermediate session token to be returned if multi factor authentication is enabled
+        public let intermediateSessionToken: String?
+        /// Indicates whether the Member is fully authenticated. If false, the Member needs to complete an MFA step to log in to the Organization.
+        public let memberAuthenticated: Bool
+        /// Information about the MFA requirements of the Organization and the Member's options for fulfilling MFA.
+        public let mfaRequired: MFARequired?
+        /// The ID of the email used to send an OTP.
+        public let methodId: String
+    }
+
+    struct AuthenticateParameters: Codable, Sendable {
+        /// The OTP to authenticate
+        let code: String
+        /// The organization ID of the member attempting to authenticate for.
+        let organizationId: String
+        /// The email of the member we're attempting to authenticate the otp for.
+        let emailAddress: String
+        /// The locale will be used if an OTP code is sent to the member's phone number as part of a secondary authentication requirement.
+        let locale: StytchLocale?
+        /// This will return both an opaque `session_token` and `session_jwt` for this session, which will automatically be stored in the browser cookies.
+        /// The `session_jwt` will have a fixed lifetime of five minutes regardless of the underlying session duration, and will be automatically refreshed by the SDK in the background over time.
+        /// This value must be a minimum of 5 and may not exceed the maximum session duration minutes value set in the https://stytch.com/dashboard/sdk-configuration SDK Configuration page of the Stytch dashboard.
+        let sessionDurationMinutes: Minutes
+
+        public init(
+            code: String,
+            organizationId: String,
+            emailAddress: String,
+            locale: StytchLocale? = nil,
+            sessionDurationMinutes: Minutes
+        ) {
+            self.code = code
+            self.organizationId = organizationId
+            self.emailAddress = emailAddress
+            self.locale = locale
+            self.sessionDurationMinutes = sessionDurationMinutes
+        }
+    }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP+SMS.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP+SMS.swift
@@ -1,17 +1,17 @@
 import Foundation
 
-public extension StytchB2BClient {
-    /// The interface for interacting with otp products.
-    static var otp: OTP {
+public extension StytchB2BClient.OTP {
+    /// The interface for interacting with otp sms products.
+    var sms: SMS {
         .init(router: router.scopedRouter {
-            $0.otp
+            $0.sms
         })
     }
 }
 
-public extension StytchB2BClient {
-    struct OTP {
-        let router: NetworkingRouter<StytchB2BClient.OTPRoute>
+public extension StytchB2BClient.OTP {
+    struct SMS {
+        let router: NetworkingRouter<StytchB2BClient.OTPRoute.SMSRoute>
 
         @Dependency(\.sessionManager) private var sessionManager
 
@@ -43,7 +43,7 @@ public extension StytchB2BClient {
     }
 }
 
-public extension StytchB2BClient.OTP {
+public extension StytchB2BClient.OTP.SMS {
     struct SendParameters: Codable, Sendable {
         let organizationId: String
         let memberId: String
@@ -69,7 +69,7 @@ public extension StytchB2BClient.OTP {
     }
 }
 
-public extension StytchB2BClient.OTP {
+public extension StytchB2BClient.OTP.SMS {
     struct AuthenticateParameters: Codable, Sendable {
         let sessionDurationMinutes: Minutes
         let organizationId: String

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public extension StytchB2BClient {
+    /// The interface for interacting with otp products.
+    static var otp: OTP {
+        .init(router: router.scopedRouter {
+            $0.otp
+        })
+    }
+}
+
+public extension StytchB2BClient {
+    struct OTP {
+        let router: NetworkingRouter<StytchB2BClient.OTPRoute>
+    }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 
 extension StytchB2BClient {
@@ -286,15 +287,60 @@ extension StytchB2BClient {
     }
 
     enum OTPRoute: RouteType {
-        case send
-        case authenticate
+        case sms(SMSRoute)
+        case email(EmailRoute)
 
         var path: Path {
             switch self {
-            case .send:
-                return "sms/send"
-            case .authenticate:
-                return "sms/authenticate"
+            case let .sms(route):
+                return "sms".appendingPath(route.path)
+            case let .email(route):
+                return "email".appendingPath(route.path)
+            }
+        }
+
+        enum SMSRoute: RouteType {
+            case send
+            case authenticate
+
+            var path: Path {
+                switch self {
+                case .send:
+                    return "send"
+                case .authenticate:
+                    return "authenticate"
+                }
+            }
+        }
+
+        enum EmailRoute: RouteType {
+            case loginOrSignup
+            case authenticate
+            case discovery(DiscoveryRoute)
+
+            var path: Path {
+                switch self {
+                case .loginOrSignup:
+                    return "login_or_signup"
+                case .authenticate:
+                    return "authenticate"
+                case let .discovery(route):
+                    return "discovery".appendingPath(route.path)
+                }
+            }
+
+            enum DiscoveryRoute: RouteType {
+                case send
+                case authenticate
+
+                var path: Path {
+                    switch self {
+                    case .send:
+                        return "send"
+                    case .authenticate:
+                        return "authenticate"
+                    }
+                }
             }
         }
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -82,7 +82,7 @@ public extension StytchB2BClient {
         case mfaOAuth(StytchB2BClient.OAuth.OAuthAuthenticateResponse)
         case discovery(StytchB2BClient.MagicLinks.DiscoveryAuthenticateResponse)
         #if !os(watchOS)
-        case discoveryOauth(StytchB2BClient.OAuth.Discovery.DiscoveryAuthenticateResponse)
+        case discoveryOauth(StytchB2BClient.DiscoveryAuthenticateResponse)
         #endif
     }
 

--- a/Tests/StytchCoreTests/B2BOAuthTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOAuthTestCase.swift
@@ -43,7 +43,7 @@ final class B2BOAuthTestCase: BaseTestCase {
     @available(tvOS 16.0, *)
     func testDiscoveryAuthenticate() async throws {
         networkInterceptor.responses {
-            StytchB2BClient.OAuth.Discovery.DiscoveryAuthenticateResponse(
+            StytchB2BClient.DiscoveryAuthenticateResponse(
                 requestId: "1234",
                 statusCode: 200,
                 wrapped: .mock
@@ -77,7 +77,7 @@ final class B2BOAuthTestCase: BaseTestCase {
     }
 }
 
-extension StytchB2BClient.OAuth.Discovery.DiscoveryAuthenticateResponseData {
+extension StytchB2BClient.DiscoveryAuthenticateResponseData {
     static var mock: Self {
         .init(
             intermediateSessionToken: "",

--- a/Tests/StytchCoreTests/B2BOTPTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOTPTestCase.swift
@@ -13,7 +13,7 @@ final class B2BOTPTestCase: BaseTestCase {
         let mfaPhoneNumber = "+15555555555"
         let locale = StytchLocale.en
 
-        let parameters = StytchB2BClient.OTP.SendParameters(
+        let parameters = StytchB2BClient.OTP.SMS.SendParameters(
             organizationId: organizationId,
             memberId: memberId,
             mfaPhoneNumber: mfaPhoneNumber,
@@ -22,7 +22,7 @@ final class B2BOTPTestCase: BaseTestCase {
 
         Current.sessionManager.updateSession(intermediateSessionToken: intermediateSessionToken)
 
-        _ = try await StytchB2BClient.otp.send(parameters: parameters)
+        _ = try await StytchB2BClient.otp.sms.send(parameters: parameters)
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
@@ -48,7 +48,7 @@ final class B2BOTPTestCase: BaseTestCase {
         let mfaPhoneNumber = "+15555555555"
         let locale = StytchLocale.en
 
-        let parameters = StytchB2BClient.OTP.SendParameters(
+        let parameters = StytchB2BClient.OTP.SMS.SendParameters(
             organizationId: organizationId,
             memberId: memberId,
             mfaPhoneNumber: mfaPhoneNumber,
@@ -58,7 +58,7 @@ final class B2BOTPTestCase: BaseTestCase {
 
         Current.sessionManager.updateSession(intermediateSessionToken: intermediateSessionToken)
 
-        _ = try await StytchB2BClient.otp.send(parameters: parameters)
+        _ = try await StytchB2BClient.otp.sms.send(parameters: parameters)
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
@@ -85,7 +85,7 @@ final class B2BOTPTestCase: BaseTestCase {
         let memberId = "memberid1234"
         let code = "code1234"
 
-        let parameters = StytchB2BClient.OTP.AuthenticateParameters(
+        let parameters = StytchB2BClient.OTP.SMS.AuthenticateParameters(
             sessionDurationMinutes: .defaultSessionDuration,
             organizationId: organizationId,
             memberId: memberId,
@@ -94,7 +94,7 @@ final class B2BOTPTestCase: BaseTestCase {
 
         Current.sessionManager.updateSession(intermediateSessionToken: intermediateSessionToken)
 
-        _ = try await StytchB2BClient.otp.authenticate(parameters: parameters)
+        _ = try await StytchB2BClient.otp.sms.authenticate(parameters: parameters)
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
@@ -108,4 +108,149 @@ final class B2BOTPTestCase: BaseTestCase {
             ])
         )
     }
+
+    func testEmailLoginOrSignup() async throws {
+        networkInterceptor.responses {
+            BasicResponse(requestId: "1234", statusCode: 200)
+        }
+
+        let organizationId = "orgid1234"
+        let emailAddress = "test@example.com"
+        let loginTemplateId = "login-template-123"
+        let signupTemplateId = "signup-template-123"
+        let locale = StytchLocale.en
+
+        let parameters = StytchB2BClient.OTP.Email.LoginOrSignupParameters(
+            organizationId: organizationId,
+            emailAddress: emailAddress,
+            loginTemplateId: loginTemplateId,
+            signupTemplateId: signupTemplateId,
+            locale: locale
+        )
+
+        _ = try await StytchB2BClient.otp.email.loginOrSignup(parameters: parameters)
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://api.stytch.com/sdk/v1/b2b/otps/email/login_or_signup",
+            method: .post([
+                "organization_id": JSON(stringLiteral: organizationId),
+                "email_address": JSON(stringLiteral: emailAddress),
+                "login_template_id": JSON(stringLiteral: loginTemplateId),
+                "signup_template_id": JSON(stringLiteral: signupTemplateId),
+                "locale": JSON(stringLiteral: locale.rawValue),
+            ])
+        )
+    }
+
+    func testEmailAuthenticate() async throws {
+        networkInterceptor.responses {
+            StytchB2BClient.OTP.Email.AuthenticateResponse.mock
+        }
+
+        Current.timer = { _, _, _ in .init() }
+
+        let code = "code1234"
+        let organizationId = "orgid1234"
+        let emailAddress = "test@example.com"
+        let locale = StytchLocale.en
+
+        let parameters = StytchB2BClient.OTP.Email.AuthenticateParameters(
+            code: code,
+            organizationId: organizationId,
+            emailAddress: emailAddress,
+            locale: locale,
+            sessionDurationMinutes: .defaultSessionDuration
+        )
+
+        _ = try await StytchB2BClient.otp.email.authenticate(parameters: parameters)
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://api.stytch.com/sdk/v1/b2b/otps/email/authenticate",
+            method: .post([
+                "code": JSON(stringLiteral: code),
+                "organization_id": JSON(stringLiteral: organizationId),
+                "email_address": JSON(stringLiteral: emailAddress),
+                "locale": JSON(stringLiteral: locale.rawValue),
+                "session_duration_minutes": JSON(integerLiteral: 5),
+            ])
+        )
+    }
+
+    func testDiscoverySend() async throws {
+        networkInterceptor.responses {
+            BasicResponse(requestId: "1234", statusCode: 200)
+        }
+
+        let emailAddress = "test@example.com"
+        let loginTemplateId = "template123"
+        let locale = StytchLocale.en
+
+        let parameters = StytchB2BClient.OTP.Email.Discovery.SendParameters(
+            emailAddress: emailAddress,
+            loginTemplateId: loginTemplateId,
+            locale: locale
+        )
+
+        _ = try await StytchB2BClient.otp.email.discovery.send(parameters: parameters)
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://api.stytch.com/sdk/v1/b2b/otps/email/discovery/send",
+            method: .post([
+                "email_address": JSON(stringLiteral: emailAddress),
+                "login_template_id": JSON(stringLiteral: loginTemplateId),
+                "locale": JSON(stringLiteral: locale.rawValue),
+            ])
+        )
+    }
+
+    func testDiscoveryAuthenticate() async throws {
+        networkInterceptor.responses {
+            StytchB2BClient.DiscoveryAuthenticateResponse(
+                requestId: "1234",
+                statusCode: 200,
+                wrapped: .mock
+            )
+        }
+
+        let emailAddress = "test@example.com"
+        let code = "code1234"
+
+        let parameters = StytchB2BClient.OTP.Email.Discovery.AuthenticateParameters(
+            code: code,
+            emailAddress: emailAddress
+        )
+
+        _ = try await StytchB2BClient.otp.email.discovery.authenticate(parameters: parameters)
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://api.stytch.com/sdk/v1/b2b/otps/email/discovery/authenticate",
+            method: .post([
+                "email_address": JSON(stringLiteral: emailAddress),
+                "code": JSON(stringLiteral: code),
+            ])
+        )
+    }
+}
+
+extension StytchB2BClient.OTP.Email.AuthenticateResponse {
+    static let mock: Self = .init(
+        requestId: "req_123",
+        statusCode: 200,
+        wrapped: .init(
+            memberSession: .mock,
+            memberId: "member_id_123",
+            member: .mock,
+            organization: .mock,
+            sessionToken: "xyzasdf",
+            sessionJwt: "i'mvalidjson",
+            intermediateSessionToken: "cccccbgkvlhvciffckuevcevtrkjfkeiklvulgrrgvke",
+            memberAuthenticated: false,
+            mfaRequired: nil,
+            methodId: ""
+        )
+    )
 }


### PR DESCRIPTION
[SDK-2205 - B2B Email OTP](https://linear.app/stytch/issue/SDK-2205/[ios]-b2b-email-otp)

## Changes:

1. I had to refactor the SMS OTP object because I had not properly namespaced it when I initially added it, I had it directly under the OTP struct. Now there is a SMS struct.
2. Added Email and Discovery OTP structs.
3. Moved `DiscoveryAuthenticateResponse` to a common place which is now shared between OAuth and Email for discovery.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
