### PR TITLE
Only load the TOTP Secret when we reach the VC

### DIFF
--- a/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController+MFA.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController+MFA.swift
@@ -20,9 +20,9 @@ extension BaseViewController {
             if b2bMFAAuthenticateResponse?.organization.allMFAMethodsAllowed == true {
                 viewController = MFAEnrollmentSelectionViewController(state: .init(configuration: configuration))
             } else if b2bMFAAuthenticateResponse?.organization.usesSMSMFAOnly == true {
-                handleSMSOTPEnrollment(configuration: configuration)
+                navigationController?.pushViewController(SMSOTPEnrollmentViewController(state: .init(configuration: configuration)), animated: true)
             } else if b2bMFAAuthenticateResponse?.organization.usesTOTPMFAOnly == true {
-                handleTOTPEnrollment(configuration: configuration)
+                navigationController?.pushViewController(TOTPEnrollmentViewController(state: .init(configuration: configuration)), animated: true)
             }
         }
 
@@ -30,28 +30,4 @@ extension BaseViewController {
             navigationController?.pushViewController(viewController, animated: true)
         }
     }
-}
-
-extension BaseViewController {
-    func handleTOTPEnrollment(configuration: StytchB2BUIClient.Configuration) {
-        Task { [weak self] in
-            do {
-                let secret = try await AuthenticationOperations.createTOTP()
-                self?.showTOTPEnrollment(configuration: configuration, secret: secret)
-            } catch {
-                self?.presentErrorAlert(error: error)
-            }
-        }
-    }
-
-    func showTOTPEnrollment(configuration: StytchB2BUIClient.Configuration, secret: String) {
-        let state = TOTPEnrollmentState(configuration: configuration, secret: secret)
-        Task { @MainActor in
-            navigationController?.pushViewController(TOTPEnrollmentViewController(state: state), animated: true)
-        }
-    }
-}
-
-extension BaseViewController {
-    func handleSMSOTPEnrollment(configuration _: StytchB2BUIClient.Configuration) {}
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAEnrollmentSelectionViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAEnrollmentSelectionViewController.swift
@@ -41,9 +41,9 @@ extension MFAEnrollmentSelectionViewController: MFAMethodSelectionViewController
     func didSelectMFAMethod(mfaMethod: StytchCore.StytchB2BClient.MfaMethod) {
         switch mfaMethod {
         case .sms:
-            handleSMSOTPEnrollment(configuration: viewModel.state.configuration)
+            navigationController?.pushViewController(SMSOTPEnrollmentViewController(state: .init(configuration: viewModel.state.configuration)), animated: true)
         case .totp:
-            handleTOTPEnrollment(configuration: viewModel.state.configuration)
+            navigationController?.pushViewController(TOTPEnrollmentViewController(state: .init(configuration: viewModel.state.configuration)), animated: true)
         }
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPEnrollmentViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPEnrollmentViewModel.swift
@@ -8,9 +8,23 @@ final class TOTPEnrollmentViewModel {
     ) {
         self.state = state
     }
+
+    func createTOTP() async throws -> String {
+        guard let organizationId = OrganizationManager.organizationId else {
+            throw StytchSDKError.noOrganziationId
+        }
+
+        guard let memberId = MemberManager.memberId else {
+            throw StytchSDKError.noMemberId
+        }
+
+        let parameters = StytchB2BClient.TOTP.CreateParameters(organizationId: organizationId, memberId: memberId, expirationMinutes: 30)
+        let response = try await StytchB2BClient.totp.create(parameters: parameters)
+        B2BAuthenticationManager.updateTotpState(totpResponse: response.wrapped)
+        return response.wrapped.secret
+    }
 }
 
 struct TOTPEnrollmentState {
     let configuration: StytchB2BUIClient.Configuration
-    let secret: String
 }

--- a/Stytch/DemoApps/StytchB2BUIDemo/StytchB2BUIDemoApp.swift
+++ b/Stytch/DemoApps/StytchB2BUIDemo/StytchB2BUIDemoApp.swift
@@ -6,7 +6,7 @@ import SwiftUI
 struct StytchB2BUIDemoApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView(configuration: StytchB2BUIDemoApp.discoveryStytchB2BUIConfig)
+            ContentView(configuration: StytchB2BUIDemoApp.allStytchB2BUIConfig)
         }
     }
 
@@ -52,7 +52,7 @@ struct StytchB2BUIDemoApp: App {
     static let allStytchB2BUIConfig: StytchB2BUIClient.Configuration = .init(
         publicToken: publicToken,
         products: [.emailMagicLinks, .sso, .passwords, .oauth],
-        authFlowType: .organization(slug: "no-mfa"),
+        authFlowType: .organization(slug: "mfa-required"),
         oauthProviders: [.init(provider: .google)]
     )
 


### PR DESCRIPTION
## Changes:

1. Modify the TOTP flow to make function where we only load the secret and recovery code when you hit the view controller. And if it fails to load then I change the "Continue" button to say "Try Again" which will attempt to create the TOTP association again. The user can also choose to go back and auth a different way.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
