### PR TITLE
[B2B UI] Use [weak self] in all tasks

### DIFF
--- a/Sources/StytchUI/Extensions/UIViewController+StytchUI.swift
+++ b/Sources/StytchUI/Extensions/UIViewController+StytchUI.swift
@@ -10,11 +10,11 @@ extension UIViewController {
     }
 
     func presentAlert(title: String?, message: String?) {
-        Task { @MainActor in
+        Task { @MainActor [weak self] in
             let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
             alertController.view.tintColor = .primaryText
             alertController.addAction(.init(title: NSLocalizedString("stytch.vcOK", value: "OK", comment: ""), style: .default))
-            present(alertController, animated: true)
+            self?.present(alertController, animated: true)
         }
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/B2BPasswordsViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/B2BPasswordsViewModel.swift
@@ -29,7 +29,7 @@ final class B2BPasswordsViewModel {
             return
         }
 
-        Task {
+        Task { [weak self] in
             do {
                 let member = try? await AuthenticationOperations.searchMember(emailAddress: emailAddress, organizationId: organizationId)
                 if member?.memberPasswordId != nil {
@@ -41,13 +41,17 @@ final class B2BPasswordsViewModel {
                     )
                     let response = try await StytchB2BClient.passwords.authenticate(parameters: parameters)
                     B2BAuthenticationManager.handleMFAReponse(b2bMFAAuthenticateResponse: response)
-                    delegate?.didAuthenticateWithPassword()
+                    self?.delegate?.didAuthenticateWithPassword()
                 } else {
-                    try await AuthenticationOperations.sendEmailMagicLinkIfPossible(emailAddress: emailAddress, organizationId: organizationId, redirectUrl: state.configuration.redirectUrl)
-                    delegate?.didSendEmailMagicLink()
+                    try await AuthenticationOperations.sendEmailMagicLinkIfPossible(
+                        emailAddress: emailAddress,
+                        organizationId: organizationId,
+                        redirectUrl: self?.state.configuration.redirectUrl
+                    )
+                    self?.delegate?.didSendEmailMagicLink()
                 }
             } catch {
-                delegate?.didError(error: error)
+                self?.delegate?.didError(error: error)
             }
         }
     }

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController+MFA.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController+MFA.swift
@@ -4,7 +4,7 @@ import UIKit
 
 extension BaseViewController {
     func startMFAFlowIfNeeded(configuration: StytchB2BUIClient.Configuration) {
-        Task { @MainActor in
+        Task { @MainActor [weak self] in
             var viewController: UIViewController?
 
             let b2bMFAAuthenticateResponse = B2BAuthenticationManager.b2bMFAAuthenticateResponse
@@ -21,14 +21,14 @@ extension BaseViewController {
                 if b2bMFAAuthenticateResponse?.organization.allMFAMethodsAllowed == true {
                     viewController = MFAEnrollmentSelectionViewController(state: .init(configuration: configuration))
                 } else if b2bMFAAuthenticateResponse?.organization.usesSMSMFAOnly == true {
-                    navigationController?.pushViewController(SMSOTPEnrollmentViewController(state: .init(configuration: configuration)), animated: true)
+                    viewController = SMSOTPEnrollmentViewController(state: .init(configuration: configuration))
                 } else if b2bMFAAuthenticateResponse?.organization.usesTOTPMFAOnly == true {
-                    navigationController?.pushViewController(TOTPEnrollmentViewController(state: .init(configuration: configuration)), animated: true)
+                    viewController = TOTPEnrollmentViewController(state: .init(configuration: configuration))
                 }
             }
 
             if let viewController {
-                navigationController?.pushViewController(viewController, animated: true)
+                self?.navigationController?.pushViewController(viewController, animated: true)
             }
         }
     }

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/DiscoveryManager.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/DiscoveryManager.swift
@@ -24,27 +24,27 @@ struct DiscoveryManager {
 
 extension BaseViewController {
     func startDiscoveryFlowIfNeeded(configuration: StytchB2BUIClient.Configuration) {
-        Task { @MainActor in
+        Task { @MainActor [weak self] in
             let discoveredOrganizations = DiscoveryManager.discoveredOrganizations
             if let singleDiscoveredOrganization = discoveredOrganizations.shouldAllowDirectLoginToOrganization(configuration.directLoginForSingleMembershipOptions) {
-                selectDiscoveredOrganization(configuration: configuration, discoveredOrganization: singleDiscoveredOrganization)
+                self?.selectDiscoveredOrganization(configuration: configuration, discoveredOrganization: singleDiscoveredOrganization)
             } else {
                 let discoveryViewController = DiscoveryViewController(state: .init(configuration: configuration))
-                navigationController?.pushViewController(discoveryViewController, animated: true)
+                self?.navigationController?.pushViewController(discoveryViewController, animated: true)
             }
         }
     }
 
     func selectDiscoveredOrganization(configuration: StytchB2BUIClient.Configuration, discoveredOrganization: StytchB2BClient.DiscoveredOrganization) {
-        Task {
+        Task { [weak self] in
             do {
                 try await DiscoveryManager.selectDiscoveredOrganization(
                     configuration: configuration,
                     discoveredOrganization: discoveredOrganization
                 )
-                startMFAFlowIfNeeded(configuration: configuration)
+                self?.startMFAFlowIfNeeded(configuration: configuration)
             } catch {
-                presentErrorAlert(error: error)
+                self?.presentErrorAlert(error: error)
             }
         }
     }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BAuthHomeViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BAuthHomeViewController.swift
@@ -38,7 +38,7 @@ final class B2BAuthHomeViewController: BaseViewController<B2BAuthHomeState, B2BA
     override func configureView() {
         super.configureView()
         viewModel.loadProducts { [weak self] productComponents in
-            Task { @MainActor in
+            Task { @MainActor [weak self] in
                 self?.configureView(productComponents: productComponents)
             }
         }
@@ -69,8 +69,8 @@ final class B2BAuthHomeViewController: BaseViewController<B2BAuthHomeState, B2BA
 
         stackView.addArrangedSubview(SpacerView())
 
-        Task {
-            try await viewModel.logRenderScreen()
+        Task { [weak self] in
+            try await self?.viewModel.logRenderScreen()
         }
     }
 
@@ -125,20 +125,28 @@ final class B2BAuthHomeViewController: BaseViewController<B2BAuthHomeState, B2BA
     }
 
     func continueAuthenticationFlowIfNeeded() {
-        Task { @MainActor in
-            if viewModel.state.configuration.authFlowType == .discovery {
-                let discoveryViewController = DiscoveryViewController(state: .init(configuration: viewModel.state.configuration))
-                navigationController?.pushViewController(discoveryViewController, animated: true)
+        Task { @MainActor [weak self] in
+            guard let configuration = self?.viewModel.state.configuration else {
+                return
+            }
+
+            if self?.viewModel.state.configuration.authFlowType == .discovery {
+                let discoveryViewController = DiscoveryViewController(state: .init(configuration: configuration))
+                self?.navigationController?.pushViewController(discoveryViewController, animated: true)
             } else {
-                startMFAFlowIfNeeded(configuration: viewModel.state.configuration)
+                self?.startMFAFlowIfNeeded(configuration: configuration)
             }
         }
     }
 
     func showEmaiilConfirmation() {
-        Task { @MainActor in
-            let emailConfirmationViewController = EmailConfirmationViewController(state: .init(configuration: viewModel.state.configuration, type: .emailConfirmation))
-            navigationController?.pushViewController(emailConfirmationViewController, animated: true)
+        Task { @MainActor [weak self] in
+            guard let configuration = self?.viewModel.state.configuration else {
+                return
+            }
+
+            let emailConfirmationViewController = EmailConfirmationViewController(state: .init(configuration: configuration, type: .emailConfirmation))
+            self?.navigationController?.pushViewController(emailConfirmationViewController, animated: true)
         }
     }
 }
@@ -159,9 +167,13 @@ extension B2BAuthHomeViewController: B2BEmailMagicLinksViewControllerDelegate {
     }
 
     func usePasswordInstead() {
-        Task { @MainActor in
-            let passwordAuthenticateViewController = PasswordAuthenticateViewController(state: .init(configuration: viewModel.state.configuration))
-            navigationController?.pushViewController(passwordAuthenticateViewController, animated: true)
+        Task { @MainActor [weak self] in
+            guard let configuration = self?.viewModel.state.configuration else {
+                return
+            }
+
+            let passwordAuthenticateViewController = PasswordAuthenticateViewController(state: .init(configuration: configuration))
+            self?.navigationController?.pushViewController(passwordAuthenticateViewController, animated: true)
         }
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BAuthHomeViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BAuthHomeViewModel.swift
@@ -26,13 +26,17 @@ extension B2BAuthHomeViewModel: B2BAuthHomeViewModelProtocol {
     func loadProducts(
         completion: @escaping ([StytchB2BUIClient.ProductComponent]) -> Void
     ) {
-        Task {
-            switch state.configuration.authFlowType {
+        Task { [weak self] in
+            guard let configuration = self?.state.configuration else {
+                return
+            }
+
+            switch configuration.authFlowType {
             case .discovery:
                 let products = StytchB2BUIClient.productComponentsOrdering(
-                    validProducts: state.configuration.products,
-                    configuration: state.configuration,
-                    hasSSOActiveConnections: false // can you do discovery via sso?
+                    validProducts: configuration.products,
+                    configuration: configuration,
+                    hasSSOActiveConnections: false
                 )
                 completion(products)
             case let .organization(slug):
@@ -42,11 +46,11 @@ extension B2BAuthHomeViewModel: B2BAuthHomeViewModelProtocol {
                         organizationAllowedAuthMethods: OrganizationManager.allowedAuthMethods,
                         organizationAuthMethods: OrganizationManager.authMethods,
                         primaryRequired: B2BAuthenticationManager.primaryRequired,
-                        configuration: state.configuration
+                        configuration: configuration
                     )
                     let products = StytchB2BUIClient.productComponentsOrdering(
                         validProducts: validProducts,
-                        configuration: state.configuration,
+                        configuration: configuration,
                         hasSSOActiveConnections: (OrganizationManager.ssoActiveConnections?.count ?? 0) > 0
                     )
                     completion(products)

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BEmailMagicLinksViewController/B2BEmailMagicLinksViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BEmailMagicLinksViewController/B2BEmailMagicLinksViewModel.swift
@@ -14,12 +14,12 @@ final class B2BEmailMagicLinksViewModel {
         completion: @escaping (Error?) -> Void
     ) {
         MemberManager.updateMemberEmailAddress(emailAddress)
-        Task {
+        Task { [weak self] in
             do {
-                if state.configuration.authFlowType == .discovery {
+                if self?.state.configuration.authFlowType == .discovery {
                     let parameters = StytchB2BClient.MagicLinks.Email.DiscoveryParameters(
                         emailAddress: emailAddress,
-                        discoveryRedirectUrl: state.configuration.redirectUrl,
+                        discoveryRedirectUrl: self?.state.configuration.redirectUrl,
                         locale: .en
                     )
                     _ = try await StytchB2BClient.magicLinks.email.discoverySend(parameters: parameters)
@@ -32,7 +32,7 @@ final class B2BEmailMagicLinksViewModel {
                     try await AuthenticationOperations.sendEmailMagicLink(
                         emailAddress: emailAddress,
                         organizationId: organizationId,
-                        redirectUrl: state.configuration.redirectUrl
+                        redirectUrl: self?.state.configuration.redirectUrl
                     )
                 }
                 completion(nil)

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BSSOViewController/B2BSSOViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BSSOViewController/B2BSSOViewController.swift
@@ -40,13 +40,13 @@ final class B2BSSOViewController: BaseViewController<SSOState, SSOViewModel> {
             return
         }
 
-        Task {
+        Task { [weak self] in
             do {
                 try await viewModel.startSSO(connectionId: ssoActiveConnection.connectionId)
-                delegate?.ssoDidAuthenticatie()
+                self?.delegate?.ssoDidAuthenticatie()
             } catch {
                 try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
-                presentErrorAlert(error: error)
+                self?.presentErrorAlert(error: error)
             }
         }
     }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
@@ -77,8 +77,12 @@ final class B2BAuthRootViewController: UIViewController {
 
 extension B2BAuthRootViewController {
     func startLoading() {
-        Task { @MainActor in
-            guard loadingView == nil else {
+        Task { @MainActor [weak self] in
+            guard self?.loadingView == nil else {
+                return
+            }
+
+            guard let view = self?.view else {
                 return
             }
 
@@ -103,17 +107,17 @@ extension B2BAuthRootViewController {
                 activityIndicator.centerYAnchor.constraint(equalTo: loadingView.centerYAnchor),
             ])
 
-            self.loadingView = loadingView
-            self.activityIndicator = activityIndicator
+            self?.loadingView = loadingView
+            self?.activityIndicator = activityIndicator
         }
     }
 
     func stopLoading() {
-        Task { @MainActor in
-            loadingView?.removeFromSuperview()
-            loadingView = nil
-            activityIndicator?.stopAnimating()
-            activityIndicator = nil
+        Task { @MainActor [weak self] in
+            self?.loadingView?.removeFromSuperview()
+            self?.loadingView = nil
+            self?.activityIndicator?.stopAnimating()
+            self?.activityIndicator = nil
         }
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPEnrollmentViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPEnrollmentViewController.swift
@@ -61,14 +61,14 @@ final class TOTPEnrollmentViewController: BaseViewController<TOTPEnrollmentState
         Task { [weak self] in
             do {
                 let secret = try await self?.viewModel.createTOTP()
-                Task { @MainActor in
+                Task { @MainActor [weak self] in
                     self?.continueButton.setTitle(NSLocalizedString("stytch.pwContinueTitle", value: "Continue", comment: ""), for: .normal)
                     self?.totpSecretView.configure(with: secret ?? "")
                     self?.error = nil
                     StytchB2BUIClient.stopLoading()
                 }
             } catch {
-                Task { @MainActor in
+                Task { @MainActor [weak self] in
                     self?.continueButton.setTitle(NSLocalizedString("stytch.pwContinueTryAgainTitle", value: "Try Again", comment: ""), for: .normal)
                     self?.presentErrorAlert(error: error)
                     self?.error = error

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/ActionableInfoViewController/ActionableInfoViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/ActionableInfoViewController/ActionableInfoViewController.swift
@@ -76,7 +76,7 @@ final class ActionableInfoViewController: BaseViewController<ActionableInfoState
         )
         controller.addAction(.init(title: NSLocalizedString("stytch.aiCancel", value: "Cancel", comment: ""), style: .default))
         controller.addAction(.init(title: NSLocalizedString("stytch.aiConfirm", value: "Send link", comment: ""), style: .default) { [weak self] _ in
-            Task { @MainActor in
+            Task { @MainActor [weak self] in
                 try await self?.viewModel.state.retryAction()
             }
         })


### PR DESCRIPTION
## Changes:

1. Based on some docs I was reading online, all usage of a Task that references self should use `[weak self] in` as a best practice.
2. https://stackoverflow.com/questions/71728943/async-await-task-and-weak-self

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A
