### PR TITLE
Add loading Spinner to root VC

### DIFF
--- a/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController+MFA.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController+MFA.swift
@@ -4,30 +4,32 @@ import UIKit
 
 extension BaseViewController {
     func startMFAFlowIfNeeded(configuration: StytchB2BUIClient.Configuration) {
-        var viewController: UIViewController?
+        Task { @MainActor in
+            var viewController: UIViewController?
 
-        let b2bMFAAuthenticateResponse = B2BAuthenticationManager.b2bMFAAuthenticateResponse
+            let b2bMFAAuthenticateResponse = B2BAuthenticationManager.b2bMFAAuthenticateResponse
 
-        if b2bMFAAuthenticateResponse?.primaryRequired != nil {
-            viewController = B2BAuthHomeViewController(state: .init(configuration: configuration))
-        } else if b2bMFAAuthenticateResponse?.member.mfaEnrolled == true {
-            if b2bMFAAuthenticateResponse?.mfaRequired?.memberOptions?.mfaPhoneNumber != nil {
-                viewController = SMSOTPEntryViewController(state: .init(configuration: configuration))
-            } else if b2bMFAAuthenticateResponse?.mfaRequired?.memberOptions?.totpRegistrationId == nil {
-                viewController = TOTPEntryViewController(state: .init(configuration: configuration))
+            if b2bMFAAuthenticateResponse?.primaryRequired != nil {
+                viewController = B2BAuthHomeViewController(state: .init(configuration: configuration))
+            } else if b2bMFAAuthenticateResponse?.member.mfaEnrolled == true {
+                if b2bMFAAuthenticateResponse?.mfaRequired?.memberOptions?.mfaPhoneNumber != nil {
+                    viewController = SMSOTPEntryViewController(state: .init(configuration: configuration))
+                } else if b2bMFAAuthenticateResponse?.mfaRequired?.memberOptions?.totpRegistrationId == nil {
+                    viewController = TOTPEntryViewController(state: .init(configuration: configuration))
+                }
+            } else {
+                if b2bMFAAuthenticateResponse?.organization.allMFAMethodsAllowed == true {
+                    viewController = MFAEnrollmentSelectionViewController(state: .init(configuration: configuration))
+                } else if b2bMFAAuthenticateResponse?.organization.usesSMSMFAOnly == true {
+                    navigationController?.pushViewController(SMSOTPEnrollmentViewController(state: .init(configuration: configuration)), animated: true)
+                } else if b2bMFAAuthenticateResponse?.organization.usesTOTPMFAOnly == true {
+                    navigationController?.pushViewController(TOTPEnrollmentViewController(state: .init(configuration: configuration)), animated: true)
+                }
             }
-        } else {
-            if b2bMFAAuthenticateResponse?.organization.allMFAMethodsAllowed == true {
-                viewController = MFAEnrollmentSelectionViewController(state: .init(configuration: configuration))
-            } else if b2bMFAAuthenticateResponse?.organization.usesSMSMFAOnly == true {
-                navigationController?.pushViewController(SMSOTPEnrollmentViewController(state: .init(configuration: configuration)), animated: true)
-            } else if b2bMFAAuthenticateResponse?.organization.usesTOTPMFAOnly == true {
-                navigationController?.pushViewController(TOTPEnrollmentViewController(state: .init(configuration: configuration)), animated: true)
-            }
-        }
 
-        if let viewController {
-            navigationController?.pushViewController(viewController, animated: true)
+            if let viewController {
+                navigationController?.pushViewController(viewController, animated: true)
+            }
         }
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/DiscoveryManager.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/DiscoveryManager.swift
@@ -24,12 +24,14 @@ struct DiscoveryManager {
 
 extension BaseViewController {
     func startDiscoveryFlowIfNeeded(configuration: StytchB2BUIClient.Configuration) {
-        let discoveredOrganizations = DiscoveryManager.discoveredOrganizations
-        if let singleDiscoveredOrganization = discoveredOrganizations.shouldAllowDirectLoginToOrganization(configuration.directLoginForSingleMembershipOptions) {
-            selectDiscoveredOrganization(configuration: configuration, discoveredOrganization: singleDiscoveredOrganization)
-        } else {
-            let discoveryViewController = DiscoveryViewController(state: .init(configuration: configuration))
-            navigationController?.pushViewController(discoveryViewController, animated: true)
+        Task { @MainActor in
+            let discoveredOrganizations = DiscoveryManager.discoveredOrganizations
+            if let singleDiscoveredOrganization = discoveredOrganizations.shouldAllowDirectLoginToOrganization(configuration.directLoginForSingleMembershipOptions) {
+                selectDiscoveredOrganization(configuration: configuration, discoveredOrganization: singleDiscoveredOrganization)
+            } else {
+                let discoveryViewController = DiscoveryViewController(state: .init(configuration: configuration))
+                navigationController?.pushViewController(discoveryViewController, animated: true)
+            }
         }
     }
 
@@ -40,9 +42,7 @@ extension BaseViewController {
                     configuration: configuration,
                     discoveredOrganization: discoveredOrganization
                 )
-                Task { @MainActor in
-                    startMFAFlowIfNeeded(configuration: configuration)
-                }
+                startMFAFlowIfNeeded(configuration: configuration)
             } catch {
                 presentErrorAlert(error: error)
             }

--- a/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient.swift
@@ -83,6 +83,14 @@ public enum StytchB2BUIClient {
         reset()
         currentController?.dismissAuth()
     }
+
+    static func startLoading() {
+        currentController?.startLoading()
+    }
+
+    static func stopLoading() {
+        currentController?.stopLoading()
+    }
 }
 
 public extension View {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordResetViewController/PasswordResetViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordResetViewController/PasswordResetViewModel.swift
@@ -12,4 +12,6 @@ final class PasswordResetViewModel {
 
 struct PasswordResetState {
     let configuration: StytchB2BUIClient.Configuration
+    let token: String
+    let email: String
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPEnrollmentViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPEnrollmentViewController.swift
@@ -57,6 +57,7 @@ final class TOTPEnrollmentViewController: BaseViewController<TOTPEnrollmentState
     }
 
     @objc func createTOTP() {
+        StytchB2BUIClient.startLoading()
         Task { [weak self] in
             do {
                 let secret = try await self?.viewModel.createTOTP()
@@ -64,12 +65,14 @@ final class TOTPEnrollmentViewController: BaseViewController<TOTPEnrollmentState
                     self?.continueButton.setTitle(NSLocalizedString("stytch.pwContinueTitle", value: "Continue", comment: ""), for: .normal)
                     self?.totpSecretView.configure(with: secret ?? "")
                     self?.error = nil
+                    StytchB2BUIClient.stopLoading()
                 }
             } catch {
                 Task { @MainActor in
                     self?.continueButton.setTitle(NSLocalizedString("stytch.pwContinueTryAgainTitle", value: "Try Again", comment: ""), for: .normal)
                     self?.presentErrorAlert(error: error)
                     self?.error = error
+                    StytchB2BUIClient.stopLoading()
                 }
             }
         }


### PR DESCRIPTION
## Changes:

1. Add a mechanism by which you can use static functions to tell the main `StytchB2BUIClient` to add a loading spinner to its root view controller and remove it. Each asynchronous operation will need to manually call start and stop.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A
