### PR TITLE
[B2B UI] Add Full Discovery And TOTP Flow to B2B UI

### DIFF
--- a/Sources/StytchCore/Generated/StytchB2BClient.MagicLinks.discoveryAuthenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchB2BClient.MagicLinks.discoveryAuthenticate+AsyncVariants.generated.swift
@@ -5,7 +5,7 @@ import Foundation
 
 public extension StytchB2BClient.MagicLinks {
     /// The Authenticate Discovery Magic Link method wraps the [authenticate](https://stytch.com/docs/b2b/api/send-discovery-email) discovery magic link API endpoint, which validates the discovery magic link token passed in.
-    func discoveryAuthenticate(parameters: DiscoveryAuthenticateParameters, completion: @escaping Completion<DiscoveryAuthenticateResponse>) {
+    func discoveryAuthenticate(parameters: DiscoveryAuthenticateParameters, completion: @escaping Completion<StytchB2BClient.DiscoveryAuthenticateResponse>) {
         Task {
             do {
                 completion(.success(try await discoveryAuthenticate(parameters: parameters)))
@@ -16,7 +16,7 @@ public extension StytchB2BClient.MagicLinks {
     }
 
     /// The Authenticate Discovery Magic Link method wraps the [authenticate](https://stytch.com/docs/b2b/api/send-discovery-email) discovery magic link API endpoint, which validates the discovery magic link token passed in.
-    func discoveryAuthenticate(parameters: DiscoveryAuthenticateParameters) -> AnyPublisher<DiscoveryAuthenticateResponse, Error> {
+    func discoveryAuthenticate(parameters: DiscoveryAuthenticateParameters) -> AnyPublisher<StytchB2BClient.DiscoveryAuthenticateResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/SharedModels/StytchError.swift
+++ b/Sources/StytchCore/SharedModels/StytchError.swift
@@ -231,6 +231,12 @@ public extension StytchSDKError {
             errorType: "no_organziation_id"
         )
     )
+    static let noMemberId = StytchSDKError(
+        message: "No Member Id Configured",
+        options: .init(
+            errorType: "no_member_id"
+        )
+    )
     static let emailNotEligibleForJitProvioning = StytchSDKError(
         message: "Email Not Eligible For Jit Provioning",
         options: .init(

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
@@ -132,18 +132,20 @@ public extension StytchB2BClient {
 
     /// A struct describing a membership and its details.
     struct Membership: Codable, Sendable {
-        private enum CodingKeys: String, CodingKey {
-            case kind = "type"
-            case details
-            case member
-        }
-
         /// The kind of membership.
-        public let kind: String
+        public let type: MembershipType
         /// The details of the membership.
         public let details: JSON?
         /// The member.
         public let member: Member
+    }
+
+    enum MembershipType: String, Sendable, Codable {
+        case activeMember = "active_member"
+        case pendingMember = "pending_member"
+        case invitedMember = "invited_member"
+        case eligibleToJoinByEmailDomain = "eligible_to_join_by_email_domain"
+        case eligibleToJoinByOauthTenant = "eligible_to_join_by_oauth_tenant"
     }
 
     struct SCIMActiveConnection: Codable, Sendable, Equatable {

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+MagicLinks.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+MagicLinks.swift
@@ -62,7 +62,7 @@ public extension StytchB2BClient {
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// The Authenticate Discovery Magic Link method wraps the [authenticate](https://stytch.com/docs/b2b/api/send-discovery-email) discovery magic link API endpoint, which validates the discovery magic link token passed in.
-        public func discoveryAuthenticate(parameters: DiscoveryAuthenticateParameters) async throws -> DiscoveryAuthenticateResponse {
+        public func discoveryAuthenticate(parameters: DiscoveryAuthenticateParameters) async throws -> StytchB2BClient.DiscoveryAuthenticateResponse {
             defer {
                 try? pkcePairManager.clearPKCECodePair()
             }
@@ -186,13 +186,13 @@ public extension StytchB2BClient.MagicLinks.Email {
         /**
          Initializes the parameters struct
          - Parameters:
-           - organizationId: The ID of the intended organization.
-           - emailAddress: The email of the member to send the invite magic link to.
-           - loginRedirectUrl: The url the member clicks from the login email magic link. This should be a url that your app receives and parses and subsequently send an API request to authenticate the magic link and log in the user. If this value is not passed, the default login redirect URL that you set in your Dashboard is used. If you have not set a default login redirect URL, an error is returned.
-           - signupRedirectUrl: The url the member clicks from the sign-up email magic link. This should be a url that your app receives and parses and subsequently send an api request to authenticate the magic link and sign-up the user. If this value is not passed, the default sign-up redirect URL that you set in your Dashboard is used. If you have not set a default sign-up redirect URL, an error is returned.
-           - loginTemplateId: Use a custom template for login emails. Your default email template will be used if omitted. The template must be a template using our built-in customizations or a custom HTML email for Magic links - Login.
-           - signupTemplateId: Use a custom template for sign-up emails. Your default email template will be used if omitted. The template must be a template using our built-in customizations or a custom HTML email for Magic links - Sign-up.
-           - locale: Used to determine which language to use when sending the user this delivery method. Parameter is a IETF BCP 47 language tag, e.g. "en". Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
+         - organizationId: The ID of the intended organization.
+         - emailAddress: The email of the member to send the invite magic link to.
+         - loginRedirectUrl: The url the member clicks from the login email magic link. This should be a url that your app receives and parses and subsequently send an API request to authenticate the magic link and log in the user. If this value is not passed, the default login redirect URL that you set in your Dashboard is used. If you have not set a default login redirect URL, an error is returned.
+         - signupRedirectUrl: The url the member clicks from the sign-up email magic link. This should be a url that your app receives and parses and subsequently send an api request to authenticate the magic link and sign-up the user. If this value is not passed, the default sign-up redirect URL that you set in your Dashboard is used. If you have not set a default sign-up redirect URL, an error is returned.
+         - loginTemplateId: Use a custom template for login emails. Your default email template will be used if omitted. The template must be a template using our built-in customizations or a custom HTML email for Magic links - Login.
+         - signupTemplateId: Use a custom template for sign-up emails. Your default email template will be used if omitted. The template must be a template using our built-in customizations or a custom HTML email for Magic links - Sign-up.
+         - locale: Used to determine which language to use when sending the user this delivery method. Parameter is a IETF BCP 47 language tag, e.g. "en". Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
          */
         public init(
             organizationId: Organization.ID,
@@ -273,20 +273,5 @@ public extension StytchB2BClient.MagicLinks.Email {
             self.locale = locale
             self.roles = roles
         }
-    }
-}
-
-public extension StytchB2BClient.MagicLinks {
-    /// The response type for discovery authentciate calls.
-    typealias DiscoveryAuthenticateResponse = Response<DiscoveryAuthenticateResponseData>
-
-    /// The underlying data for the DiscoveryAuthenticateResponse type.
-    struct DiscoveryAuthenticateResponseData: DiscoveryIntermediateSessionTokenDataType, Codable, Sendable {
-        /// The discovered organizations.
-        public let discoveredOrganizations: [StytchB2BClient.DiscoveredOrganization]
-        /// The intermediate session token.
-        public let intermediateSessionToken: String
-        /// The member's email address.
-        public let emailAddress: String
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
@@ -153,7 +153,7 @@ public extension StytchB2BClient.OAuth.ThirdParty {
 }
 
 public extension StytchB2BClient.OAuth.ThirdParty.Provider {
-    var client: ThirdPartyB2BOAuthProviderProtocol {
+    var client: StytchB2BClient.OAuth.ThirdParty {
         switch self {
         case .google:
             return StytchB2BClient.oauth.google

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -77,10 +77,9 @@ public extension StytchB2BClient {
 
     /// Wrapper around the possible types returned from the `handle(url:sessionDuration:)` function.
     enum DeeplinkResponse: Sendable {
-        case auth(B2BAuthenticateResponse)
         case mfauth(B2BMFAAuthenticateResponse)
         case mfaOAuth(StytchB2BClient.OAuth.OAuthAuthenticateResponse)
-        case discovery(StytchB2BClient.MagicLinks.DiscoveryAuthenticateResponse)
+        case discovery(StytchB2BClient.DiscoveryAuthenticateResponse)
         #if !os(watchOS)
         case discoveryOauth(StytchB2BClient.DiscoveryAuthenticateResponse)
         #endif

--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
@@ -132,7 +132,7 @@ public extension StytchClient.OAuth.ThirdParty {
 }
 
 public extension StytchClient.OAuth.ThirdParty.Provider {
-    var client: ThirdPartyOAuthProviderProtocol {
+    var client: StytchClient.OAuth.ThirdParty {
         switch self {
         case .amazon:
             return StytchClient.oauth.amazon

--- a/Sources/StytchUI/Components/Button.swift
+++ b/Sources/StytchUI/Components/Button.swift
@@ -127,4 +127,38 @@ extension Button {
         button.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
         return button
     }
+
+    static func createTextButton(
+        withPlainText plainText: String,
+        boldText: String? = nil,
+        fontSize: CGFloat = 16,
+        action: Selector,
+        target: Any
+    ) -> Button {
+        // Create the button
+        let button = Button(type: .system)
+
+        // Create attributed text
+        let attributedText = NSMutableAttributedString(string: plainText, attributes: [
+            .font: UIFont.systemFont(ofSize: fontSize),
+            .foregroundColor: UIColor.black,
+        ])
+
+        // If boldText is provided, append it with bold style
+        if let boldText = boldText {
+            let boldAttributedText = NSAttributedString(string: " \(boldText)", attributes: [
+                .font: UIFont.boldSystemFont(ofSize: fontSize),
+                .foregroundColor: UIColor.black,
+            ])
+            attributedText.append(boldAttributedText)
+        }
+
+        // Set the attributed title to the button
+        button.setAttributedTitle(attributedText, for: .normal)
+
+        // Add the action to the button
+        button.addTarget(target, action: action, for: .touchUpInside)
+
+        return button
+    }
 }

--- a/Sources/StytchUI/Components/OTPCodeEntryView.swift
+++ b/Sources/StytchUI/Components/OTPCodeEntryView.swift
@@ -1,0 +1,101 @@
+import UIKit
+
+protocol OTPCodeEntryViewDelegate: AnyObject {
+    /// Called when the user has entered all 6 digits
+    func didEnterOTPCode(_ code: String)
+}
+
+class OTPCodeEntryView: UIView, UITextFieldDelegate {
+    weak var delegate: OTPCodeEntryViewDelegate?
+
+    private let hiddenTextField = UITextField()
+    private var digitLabels: [UILabel] = []
+    private let numberOfBoxes = 6
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+
+    private func setupUI() {
+        // Configure hidden text field
+        hiddenTextField.keyboardType = .numberPad
+        hiddenTextField.delegate = self
+        hiddenTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
+        addSubview(hiddenTextField)
+
+        // Create a stack view for digit boxes
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
+        stackView.spacing = 8
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        for _ in 0..<numberOfBoxes {
+            let label = UILabel()
+            label.textAlignment = .center
+            label.layer.borderWidth = 1
+            label.layer.borderColor = UIColor.gray.cgColor
+            label.font = UIFont.systemFont(ofSize: 24)
+            label.text = ""
+            label.layer.cornerRadius = 8
+            label.clipsToBounds = true
+            digitLabels.append(label)
+            stackView.addArrangedSubview(label)
+        }
+
+        addSubview(stackView)
+
+        // Constraints for the stack view
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        // Add tap gesture to bring up the keyboard
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(startEditing))
+        addGestureRecognizer(tapGesture)
+    }
+
+    @objc private func startEditing() {
+        hiddenTextField.becomeFirstResponder()
+    }
+
+    @objc private func textFieldDidChange() {
+        guard let text = hiddenTextField.text, text.count <= numberOfBoxes else {
+            hiddenTextField.text = String(hiddenTextField.text?.prefix(numberOfBoxes) ?? "")
+            return
+        }
+
+        // Update each label with the corresponding digit
+        for boxIndex in 0..<numberOfBoxes {
+            if boxIndex < text.count {
+                let index = text.index(text.startIndex, offsetBy: boxIndex)
+                digitLabels[boxIndex].text = String(text[index])
+            } else {
+                digitLabels[boxIndex].text = ""
+            }
+        }
+
+        // Notify delegate when all digits are entered
+        if text.count == numberOfBoxes {
+            delegate?.didEnterOTPCode(text)
+            hiddenTextField.resignFirstResponder()
+        }
+    }
+
+    /// Clears all entered digits
+    func clear() {
+        hiddenTextField.text = ""
+        for label in digitLabels {
+            label.text = ""
+        }
+    }
+}

--- a/Sources/StytchUI/Extensions/UILabel+StytchUI.swift
+++ b/Sources/StytchUI/Extensions/UILabel+StytchUI.swift
@@ -9,4 +9,52 @@ extension UILabel {
         label.textColor = .primaryText
         return label
     }
+
+    static func makeSubtitleLabel(text: String? = nil) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.numberOfLines = 0
+        label.font = .systemFont(ofSize: 18, weight: .semibold)
+        label.textColor = .secondaryText
+        return label
+    }
+
+    static func makeFooterLabel(text: String? = nil) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.numberOfLines = 0
+        label.font = .systemFont(ofSize: 14, weight: .regular)
+        label.textColor = .secondaryText
+        return label
+    }
+
+    static func makeComboLabel(
+        withPlainText plainText: String,
+        boldText: String? = nil,
+        fontSize: CGFloat = 16,
+        alignment: NSTextAlignment = .left
+    ) -> UILabel {
+        // Create the label
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.textAlignment = alignment
+
+        // Create attributed text
+        let attributedText = NSMutableAttributedString(string: plainText, attributes: [
+            .font: UIFont.systemFont(ofSize: fontSize),
+        ])
+
+        // If boldText is provided, append it with bold style
+        if let boldText = boldText {
+            let boldAttributedText = NSAttributedString(string: " \(boldText)", attributes: [
+                .font: UIFont.boldSystemFont(ofSize: fontSize),
+            ])
+            attributedText.append(boldAttributedText)
+        }
+
+        // Set the attributed text to the label
+        label.attributedText = attributedText
+
+        return label
+    }
 }

--- a/Sources/StytchUI/Extensions/UIViewController+StytchUI.swift
+++ b/Sources/StytchUI/Extensions/UIViewController+StytchUI.swift
@@ -2,13 +2,16 @@ import StytchCore
 import UIKit
 
 extension UIViewController {
-    func presentAlert(error: Error) {
+    func presentErrorAlert(error: Error) {
+        presentAlert(
+            title: NSLocalizedString("stytch.vcErrorTitle", value: "Error", comment: ""),
+            message: (error as? StytchError)?.message ?? error.localizedDescription
+        )
+    }
+
+    func presentAlert(title: String?, message: String?) {
         Task { @MainActor in
-            let alertController = UIAlertController(
-                title: NSLocalizedString("stytch.vcErrorTitle", value: "Error", comment: ""),
-                message: (error as? StytchError)?.message ?? error.localizedDescription,
-                preferredStyle: .alert
-            )
+            let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
             alertController.view.tintColor = .primaryText
             alertController.addAction(.init(title: NSLocalizedString("stytch.vcOK", value: "OK", comment: ""), style: .default))
             present(alertController, animated: true)

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/AuthenticationOperations.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/AuthenticationOperations.swift
@@ -60,4 +60,19 @@ struct AuthenticationOperations {
         )
         _ = try await StytchB2BClient.magicLinks.email.loginOrSignup(parameters: parameters)
     }
+
+    static func createTOTP() async throws -> String {
+        guard let organizationId = OrganizationManager.organizationId else {
+            throw StytchSDKError.noOrganziationId
+        }
+
+        guard let memberId = MemberManager.memberId else {
+            throw StytchSDKError.noMemberId
+        }
+
+        let parameters = StytchB2BClient.TOTP.CreateParameters(organizationId: organizationId, memberId: memberId, expirationMinutes: 30)
+        let response = try await StytchB2BClient.totp.create(parameters: parameters)
+        B2BAuthenticationManager.updateTotpState(totpResponse: response.wrapped)
+        return response.wrapped.secret
+    }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/B2BAuthenticationManager.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/B2BAuthenticationManager.swift
@@ -16,7 +16,8 @@ enum B2BAuthenticationManager {
 
     static func handleMFAReponse(b2bMFAAuthenticateResponse: B2BMFAAuthenticateResponseDataType) {
         Self.b2bMFAAuthenticateResponse = b2bMFAAuthenticateResponse
-        OrganizationManager.updateOrganization(newOrganization: b2bMFAAuthenticateResponse.organization)
+        OrganizationManager.updateOrganization(b2bMFAAuthenticateResponse.organization)
+        MemberManager.updateMember(b2bMFAAuthenticateResponse.member)
     }
 
     static func handleSecondaryReponse(b2bAuthenticateResponse: B2BAuthenticateResponseDataType) {
@@ -33,35 +34,5 @@ enum B2BAuthenticationManager {
         secret = nil
         recoveryCodes = nil
         didSaveRecoveryCodes = false
-    }
-}
-
-extension BaseViewController {
-    func startMFAFlowIfNeeded(configuration: StytchB2BUIClient.Configuration) {
-        var viewController: UIViewController?
-
-        let b2bMFAAuthenticateResponse = B2BAuthenticationManager.b2bMFAAuthenticateResponse
-
-        if b2bMFAAuthenticateResponse?.primaryRequired != nil {
-            viewController = B2BAuthHomeViewController(state: .init(configuration: configuration))
-        } else if b2bMFAAuthenticateResponse?.member.mfaEnrolled == true {
-            if b2bMFAAuthenticateResponse?.mfaRequired?.memberOptions?.mfaPhoneNumber != nil {
-                viewController = SMSOTPEntryViewController(state: .init(configuration: configuration))
-            } else if b2bMFAAuthenticateResponse?.mfaRequired?.memberOptions?.totpRegistrationId == nil {
-                viewController = TOTPEntryViewController(state: .init(configuration: configuration))
-            }
-        } else {
-            if b2bMFAAuthenticateResponse?.organization.allMFAMethodsAllowed == true {
-                viewController = MFAEnrollmentSelectionViewController(state: .init(configuration: configuration))
-            } else if b2bMFAAuthenticateResponse?.organization.usesSMSMFAOnly == true {
-                viewController = SMSOTPEnrollmentViewController(state: .init(configuration: configuration))
-            } else if b2bMFAAuthenticateResponse?.organization.usesTOTPMFAOnly == true {
-                viewController = TOTPEnrollmentViewController(state: .init(configuration: configuration))
-            }
-        }
-
-        if let viewController {
-            navigationController?.pushViewController(viewController, animated: true)
-        }
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/B2BPasswordsViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/B2BPasswordsViewModel.swift
@@ -22,6 +22,8 @@ final class B2BPasswordsViewModel {
         emailAddress: String,
         password: String
     ) {
+        MemberManager.updateMemberEmailAddress(emailAddress)
+
         guard let organizationId = OrganizationManager.organizationId else {
             delegate?.didError(error: StytchSDKError.noOrganziationId)
             return

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController+MFA.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController+MFA.swift
@@ -1,0 +1,57 @@
+import Foundation
+import StytchCore
+import UIKit
+
+extension BaseViewController {
+    func startMFAFlowIfNeeded(configuration: StytchB2BUIClient.Configuration) {
+        var viewController: UIViewController?
+
+        let b2bMFAAuthenticateResponse = B2BAuthenticationManager.b2bMFAAuthenticateResponse
+
+        if b2bMFAAuthenticateResponse?.primaryRequired != nil {
+            viewController = B2BAuthHomeViewController(state: .init(configuration: configuration))
+        } else if b2bMFAAuthenticateResponse?.member.mfaEnrolled == true {
+            if b2bMFAAuthenticateResponse?.mfaRequired?.memberOptions?.mfaPhoneNumber != nil {
+                viewController = SMSOTPEntryViewController(state: .init(configuration: configuration))
+            } else if b2bMFAAuthenticateResponse?.mfaRequired?.memberOptions?.totpRegistrationId == nil {
+                viewController = TOTPEntryViewController(state: .init(configuration: configuration))
+            }
+        } else {
+            if b2bMFAAuthenticateResponse?.organization.allMFAMethodsAllowed == true {
+                viewController = MFAEnrollmentSelectionViewController(state: .init(configuration: configuration))
+            } else if b2bMFAAuthenticateResponse?.organization.usesSMSMFAOnly == true {
+                handleSMSOTPEnrollment(configuration: configuration)
+            } else if b2bMFAAuthenticateResponse?.organization.usesTOTPMFAOnly == true {
+                handleTOTPEnrollment(configuration: configuration)
+            }
+        }
+
+        if let viewController {
+            navigationController?.pushViewController(viewController, animated: true)
+        }
+    }
+}
+
+extension BaseViewController {
+    func handleTOTPEnrollment(configuration: StytchB2BUIClient.Configuration) {
+        Task { [weak self] in
+            do {
+                let secret = try await AuthenticationOperations.createTOTP()
+                self?.showTOTPEnrollment(configuration: configuration, secret: secret)
+            } catch {
+                self?.presentErrorAlert(error: error)
+            }
+        }
+    }
+
+    func showTOTPEnrollment(configuration: StytchB2BUIClient.Configuration, secret: String) {
+        let state = TOTPEnrollmentState(configuration: configuration, secret: secret)
+        Task { @MainActor in
+            navigationController?.pushViewController(TOTPEnrollmentViewController(state: state), animated: true)
+        }
+    }
+}
+
+extension BaseViewController {
+    func handleSMSOTPEnrollment(configuration _: StytchB2BUIClient.Configuration) {}
+}

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/DiscoveryManager.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/DiscoveryManager.swift
@@ -1,0 +1,82 @@
+import StytchCore
+
+struct DiscoveryManager {
+    static var discoveredOrganizations: [StytchB2BClient.DiscoveredOrganization] = []
+
+    static func updateDiscoveredOrganizations(newDiscoveredOrganizations: [StytchB2BClient.DiscoveredOrganization]) {
+        discoveredOrganizations = newDiscoveredOrganizations
+    }
+
+    static func selectDiscoveredOrganization(configuration: StytchB2BUIClient.Configuration, discoveredOrganization: StytchB2BClient.DiscoveredOrganization) async throws {
+        let response = try await StytchB2BClient.discovery.exchangeIntermediateSession(
+            parameters: .init(
+                organizationId: discoveredOrganization.organization.organizationId,
+                sessionDuration: configuration.sessionDurationMinutes
+            )
+        )
+        B2BAuthenticationManager.handleMFAReponse(b2bMFAAuthenticateResponse: response)
+    }
+
+    static func reset() {
+        discoveredOrganizations = []
+    }
+}
+
+extension BaseViewController {
+    func startDiscoveryFlowIfNeeded(configuration: StytchB2BUIClient.Configuration) {
+        let discoveredOrganizations = DiscoveryManager.discoveredOrganizations
+        if let singleDiscoveredOrganization = discoveredOrganizations.shouldAllowDirectLoginToOrganization(configuration.directLoginForSingleMembershipOptions) {
+            selectDiscoveredOrganization(configuration: configuration, discoveredOrganization: singleDiscoveredOrganization)
+        } else {
+            let discoveryViewController = DiscoveryViewController(state: .init(configuration: configuration))
+            navigationController?.pushViewController(discoveryViewController, animated: true)
+        }
+    }
+
+    func selectDiscoveredOrganization(configuration: StytchB2BUIClient.Configuration, discoveredOrganization: StytchB2BClient.DiscoveredOrganization) {
+        Task {
+            do {
+                try await DiscoveryManager.selectDiscoveredOrganization(
+                    configuration: configuration,
+                    discoveredOrganization: discoveredOrganization
+                )
+                Task { @MainActor in
+                    startMFAFlowIfNeeded(configuration: configuration)
+                }
+            } catch {
+                presentErrorAlert(error: error)
+            }
+        }
+    }
+}
+
+// Determine if a single discovered organization exsists
+extension Array where Element == StytchB2BClient.DiscoveredOrganization {
+    func shouldAllowDirectLoginToOrganization(_ directLoginForSingleMembershipOptions: StytchB2BUIClient.DirectLoginForSingleMembershipOptions? = nil) -> StytchB2BClient.DiscoveredOrganization? {
+        let invitedTypes: [StytchB2BClient.MembershipType] = [.pendingMember, .invitedMember]
+        let jitEligible: [StytchB2BClient.MembershipType] = [.eligibleToJoinByEmailDomain, .eligibleToJoinByOauthTenant]
+
+        // If direct login is not enabled, return nil
+        guard let directLoginForSingleMembershipOptions = directLoginForSingleMembershipOptions else {
+            return nil
+        }
+
+        // Count active memberships
+        let activeOrganizations = filter { org in
+            org.membership.type == .activeMember
+        }
+
+        // Check for pending invites or JIT provisioning, depending on config
+        let hasBlockingConditions = contains { org in
+            (invitedTypes.contains(org.membership.type) && !directLoginForSingleMembershipOptions.ignoreInvites) ||
+                (jitEligible.contains(org.membership.type) && !directLoginForSingleMembershipOptions.ignoreJitProvisioning)
+        }
+
+        // Allow direct login if there is exactly one active membership and no blocking conditions
+        if activeOrganizations.count == 1, !hasBlockingConditions {
+            return activeOrganizations[0]
+        }
+
+        return nil
+    }
+}

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/MemberManager.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/MemberManager.swift
@@ -1,0 +1,45 @@
+import StytchCore
+
+struct MemberManager {
+    static var member: Member?
+    fileprivate static var _emailAddress: String?
+    fileprivate static var _phoneNumber: String?
+
+    static var memberId: String? {
+        member?.id.rawValue
+    }
+
+    static var emailAddress: String? {
+        if let memberEmailAddress = member?.emailAddress {
+            return memberEmailAddress
+        } else {
+            return _emailAddress
+        }
+    }
+
+    static var phoneNumber: String? {
+        if let memberPhoneNumber = member?.mfaPhoneNumber {
+            return memberPhoneNumber
+        } else {
+            return _phoneNumber
+        }
+    }
+
+    static func updateMember(_ member: Member) {
+        self.member = member
+    }
+
+    static func updateMemberEmailAddress(_ emailAddress: String) {
+        _emailAddress = emailAddress
+    }
+
+    static func updateMemberPhoneNumber(_ phoneNumber: String) {
+        _phoneNumber = phoneNumber
+    }
+
+    static func reset() {
+        member = nil
+        _emailAddress = nil
+        _phoneNumber = nil
+    }
+}

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/OrganizationManager.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/OrganizationManager.swift
@@ -41,7 +41,11 @@ struct OrganizationManager {
         organization = response.organization
     }
 
-    static func updateOrganization(newOrganization: Organization) {
+    static func updateOrganization(_ newOrganization: Organization) {
         organization = newOrganization
+    }
+
+    static func reset() {
+        organization = nil
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient+Configuration.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient+Configuration.swift
@@ -17,7 +17,7 @@ public extension StytchB2BUIClient {
         public let passwordOptions: B2BPasswordOptions?
         public let oauthProviders: [B2BOAuthProviderOptions]
         public let emailOtpOptions: B2BEmailOTPOptions?
-        public let directLoginForSingleMembership: DirectLoginForSingleMembershipConfig?
+        public let directLoginForSingleMembershipOptions: DirectLoginForSingleMembershipOptions?
         public let disableCreateOrganization: Bool?
         public let mfaProductOrder: [B2BMFAProducts]?
         public let mfaProductInclude: [B2BMFAProducts]?
@@ -79,7 +79,7 @@ public extension StytchB2BUIClient {
             passwordOptions: B2BPasswordOptions? = nil,
             oauthProviders: [B2BOAuthProviderOptions] = [],
             emailOtpOptions: B2BEmailOTPOptions? = nil,
-            directLoginForSingleMembership: DirectLoginForSingleMembershipConfig? = nil,
+            directLoginForSingleMembershipOptions: DirectLoginForSingleMembershipOptions? = nil,
             disableCreateOrganization: Bool? = nil,
             mfaProductOrder: [B2BMFAProducts]? = nil,
             mfaProductInclude: [B2BMFAProducts]? = nil,
@@ -95,7 +95,7 @@ public extension StytchB2BUIClient {
             self.passwordOptions = passwordOptions
             self.oauthProviders = oauthProviders
             self.emailOtpOptions = emailOtpOptions
-            self.directLoginForSingleMembership = directLoginForSingleMembership
+            self.directLoginForSingleMembershipOptions = directLoginForSingleMembershipOptions
             self.disableCreateOrganization = disableCreateOrganization
             self.mfaProductOrder = mfaProductOrder
             self.mfaProductInclude = mfaProductInclude
@@ -168,7 +168,7 @@ public extension StytchB2BUIClient {
         }
     }
 
-    struct DirectLoginForSingleMembershipConfig: Codable {
+    struct DirectLoginForSingleMembershipOptions: Codable {
         public let status: Bool
         public let ignoreInvites: Bool
         public let ignoreJitProvisioning: Bool

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BAuthHomeViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BAuthHomeViewController.swift
@@ -137,7 +137,7 @@ final class B2BAuthHomeViewController: BaseViewController<B2BAuthHomeState, B2BA
 
     func showEmaiilConfirmation() {
         Task { @MainActor in
-            let emailConfirmationViewController = EmailConfirmationViewController(state: .init(configuration: viewModel.state.configuration))
+            let emailConfirmationViewController = EmailConfirmationViewController(state: .init(configuration: viewModel.state.configuration, type: .emailConfirmation))
             navigationController?.pushViewController(emailConfirmationViewController, animated: true)
         }
     }
@@ -146,6 +146,10 @@ final class B2BAuthHomeViewController: BaseViewController<B2BAuthHomeState, B2BA
 extension B2BAuthHomeViewController: B2BOAuthViewControllerDelegate {
     func oauthDidAuthenticatie() {
         continueAuthenticationFlowIfNeeded()
+    }
+
+    func oauthDiscoveryDidAuthenticatie() {
+        startDiscoveryFlowIfNeeded(configuration: viewModel.state.configuration)
     }
 }
 

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BEmailMagicLinksViewController/B2BEmailMagicLinksViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BEmailMagicLinksViewController/B2BEmailMagicLinksViewController.swift
@@ -84,7 +84,7 @@ final class B2BEmailMagicLinksViewController: BaseViewController<B2BEmailMagicLi
         if let emailAddress = emailInput.text {
             viewModel.sendEmailMagicLink(emailAddress: emailAddress) { [weak self] error in
                 if let error {
-                    self?.presentAlert(error: error)
+                    self?.presentErrorAlert(error: error)
                 } else {
                     self?.delegate?.emailMagicLinkSent()
                 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BPasswordsHomeViewController/B2BPasswordsHomeViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BPasswordsHomeViewController/B2BPasswordsHomeViewController.swift
@@ -103,6 +103,6 @@ extension B2BPasswordsHomeViewController: B2BPasswordsViewModelDelegate {
     }
 
     func didError(error: any Error) {
-        presentAlert(error: error)
+        presentErrorAlert(error: error)
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BSSOViewController/B2BSSOViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BSSOViewController/B2BSSOViewController.swift
@@ -46,7 +46,7 @@ final class B2BSSOViewController: BaseViewController<SSOState, SSOViewModel> {
                 delegate?.ssoDidAuthenticatie()
             } catch {
                 try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
-                presentAlert(error: error)
+                presentErrorAlert(error: error)
             }
         }
     }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
@@ -77,4 +77,8 @@ final class B2BAuthRootViewController: UIViewController {
     func startMfaFlowIfNeeded() {
         homeController?.startMFAFlowIfNeeded(configuration: configuration)
     }
+
+    func startDiscoveryFlowIfNeeded() {
+        homeController?.startDiscoveryFlowIfNeeded(configuration: configuration)
+    }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/DiscoveryViewController/DiscoveredOrganizationTableViewCell.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/DiscoveryViewController/DiscoveredOrganizationTableViewCell.swift
@@ -1,0 +1,83 @@
+import StytchCore
+import UIKit
+
+class DiscoveredOrganizationTableViewCell: UITableViewCell {
+    private let iconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        imageView.layer.cornerRadius = 16 // Assuming it's a circular icon
+        imageView.clipsToBounds = true
+        imageView.backgroundColor = .systemGray // Placeholder background color
+        return imageView
+    }()
+
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: 16)
+        label.textColor = .black
+        return label
+    }()
+
+    private let joinLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "Join"
+        label.font = UIFont.systemFont(ofSize: 16)
+        label.textColor = .systemBlue
+        return label
+    }()
+
+    private let disclosureImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        imageView.image = UIImage(systemName: "chevron.right")
+        imageView.tintColor = .gray
+        return imageView
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        // Add subviews
+        contentView.addSubview(iconImageView)
+        contentView.addSubview(descriptionLabel)
+        contentView.addSubview(joinLabel)
+        contentView.addSubview(disclosureImageView)
+
+        // Add constraints
+        NSLayoutConstraint.activate([
+            // Icon ImageView
+            iconImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 0),
+            iconImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            iconImageView.widthAnchor.constraint(equalToConstant: 32),
+            iconImageView.heightAnchor.constraint(equalToConstant: 32),
+
+            // Description Label
+            descriptionLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 16),
+            descriptionLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            // Join Label
+            joinLabel.trailingAnchor.constraint(equalTo: disclosureImageView.leadingAnchor, constant: -8),
+            joinLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            // Disclosure Indicator
+            disclosureImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            disclosureImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            disclosureImageView.widthAnchor.constraint(equalToConstant: 12),
+            disclosureImageView.heightAnchor.constraint(equalToConstant: 12),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with discoveredOrganization: StytchB2BClient.DiscoveredOrganization, image: UIImage?) {
+        descriptionLabel.text = discoveredOrganization.organization.name
+        iconImageView.image = image // Set image for the icon
+    }
+}

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/DiscoveryViewController/DiscoveredOrganizationsViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/DiscoveryViewController/DiscoveredOrganizationsViewController.swift
@@ -1,0 +1,72 @@
+import StytchCore
+import UIKit
+
+protocol DiscoveredOrganizationsViewControllerDelegate: AnyObject {
+    func didSelectDiscoveredOrganization(discoveredOrganization: StytchB2BClient.DiscoveredOrganization)
+}
+
+class DiscoveredOrganizationsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+    private let tableView = UITableView()
+    private let discoveredOrganizations: [StytchB2BClient.DiscoveredOrganization]
+    weak var delegate: DiscoveredOrganizationsViewControllerDelegate?
+
+    init(discoveredOrganizations: [StytchB2BClient.DiscoveredOrganization]) {
+        self.discoveredOrganizations = discoveredOrganizations
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(tableView)
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+        ])
+
+        tableView.register(DiscoveredOrganizationTableViewCell.self, forCellReuseIdentifier: "DiscoveredOrganizationTableViewCell")
+        tableView.dataSource = self
+        tableView.delegate = self
+
+        tableView.separatorInset = UIEdgeInsets.zero
+        tableView.layoutMargins = UIEdgeInsets.zero
+        tableView.cellLayoutMarginsFollowReadableWidth = false
+    }
+
+    func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
+        discoveredOrganizations.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "DiscoveredOrganizationTableViewCell", for: indexPath) as? DiscoveredOrganizationTableViewCell else {
+            return UITableViewCell()
+        }
+
+        cell.separatorInset = UIEdgeInsets.zero
+        cell.layoutMargins = UIEdgeInsets.zero
+
+        let discoveredOrganization = discoveredOrganizations[indexPath.row]
+        cell.configure(with: discoveredOrganization, image: nil)
+        return cell
+    }
+
+    func tableView(_: UITableView, heightForRowAt _: IndexPath) -> CGFloat {
+        60.0
+    }
+
+    func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let discoveredOrganization = discoveredOrganizations[indexPath.row]
+        delegate?.didSelectDiscoveredOrganization(discoveredOrganization: discoveredOrganization)
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+}

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/DiscoveryViewController/DiscoveryViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/DiscoveryViewController/DiscoveryViewController.swift
@@ -18,10 +18,22 @@ final class DiscoveryViewController: BaseViewController<DiscoveryState, Discover
 
         stackView.addArrangedSubview(titleLabel)
 
+        let discoveredOrganizationsViewController = DiscoveredOrganizationsViewController(discoveredOrganizations: DiscoveryManager.discoveredOrganizations)
+        discoveredOrganizationsViewController.delegate = self
+        addChild(discoveredOrganizationsViewController)
+        stackView.addArrangedSubview(discoveredOrganizationsViewController.view)
+        discoveredOrganizationsViewController.didMove(toParent: self)
+
         attachStackView(within: view)
 
         NSLayoutConstraint.activate(
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
+    }
+}
+
+extension DiscoveryViewController: DiscoveredOrganizationsViewControllerDelegate {
+    func didSelectDiscoveredOrganization(discoveredOrganization: StytchCore.StytchB2BClient.DiscoveredOrganization) {
+        selectDiscoveredOrganization(configuration: viewModel.state.configuration, discoveredOrganization: discoveredOrganization)
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailConfirmationViewController/EmailConfirmationViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailConfirmationViewController/EmailConfirmationViewController.swift
@@ -3,10 +3,6 @@ import StytchCore
 import UIKit
 
 final class EmailConfirmationViewController: BaseViewController<EmailConfirmationState, EmailConfirmationViewModel> {
-    private let titleLabel: UILabel = .makeTitleLabel(
-        text: NSLocalizedString("stytchEmailConfirmationTitle", value: "Check your email!", comment: "")
-    )
-
     init(state: EmailConfirmationState) {
         super.init(viewModel: EmailConfirmationViewModel(state: state))
     }
@@ -16,12 +12,43 @@ final class EmailConfirmationViewController: BaseViewController<EmailConfirmatio
 
         stackView.spacing = .spacingRegular
 
+        let titleLabel: UILabel = .makeTitleLabel(text: viewModel.title)
         stackView.addArrangedSubview(titleLabel)
+
+        let emailConfirmationLabel = UILabel.makeComboLabel(
+            withPlainText: viewModel.message,
+            boldText: MemberManager.emailAddress,
+            fontSize: 18,
+            alignment: .left
+        )
+        stackView.addArrangedSubview(emailConfirmationLabel)
+
+        let tryAgainButton = Button.createTextButton(
+            withPlainText: viewModel.primarySubtext,
+            boldText: viewModel.secondaryBoldSubtext,
+            action: #selector(buttonTapped),
+            target: self
+        )
+        tryAgainButton.contentHorizontalAlignment = .leading
+        stackView.addArrangedSubview(tryAgainButton)
+
+        stackView.addArrangedSubview(SpacerView())
 
         attachStackView(within: view)
 
         NSLayoutConstraint.activate(
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
+    }
+
+    @objc func buttonTapped() {
+        switch viewModel.state.type {
+        case .emailConfirmation:
+            navigationController?.popToRootViewController(animated: true)
+        case .passwordSetNew:
+            break
+        case .passwordResetVerify:
+            break
+        }
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailConfirmationViewController/EmailConfirmationViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailConfirmationViewController/EmailConfirmationViewModel.swift
@@ -10,6 +10,59 @@ final class EmailConfirmationViewModel {
     }
 }
 
+extension EmailConfirmationViewModel {
+    var title: String {
+        switch state.type {
+        case .emailConfirmation:
+            return "Check your email"
+        case .passwordSetNew:
+            return "Check your email!"
+        case .passwordResetVerify:
+            return "Please verify your email"
+        }
+    }
+
+    var message: String {
+        switch state.type {
+        case .emailConfirmation:
+            return "An email was sent to"
+        case .passwordSetNew:
+            return "A login link was sent to you at"
+        case .passwordResetVerify:
+            return "A login link was sent to you at"
+        }
+    }
+
+    var primarySubtext: String {
+        switch state.type {
+        case .emailConfirmation:
+            return "Didn’t get it?"
+        case .passwordSetNew:
+            return "Didn't get it?"
+        case .passwordResetVerify:
+            return "Didn't get it?"
+        }
+    }
+
+    var secondaryBoldSubtext: String {
+        switch state.type {
+        case .emailConfirmation:
+            return "Try Again"
+        case .passwordSetNew:
+            return "Resend email"
+        case .passwordResetVerify:
+            return "Resend email"
+        }
+    }
+}
+
 struct EmailConfirmationState {
     let configuration: StytchB2BUIClient.Configuration
+    let type: EmailConfirmationType
+}
+
+enum EmailConfirmationType {
+    case emailConfirmation
+    case passwordSetNew
+    case passwordResetVerify
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAEnrollmentSelectionTableViewCell.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAEnrollmentSelectionTableViewCell.swift
@@ -1,0 +1,55 @@
+import StytchCore
+import UIKit
+
+class MFAEnrollmentSelectionTableViewCell: UITableViewCell {
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: 16)
+        label.textColor = .black
+        return label
+    }()
+
+    private let disclosureImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        imageView.image = UIImage(systemName: "chevron.right")
+        imageView.tintColor = .gray
+        return imageView
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        // Add subviews
+        contentView.addSubview(descriptionLabel)
+        contentView.addSubview(disclosureImageView)
+
+        // Add constraints
+        NSLayoutConstraint.activate([
+            // Description Label
+            descriptionLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 0),
+            descriptionLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            // Disclosure Indicator
+            disclosureImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            disclosureImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            disclosureImageView.widthAnchor.constraint(equalToConstant: 12),
+            disclosureImageView.heightAnchor.constraint(equalToConstant: 12),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with mfaMethod: StytchB2BClient.MfaMethod, image _: UIImage?) {
+        if mfaMethod == .sms {
+            descriptionLabel.text = "Text me a code"
+        } else {
+            descriptionLabel.text = "Use an authenticator app"
+        }
+    }
+}

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAEnrollmentSelectionViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAEnrollmentSelectionViewController.swift
@@ -7,6 +7,10 @@ final class MFAEnrollmentSelectionViewController: BaseViewController<MFAEnrollme
         text: NSLocalizedString("stytchMfaEnrollmentTitle", value: "Set up Multi-Factor Authentication", comment: "")
     )
 
+    private let subtitleLabel: UILabel = .makeSubtitleLabel(
+        text: NSLocalizedString("stytchMfaEnrollmentSubtitle", value: "Add an additional form of verification to make your account more secure.", comment: "")
+    )
+
     init(state: MFAEnrollmentSelectionState) {
         super.init(viewModel: MFAEnrollmentSelectionViewModel(state: state))
     }
@@ -17,6 +21,13 @@ final class MFAEnrollmentSelectionViewController: BaseViewController<MFAEnrollme
         stackView.spacing = .spacingRegular
 
         stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(subtitleLabel)
+
+        let mfaMethodSelectionViewController = MFAMethodSelectionViewController(mfaMethods: [.sms, .totp])
+        mfaMethodSelectionViewController.delegate = self
+        addChild(mfaMethodSelectionViewController)
+        stackView.addArrangedSubview(mfaMethodSelectionViewController.view)
+        mfaMethodSelectionViewController.didMove(toParent: self)
 
         attachStackView(within: view)
 
@@ -24,12 +35,15 @@ final class MFAEnrollmentSelectionViewController: BaseViewController<MFAEnrollme
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
     }
+}
 
-    func showSMSOTPEnrollment() {
-        navigationController?.pushViewController(SMSOTPEnrollmentViewController(state: .init(configuration: viewModel.state.configuration)), animated: true)
-    }
-
-    func showTOTPEnrollment() {
-        navigationController?.pushViewController(TOTPEnrollmentViewController(state: .init(configuration: viewModel.state.configuration)), animated: true)
+extension MFAEnrollmentSelectionViewController: MFAMethodSelectionViewControllerDelegate {
+    func didSelectMFAMethod(mfaMethod: StytchCore.StytchB2BClient.MfaMethod) {
+        switch mfaMethod {
+        case .sms:
+            handleSMSOTPEnrollment(configuration: viewModel.state.configuration)
+        case .totp:
+            handleTOTPEnrollment(configuration: viewModel.state.configuration)
+        }
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAMethodSelectionViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAMethodSelectionViewController.swift
@@ -1,0 +1,72 @@
+import StytchCore
+import UIKit
+
+protocol MFAMethodSelectionViewControllerDelegate: AnyObject {
+    func didSelectMFAMethod(mfaMethod: StytchB2BClient.MfaMethod)
+}
+
+class MFAMethodSelectionViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+    private let tableView = UITableView()
+    private let mfaMethods: [StytchB2BClient.MfaMethod]
+    weak var delegate: MFAMethodSelectionViewControllerDelegate?
+
+    init(mfaMethods: [StytchB2BClient.MfaMethod]) {
+        self.mfaMethods = mfaMethods
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(tableView)
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+        ])
+
+        tableView.register(MFAEnrollmentSelectionTableViewCell.self, forCellReuseIdentifier: "MFAEnrollmentSelectionTableViewCell")
+        tableView.dataSource = self
+        tableView.delegate = self
+
+        tableView.separatorInset = UIEdgeInsets.zero
+        tableView.layoutMargins = UIEdgeInsets.zero
+        tableView.cellLayoutMarginsFollowReadableWidth = false
+    }
+
+    func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
+        mfaMethods.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "MFAEnrollmentSelectionTableViewCell", for: indexPath) as? MFAEnrollmentSelectionTableViewCell else {
+            return UITableViewCell()
+        }
+
+        cell.separatorInset = UIEdgeInsets.zero
+        cell.layoutMargins = UIEdgeInsets.zero
+
+        let mfaMethod = mfaMethods[indexPath.row]
+        cell.configure(with: mfaMethod, image: nil)
+        return cell
+    }
+
+    func tableView(_: UITableView, heightForRowAt _: IndexPath) -> CGFloat {
+        60.0
+    }
+
+    func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let mfaMethod = mfaMethods[indexPath.row]
+        delegate?.didSelectMFAMethod(mfaMethod: mfaMethod)
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+}

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordAuthenticateViewController/PasswordAuthenticateViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordAuthenticateViewController/PasswordAuthenticateViewController.swift
@@ -33,6 +33,6 @@ extension PasswordAuthenticateViewController: B2BPasswordsViewModelDelegate {
     func didSendEmailMagicLink() {}
 
     func didError(error: any Error) {
-        presentAlert(error: error)
+        presentErrorAlert(error: error)
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEntryViewController/SMSOTPEntryViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEntryViewController/SMSOTPEntryViewController.swift
@@ -17,6 +17,11 @@ final class SMSOTPEntryViewController: BaseViewController<SMSOTPEntryState, SMSO
         stackView.spacing = .spacingRegular
 
         stackView.addArrangedSubview(titleLabel)
+        let otpView = OTPCodeEntryView(frame: .zero)
+        otpView.delegate = self
+        stackView.addArrangedSubview(otpView)
+
+        stackView.addArrangedSubview(SpacerView())
 
         attachStackView(within: view)
 
@@ -24,4 +29,8 @@ final class SMSOTPEntryViewController: BaseViewController<SMSOTPEntryState, SMSO
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
     }
+}
+
+extension SMSOTPEntryViewController: OTPCodeEntryViewDelegate {
+    func didEnterOTPCode(_: String) {}
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPEnrollmentViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPEnrollmentViewController.swift
@@ -4,8 +4,18 @@ import UIKit
 
 final class TOTPEnrollmentViewController: BaseViewController<TOTPEnrollmentState, TOTPEnrollmentViewModel> {
     private let titleLabel: UILabel = .makeTitleLabel(
-        text: NSLocalizedString("stytchSMSOTPEnrollmentTitle", value: "Copy the code below to link your authenticator app", comment: "")
+        text: NSLocalizedString("stytchTOTPEnrollmentTitle", value: "Copy the code below to link your authenticator app", comment: "")
     )
+
+    private let subtitleLabel: UILabel = .makeSubtitleLabel(
+        text: NSLocalizedString("stytchTOTPEnrollmentSubtitle", value: "Enter the key below into your authenticator app. If you don’t have an authenticator app, you’ll need to install one first.", comment: "")
+    )
+
+    private lazy var continueButton: Button = .primary(
+        title: NSLocalizedString("stytch.pwContinueTitle", value: "Continue", comment: "")
+    ) { [weak self] in
+        self?.continueWithTOTP()
+    }
 
     init(state: TOTPEnrollmentState) {
         super.init(viewModel: TOTPEnrollmentViewModel(state: state))
@@ -17,11 +27,29 @@ final class TOTPEnrollmentViewController: BaseViewController<TOTPEnrollmentState
         stackView.spacing = .spacingRegular
 
         stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(subtitleLabel)
+
+        let totpSecretView = TOTPSecretView(secret: viewModel.state.secret)
+        totpSecretView.delegate = self
+        stackView.addArrangedSubview(totpSecretView)
+
+        stackView.addArrangedSubview(continueButton)
+        stackView.addArrangedSubview(SpacerView())
 
         attachStackView(within: view)
 
         NSLayoutConstraint.activate(
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
+    }
+
+    private func continueWithTOTP() {
+        navigationController?.pushViewController(TOTPEntryViewController(state: .init(configuration: viewModel.state.configuration)), animated: true)
+    }
+}
+
+extension TOTPEnrollmentViewController: TOTPSecretViewDelegate {
+    func didCopyTOTPSecret() {
+        presentAlert(title: "Secret Copied!", message: nil)
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPEnrollmentViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPEnrollmentViewModel.swift
@@ -12,4 +12,5 @@ final class TOTPEnrollmentViewModel {
 
 struct TOTPEnrollmentState {
     let configuration: StytchB2BUIClient.Configuration
+    let secret: String
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPSecretView.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPSecretView.swift
@@ -1,0 +1,76 @@
+import StytchCore
+import UIKit
+
+protocol TOTPSecretViewDelegate: AnyObject {
+    func didCopyTOTPSecret()
+}
+
+class TOTPSecretView: UIView {
+    weak var delegate: TOTPSecretViewDelegate?
+    private let textLabel = UILabel()
+    private let copyButton = UIButton(type: .system)
+
+    init(secret: String) {
+        super.init(frame: .zero)
+        setupView()
+        configure(with: secret)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    private func setupView() {
+        // Main container
+        let containerView = UIView()
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.backgroundColor = .systemGray6
+        containerView.layer.cornerRadius = 8
+        containerView.layer.borderWidth = 1
+        containerView.layer.borderColor = UIColor.systemGray4.cgColor
+        addSubview(containerView)
+
+        // Text label
+        textLabel.font = UIFont.monospacedSystemFont(ofSize: 16, weight: .regular)
+        textLabel.textColor = .label
+        textLabel.numberOfLines = 0
+        textLabel.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(textLabel)
+
+        // Copy button
+        copyButton.setImage(UIImage(systemName: "doc.on.doc"), for: .normal)
+        copyButton.tintColor = .systemGray
+        copyButton.translatesAutoresizingMaskIntoConstraints = false
+        copyButton.addTarget(self, action: #selector(copyToClipboard), for: .touchUpInside)
+        containerView.addSubview(copyButton)
+
+        // Layout constraints
+        NSLayoutConstraint.activate([
+            // Container view
+            containerView.topAnchor.constraint(equalTo: topAnchor),
+            containerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            containerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            containerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            containerView.heightAnchor.constraint(equalToConstant: 60),
+
+            // Text label
+            textLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 15),
+            textLabel.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+
+            // Copy button
+            copyButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -15),
+            copyButton.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+            copyButton.leadingAnchor.constraint(greaterThanOrEqualTo: textLabel.trailingAnchor, constant: 10),
+        ])
+    }
+
+    func configure(with secret: String) {
+        textLabel.text = secret
+    }
+
+    @objc private func copyToClipboard() {
+        UIPasteboard.general.string = textLabel.text
+        delegate?.didCopyTOTPSecret()
+    }
+}

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEntryViewController/TOTPEntryViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEntryViewController/TOTPEntryViewController.swift
@@ -7,6 +7,14 @@ final class TOTPEntryViewController: BaseViewController<TOTPEntryState, TOTPEntr
         text: NSLocalizedString("stytchTOTPEntryTitle", value: "Enter verification code", comment: "")
     )
 
+    private let subtitleLabel: UILabel = .makeSubtitleLabel(
+        text: NSLocalizedString("stytchTOTPEntrySubtitle", value: "Enter the 6-digit code from your authenticator app.", comment: "")
+    )
+
+    private let footerLabel: UILabel = .makeFooterLabel(
+        text: NSLocalizedString("stytchTOTPEntryFooter", value: "If the verification code doesn’t work, go back to your authenticator app to get a new code.", comment: "")
+    )
+
     init(state: TOTPEntryState) {
         super.init(viewModel: TOTPEntryViewModel(state: state))
     }
@@ -14,14 +22,44 @@ final class TOTPEntryViewController: BaseViewController<TOTPEntryState, TOTPEntr
     override func configureView() {
         super.configureView()
 
-        stackView.spacing = .spacingRegular
+        stackView.spacing = .spacingLarge
 
         stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(subtitleLabel)
+
+        let otpView = OTPCodeEntryView(frame: .zero)
+        otpView.delegate = self
+        stackView.addArrangedSubview(otpView)
+
+        stackView.addArrangedSubview(footerLabel)
+
+        stackView.addArrangedSubview(SpacerView())
 
         attachStackView(within: view)
+
+        NSLayoutConstraint.activate([
+            otpView.heightAnchor.constraint(equalToConstant: 50),
+        ])
 
         NSLayoutConstraint.activate(
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
+    }
+
+    private func continueWithTOTP() {
+        navigationController?.pushViewController(RecoveryCodeSaveViewController(state: .init(configuration: viewModel.state.configuration)), animated: true)
+    }
+}
+
+extension TOTPEntryViewController: OTPCodeEntryViewDelegate {
+    func didEnterOTPCode(_ code: String) {
+        Task { [weak self] in
+            do {
+                try await self?.viewModel.authenticateTOTP(code: code)
+                self?.continueWithTOTP()
+            } catch {
+                self?.presentErrorAlert(error: error)
+            }
+        }
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEntryViewController/TOTPEntryViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEntryViewController/TOTPEntryViewModel.swift
@@ -8,6 +8,27 @@ final class TOTPEntryViewModel {
     ) {
         self.state = state
     }
+
+    func authenticateTOTP(code: String) async throws {
+        guard let organizationId = OrganizationManager.organizationId else {
+            throw StytchSDKError.noOrganziationId
+        }
+
+        guard let memberId = MemberManager.memberId else {
+            throw StytchSDKError.noMemberId
+        }
+
+        let parameters = StytchB2BClient.TOTP.AuthenticateParameters(
+            sessionDurationMinutes: state.configuration.sessionDurationMinutes,
+            organizationId: organizationId,
+            memberId: memberId,
+            code: code,
+            setMfaEnrollment: .enroll,
+            setDefaultMfa: true
+        )
+        let response = try await StytchB2BClient.totp.authenticate(parameters: parameters)
+        B2BAuthenticationManager.handleSecondaryReponse(b2bAuthenticateResponse: response)
+    }
 }
 
 struct TOTPEntryState {

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/ActionableInfoViewController/ActionableInfoViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/ActionableInfoViewController/ActionableInfoViewController.swift
@@ -95,7 +95,7 @@ final class ActionableInfoViewController: BaseViewController<ActionableInfoState
                         self.launchForgotPassword(email: email)
                     }
                 } catch {
-                    presentAlert(error: error)
+                    presentErrorAlert(error: error)
                 }
             }
         case let .didTapLoginWithoutPassword(email: email):
@@ -106,7 +106,7 @@ final class ActionableInfoViewController: BaseViewController<ActionableInfoState
                         self.launchCheckYourEmail(email: email)
                     }
                 } catch {
-                    presentAlert(error: error)
+                    presentErrorAlert(error: error)
                 }
             }
         }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/AuthHomeViewController/AuthHomeViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/AuthHomeViewController/AuthHomeViewController.swift
@@ -46,7 +46,7 @@ final class AuthHomeViewController: BaseViewController<AuthHomeState, AuthHomeVi
         do {
             try viewModel.checkValidConfig()
         } catch {
-            presentAlert(error: error)
+            presentErrorAlert(error: error)
             return
         }
 

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/AuthInputViewController/AuthInputViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/AuthInputViewController/AuthInputViewController.swift
@@ -271,7 +271,7 @@ final class AuthInputViewController: BaseViewController<AuthInputState, AuthInpu
                     }
                 }
             } catch {
-                presentAlert(error: error)
+                presentErrorAlert(error: error)
             }
         }
     }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/OAuthViewController/OAuthViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/OAuthViewController/OAuthViewController.swift
@@ -33,7 +33,7 @@ final class OAuthViewController: BaseViewController<OAuthState, OAuthViewModel> 
                 try await viewModel.startOAuth(provider: provider)
             } catch {
                 try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
-                presentAlert(error: error)
+                presentErrorAlert(error: error)
             }
         }
     }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/OTPCodeViewController/OTPCodeViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/OTPCodeViewController/OTPCodeViewController.swift
@@ -51,7 +51,7 @@ final class OTPCodeViewController: BaseViewController<OTPCodeState, OTPCodeViewM
                     self?.launchPassword(email: email)
                 }
             } catch {
-                self?.presentAlert(error: error)
+                self?.presentErrorAlert(error: error)
             }
         }
     }
@@ -93,7 +93,7 @@ final class OTPCodeViewController: BaseViewController<OTPCodeState, OTPCodeViewM
                     }
                 } catch {
                     try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
-                    self.presentAlert(error: error)
+                    self.presentErrorAlert(error: error)
                 }
             }
         }
@@ -108,7 +108,7 @@ final class OTPCodeViewController: BaseViewController<OTPCodeState, OTPCodeViewM
                         self.showInvalidCode()
                     }
                 } catch {
-                    self.presentAlert(error: error)
+                    self.presentErrorAlert(error: error)
                 }
             }
         }
@@ -162,7 +162,7 @@ final class OTPCodeViewController: BaseViewController<OTPCodeState, OTPCodeViewM
             do {
                 try await viewModel.resendCode(input: viewModel.state.input)
             } catch {
-                presentAlert(error: error)
+                presentErrorAlert(error: error)
             }
         }
     }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/PasswordViewController/PasswordViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/PasswordViewController/PasswordViewController.swift
