### PR TITLE
Add missing value to MFA response “primaryRequired”

### DIFF
--- a/Sources/StytchCore/SharedModels/Response.swift
+++ b/Sources/StytchCore/SharedModels/Response.swift
@@ -95,6 +95,7 @@ extension Response: B2BMFAAuthenticateResponseDataType where Wrapped: B2BMFAAuth
     public var memberId: Member.ID { wrapped.memberId }
     public var memberAuthenticated: Bool { wrapped.memberAuthenticated }
     public var mfaRequired: MFARequired? { wrapped.mfaRequired }
+    public var primaryRequired: PrimaryRequired? { wrapped.primaryRequired }
 }
 
 extension Response: DiscoveryIntermediateSessionTokenDataType where Wrapped: DiscoveryIntermediateSessionTokenDataType {

--- a/Sources/StytchCore/StytchB2BClient/Models/B2BMFAAuthenticateResponse.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/B2BMFAAuthenticateResponse.swift
@@ -26,6 +26,8 @@ public struct B2BMFAAuthenticateResponseData: Codable, Sendable, B2BMFAAuthentic
     public let memberAuthenticated: Bool
     /// Information about the MFA requirements of the Organization and the Member's options for fulfilling MFA.
     public let mfaRequired: MFARequired?
+    /// Information about the primary authentication requirements of the Organization.
+    public let primaryRequired: PrimaryRequired?
 }
 
 /// The interface which a data type must conform to for all underlying data in B2B MFA `authenticate` responses.
@@ -48,12 +50,21 @@ public protocol B2BMFAAuthenticateResponseDataType {
     var memberAuthenticated: Bool { get }
     /// Information about the MFA requirements of the Organization and the Member's options for fulfilling MFA.
     var mfaRequired: MFARequired? { get }
+    /// Information about the primary authentication requirements of the Organization.
+    var primaryRequired: PrimaryRequired? { get }
 }
 
 /// The interface which a data type must conform to for all discovery flows that return a non optional intermediate session token
 public protocol DiscoveryIntermediateSessionTokenDataType {
     /// The non optional intermediate session token returned by discovery flows separate from multi factor authentication
     var intermediateSessionToken: String { get }
+}
+
+public struct PrimaryRequired: Codable, Sendable {
+    // Details the auth method that the member must also complete to fulfill the primary authentication requirements of the Organization.
+    // For example, a value of [magic_link] indicates that the Member must also complete a magic link authentication step.
+    // If you have an intermediate session token, you must pass it into that primary authentication step.
+    var allowedAuthMethods: [String]
 }
 
 public struct MFARequired: Codable, Sendable {

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
@@ -104,6 +104,8 @@ public extension StytchB2BClient.OAuth {
         public let memberAuthenticated: Bool
         /// Information about the MFA requirements of the Organization and the Member's options for fulfilling MFA.
         public let mfaRequired: MFARequired?
+        /// Information about the primary authentication requirements of the Organization.
+        public let primaryRequired: PrimaryRequired?
         /// The provider_values object lists relevant identifiers, values, and scopes for a given OAuth provider.
         /// For example this object will include a provider's access_token that you can use to access the provider's API for a given user.
         /// Note that these values will vary based on the OAuth provider in question, e.g. id_token is only returned by OIDC compliant identity providers.

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP+Email.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP+Email.swift
@@ -83,6 +83,8 @@ public extension StytchB2BClient.OTP.Email {
         public let memberAuthenticated: Bool
         /// Information about the MFA requirements of the Organization and the Member's options for fulfilling MFA.
         public let mfaRequired: MFARequired?
+        /// Information about the primary authentication requirements of the Organization.
+        public let primaryRequired: PrimaryRequired?
         /// The ID of the email used to send an OTP.
         public let methodId: String
     }

--- a/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
@@ -205,7 +205,8 @@ extension B2BMFAAuthenticateResponse {
             sessionJwt: "i'mvalidjson",
             intermediateSessionToken: "cccccbgkvlhvciffckuevcevtrkjfkeiklvulgrrgvke",
             memberAuthenticated: false,
-            mfaRequired: nil
+            mfaRequired: nil,
+            primaryRequired: nil
         )
     )
 }

--- a/Tests/StytchCoreTests/B2BOAuthTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOAuthTestCase.swift
@@ -101,6 +101,7 @@ extension StytchB2BClient.OAuth.OAuthAuthenticateResponse {
             intermediateSessionToken: "cccccbgkvlhvciffckuevcevtrkjfkeiklvulgrrgvke",
             memberAuthenticated: false,
             mfaRequired: nil,
+            primaryRequired: nil,
             providerValues: .mock
         )
     )

--- a/Tests/StytchCoreTests/B2BOTPTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOTPTestCase.swift
@@ -250,6 +250,7 @@ extension StytchB2BClient.OTP.Email.AuthenticateResponse {
             intermediateSessionToken: "cccccbgkvlhvciffckuevcevtrkjfkeiklvulgrrgvke",
             memberAuthenticated: false,
             mfaRequired: nil,
+            primaryRequired: nil,
             methodId: ""
         )
     )


### PR DESCRIPTION
## Changes:

1.  Though investigation of functionality of the B2B UI we realized that the MFA response type was missing the needed field "primaryRequired" so we added it.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