@@ -18,7 +18,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                     self?.launchCheckYourEmail(email: email)
                 }
             } catch {
-                self?.presentAlert(error: error)
+                self?.presentErrorAlert(error: error)
             }
         }
     }
@@ -87,7 +87,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                     self?.launchForgotPassword(email: email)
                 }
             } catch {
-                self?.presentAlert(error: error)
+                self?.presentErrorAlert(error: error)
             }
         }
     }
@@ -105,7 +105,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                     self?.launchCheckYourEmail(email: email)
                 }
             } catch {
-                self?.presentAlert(error: error)
+                self?.presentErrorAlert(error: error)
             }
         }
     }
@@ -244,7 +244,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                     try await viewModel.setPassword(token: token, password: password)
                 } catch {
                     try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
-                    presentAlert(error: error)
+                    presentErrorAlert(error: error)
                 }
             }
         case .login:
@@ -253,7 +253,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                     try await viewModel.login(email: email, password: password)
                 } catch {
                     try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
-                    presentAlert(error: error)
+                    presentErrorAlert(error: error)
                 }
             }
         case .signup:
@@ -262,7 +262,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                     try await viewModel.signup(email: email, password: password)
                 } catch {
                     try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
-                    presentAlert(error: error)
+                    presentErrorAlert(error: error)
                 }
             }
         }
@@ -309,7 +309,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                 }
                 passwordInput.progressBar.progress = .init(rawValue: Int(response.score) - 1)
             } catch {
-                presentAlert(error: error)
+                presentErrorAlert(error: error)
             }
         }
     }

--- a/Stytch/DemoApps/B2BWorkbench/SceneDelegate.swift
+++ b/Stytch/DemoApps/B2BWorkbench/SceneDelegate.swift
@@ -28,8 +28,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 case let .handled(response):
                     // Handled via RootVC onAuthChange publisher
                     switch response {
-                    case .auth:
-                        print("auth response: \(response)")
                     case let .discovery(authResponse):
                         print("discovery auth response: \(authResponse)")
                     case let .discoveryOauth(authResponse):

--- a/Stytch/DemoApps/B2BWorkbench/ViewControllers/AuthHomeViewController.swift
+++ b/Stytch/DemoApps/B2BWorkbench/ViewControllers/AuthHomeViewController.swift
@@ -1,3 +1,5 @@
+import StytchCore
+import StytchUI
 import UIKit
 
 final class AuthHomeViewController: UIViewController {
@@ -59,6 +61,13 @@ final class AuthHomeViewController: UIViewController {
         self?.navigationController?.pushViewController(SCIMViewController(), animated: true)
     })
 
+    lazy var b2bUIButton: UIButton = .init(title: "B2B UI", primaryAction: .init { [weak self] _ in
+        StytchB2BUIClient.configure(configuration: Self.allStytchB2BUIConfig)
+        if let strongSelf = self {
+            StytchB2BUIClient.presentController(controller: strongSelf)
+        }
+    })
+
     func saveOrgID() {
         UserDefaults.standard.set(orgIdTextField.text, forKey: Constants.orgIdDefaultsKey)
     }
@@ -92,6 +101,7 @@ final class AuthHomeViewController: UIViewController {
         stackView.addArrangedSubview(recoveryCodesButton)
         stackView.addArrangedSubview(oauthButton)
         stackView.addArrangedSubview(scimButton)
+        stackView.addArrangedSubview(b2bUIButton)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -102,6 +112,24 @@ final class AuthHomeViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         saveOrgID()
+    }
+
+    static var allStytchB2BUIConfig: StytchB2BUIClient.Configuration = .init(
+        publicToken: publicToken,
+        products: [.emailMagicLinks, .sso, .passwords, .oauth],
+        authFlowType: .organization(slug: "no-mfa"),
+        oauthProviders: [.init(provider: .google)]
+    )
+
+    static var discoveryStytchB2BUIConfig: StytchB2BUIClient.Configuration = .init(
+        publicToken: publicToken,
+        products: [.emailMagicLinks, .sso, .passwords, .oauth],
+        authFlowType: .discovery,
+        oauthProviders: [.init(provider: .google)]
+    )
+
+    static var publicToken: String {
+        UserDefaults.standard.string(forKey: Constants.publicTokenDefaultsKey) ?? ""
     }
 }
 

--- a/Stytch/DemoApps/StytchB2BUIDemo/StytchB2BUIDemoApp.swift
+++ b/Stytch/DemoApps/StytchB2BUIDemo/StytchB2BUIDemoApp.swift
@@ -6,7 +6,7 @@ import SwiftUI
 struct StytchB2BUIDemoApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView(configuration: StytchB2BUIDemoApp.oauthAndPasswrodsStytchB2BUIConfig)
+            ContentView(configuration: StytchB2BUIDemoApp.discoveryStytchB2BUIConfig)
         }
     }
 

--- a/Stytch/Stytch.xcodeproj/project.pbxproj
+++ b/Stytch/Stytch.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		745BAB7E2C88D2B300771497 /* LoggedInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 745BAB7D2C88D2B300771497 /* LoggedInView.swift */; };
 		745BAB802C88E09E00771497 /* OTPAuthenticationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 745BAB7F2C88E09E00771497 /* OTPAuthenticationManager.swift */; };
 		745BAB822C89FBA800771497 /* User.Name+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 745BAB812C89FBA800771497 /* User.Name+Helpers.swift */; };
+		7462DACB2D0236F100329553 /* StytchUI in Frameworks */ = {isa = PBXBuildFile; productRef = 7462DACA2D0236F100329553 /* StytchUI */; };
 		7478F7D92BF595CD00BCB233 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7478F7D82BF595CD00BCB233 /* Launch Screen.storyboard */; };
 		7478F7DC2BF6467900BCB233 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7478F7DA2BF6467900BCB233 /* Extensions.swift */; };
 		749F88862BFBD63E00D7F386 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 749F88852BFBD63E00D7F386 /* Launch Screen.storyboard */; };
@@ -180,6 +181,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7462DACB2D0236F100329553 /* StytchUI in Frameworks */,
 				74234D512C21EB770001DA69 /* SwiftOTP in Frameworks */,
 				2231532D299EE5E700BA9126 /* StytchCore in Frameworks */,
 			);
@@ -455,6 +457,7 @@
 			packageProductDependencies = (
 				2231532C299EE5E700BA9126 /* StytchCore */,
 				74234D502C21EB770001DA69 /* SwiftOTP */,
+				7462DACA2D0236F100329553 /* StytchUI */,
 			);
 			productName = B2BWorkbench;
 			productReference = 22315318299EE16D00BA9126 /* B2BWorkbench.app */;
@@ -1490,6 +1493,10 @@
 		745BAB782C88C96800771497 /* StytchCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = StytchCore;
+		};
+		7462DACA2D0236F100329553 /* StytchUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = StytchUI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Tests/StytchCoreTests/B2BDiscoveryTestCase.swift
+++ b/Tests/StytchCoreTests/B2BDiscoveryTestCase.swift
@@ -15,7 +15,7 @@ final class B2BDiscoveryTestCase: BaseTestCase {
                     discoveredOrganizations: [
                         .init(
                             organization: .mock,
-                            membership: .init(kind: "somethign", details: nil, member: .mock),
+                            membership: .init(type: .activeMember, details: nil, member: .mock),
                             memberAuthenticated: false,
                             mfaRequired: nil,
                             primaryRequired: nil

--- a/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
@@ -141,13 +141,13 @@ final class B2BMagicLinksTestCase: BaseTestCase {
 
     func testDiscoveryAuthenticate() async throws {
         networkInterceptor.responses {
-            StytchB2BClient.MagicLinks.DiscoveryAuthenticateResponse(
+            StytchB2BClient.DiscoveryAuthenticateResponse(
                 requestId: "123",
                 statusCode: 200,
                 wrapped: .init(
-                    discoveredOrganizations: [],
                     intermediateSessionToken: "IMS",
-                    emailAddress: "1@2.3"
+                    emailAddress: "1@2.3",
+                    discoveredOrganizations: []
                 )
             )
         }


### PR DESCRIPTION
[[iOS] Build discovery screen](https://linear.app/stytch/issue/SDK-2281/[ios]-build-discovery-screen) - Still need to do the flow where there are no discovered orgs.
[[iOS] Build EmailConfirmation screen](https://linear.app/stytch/issue/SDK-2280/[ios]-build-emailconfirmation-screen)
[[iOS] Build MFAEnrollmentSelection](https://linear.app/stytch/issue/SDK-2277/[ios]-build-mfaenrollmentselection)
[[iOS] Build PasswordResetVerifyConfirmation](https://linear.app/stytch/issue/SDK-2273/[ios]-build-passwordresetverifyconfirmation)
[[iOS] BuildPasswordSetNewConfirmation](https://linear.app/stytch/issue/SDK-2271/[ios]-buildpasswordsetnewconfirmation)
[[iOS] Build TOTPEnrollment](https://linear.app/stytch/issue/SDK-2265/[ios]-build-totpenrollment)
[[iOS] Build TOTPEntry](https://linear.app/stytch/issue/SDK-2264/[ios]-build-totpentry)

## Changes:

1. Create new `MembershipType` for `DiscoveredOrganization. Membership`
2. Remove redundant response type for EML `DiscoveryAuthenticateResponse` standardize around a single one in the common file for all `DiscoveryAuthenticateResponse`.
3. Create new `OTPCodeEntryView` which has the 6 boxes, B2C was using one with a single text field, so I will have to go back and replace that for B2C also in another PR.
4. Add missing icons.
5. Create new extension methods for buttons, labels, and alerts.
6. Add `DiscoveryManager` and `MemberManager` to help keep global state for those types.
7. Complete the happy path for discovery.
8. Make the `EmailConfirmationViewController` for the three types of cases.
9. Fill out `MFAMethodSelectionViewController` and extract functionality to a common place.
10. Fill out `TOTPEnrollmentViewController` and `TOTPEntryViewController`.
11. Add the prebuilt B2B UI to the B2BWorkbench app so I can test it in UIKit also.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
