### PR TITLE
[B2B UI] Create publisher to correctly dismiss UI when needed

### DIFF
--- a/Sources/StytchUI/Components/Button.swift
+++ b/Sources/StytchUI/Components/Button.swift
@@ -141,14 +141,14 @@ extension Button {
         // Create attributed text
         let attributedText = NSMutableAttributedString(string: plainText, attributes: [
             .font: UIFont.systemFont(ofSize: fontSize),
-            .foregroundColor: UIColor.black,
+            .foregroundColor: UIColor.primaryText,
         ])
 
         // If boldText is provided, append it with bold style
         if let boldText = boldText {
             let boldAttributedText = NSAttributedString(string: " \(boldText)", attributes: [
                 .font: UIFont.boldSystemFont(ofSize: fontSize),
-                .foregroundColor: UIColor.black,
+                .foregroundColor: UIColor.primaryText,
             ])
             attributedText.append(boldAttributedText)
         }

--- a/Sources/StytchUI/Extensions/UIViewController+StytchUI.swift
+++ b/Sources/StytchUI/Extensions/UIViewController+StytchUI.swift
@@ -9,12 +9,25 @@ extension UIViewController {
         )
     }
 
-    func presentAlert(title: String?, message: String?) {
+    func presentAlert(title: String?, message: String? = nil) {
         Task { @MainActor in
             let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
             alertController.view.tintColor = .primaryText
             alertController.addAction(.init(title: NSLocalizedString("stytch.vcOK", value: "OK", comment: ""), style: .default))
             present(alertController, animated: true)
         }
+    }
+
+    func presentShareSheet(text: String) {
+        let activityViewController = UIActivityViewController(activityItems: [text], applicationActivities: nil)
+
+        // For iPads, you need to set the popoverPresentationController source
+        if let popoverController = activityViewController.popoverPresentationController {
+            popoverController.sourceView = view
+            popoverController.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 0, height: 0)
+            popoverController.permittedArrowDirections = []
+        }
+
+        present(activityViewController, animated: true, completion: nil)
     }
 }

--- a/Sources/StytchUI/Shared/StytchTheme.swift
+++ b/Sources/StytchUI/Shared/StytchTheme.swift
@@ -93,7 +93,7 @@ public class StytchTheme: Codable {
     let progressDanger: UIColorPair
     /// A `CGFloat` describing the radius of corners where applied. Defaults to 4
     let cornerRadius: CGFloat
-    /// A `CGFloat` describing the vertical margins where applied. Defaults to 64
+    /// A `CGFloat` describing the vertical margins where applied. Defaults to 32
     let verticalMargin: CGFloat
     /// A `CGFloat` describing the horizontal margins where applied. Defaults to 32
     let horizontalMargin: CGFloat
@@ -129,7 +129,7 @@ public class StytchTheme: Codable {
         progressSuccess: UIColorPair = .init(dark: .mint, light: .pine),
         progressDanger: UIColorPair = .init(dark: .peach, light: .maroon),
         cornerRadius: CGFloat = 4,
-        verticalMargin: CGFloat = 64,
+        verticalMargin: CGFloat = 32,
         horizontalMargin: CGFloat = 32,
         buttonHeight: CGFloat = 45,
         spacingTiny: CGFloat = 4,

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/AuthenticationOperations.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/AuthenticationOperations.swift
@@ -72,7 +72,7 @@ struct AuthenticationOperations {
 
         let parameters = StytchB2BClient.TOTP.CreateParameters(organizationId: organizationId, memberId: memberId, expirationMinutes: 30)
         let response = try await StytchB2BClient.totp.create(parameters: parameters)
-        B2BAuthenticationManager.updateTotpState(totpResponse: response.wrapped)
+        B2BAuthenticationManager.handleTOTPResponse(totpResponse: response.wrapped)
         return response.wrapped.secret
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/B2BAuthenticationManager.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/B2BAuthenticationManager.swift
@@ -1,38 +1,75 @@
+import Combine
 import Foundation
 import StytchCore
 import UIKit
 
 enum B2BAuthenticationManager {
-    /// Values from the B2BMFAAuthenticateResponseDataType
+    static var dismissUI: AnyPublisher<Void, Never> {
+        dismissUIPublisher.eraseToAnyPublisher()
+    }
+
+    private static let dismissUIPublisher = PassthroughSubject<Void, Never>()
+
+    /// Values from the primary B2BMFAAuthenticateResponseDataType
     static var b2bMFAAuthenticateResponse: B2BMFAAuthenticateResponseDataType?
     static var primaryRequired: StytchB2BClient.PrimaryRequired? {
         b2bMFAAuthenticateResponse?.primaryRequired
     }
 
     /// totp related fields
-    static var secret: String?
-    static var recoveryCodes: [String]?
-    static var didSaveRecoveryCodes: Bool = false
+    static var totpResponse: StytchB2BClient.TOTP.CreateResponseData?
+    static var recoveryCodes: [String] {
+        totpResponse?.recoveryCodes ?? []
+    }
 
-    static func handleMFAReponse(b2bMFAAuthenticateResponse: B2BMFAAuthenticateResponseDataType) {
+    fileprivate static var didSaveRecoveryCodes: Bool = false
+
+    /// Values from the secondary B2BAuthenticateResponseDataType
+    static var b2bAuthenticateResponse: B2BAuthenticateResponseDataType?
+
+    static func handlePrimaryMFAReponse(b2bMFAAuthenticateResponse: B2BMFAAuthenticateResponseDataType) {
         Self.b2bMFAAuthenticateResponse = b2bMFAAuthenticateResponse
         OrganizationManager.updateOrganization(b2bMFAAuthenticateResponse.organization)
         MemberManager.updateMember(b2bMFAAuthenticateResponse.member)
+        dismissUIIfNeeded()
     }
 
     static func handleSecondaryReponse(b2bAuthenticateResponse: B2BAuthenticateResponseDataType) {
-        print(b2bAuthenticateResponse.memberSession)
+        Self.b2bAuthenticateResponse = b2bAuthenticateResponse
+        dismissUIIfNeeded()
     }
 
-    static func updateTotpState(totpResponse: StytchB2BClient.TOTP.CreateResponseData) {
-        secret = totpResponse.secret
-        recoveryCodes = totpResponse.recoveryCodes
+    static func recoveryCodesSaved() {
+        didSaveRecoveryCodes = true
+        dismissUIIfNeeded()
+    }
+
+    static func handleTOTPResponse(totpResponse: StytchB2BClient.TOTP.CreateResponseData) {
+        Self.totpResponse = totpResponse
+    }
+
+    static func dismissUIIfNeeded() {
+        var memberSession: MemberSession?
+        if let secondaryResponse = b2bAuthenticateResponse {
+            memberSession = secondaryResponse.memberSession
+        } else if let primaryResponse = b2bMFAAuthenticateResponse {
+            memberSession = primaryResponse.memberSession
+        }
+
+        // If we have a member session we are fully authenticated
+        // We then need to check if we have a totpResponse which would only happen if this was a first time flow and the user was creating their totp association
+        // So if the totp response is not nil we want to wait to dismiss the ui until the user has saved the recovery codes
+        if memberSession != nil {
+            if totpResponse == nil || (totpResponse != nil && didSaveRecoveryCodes == true) {
+                dismissUIPublisher.send()
+            }
+        }
     }
 
     static func reset() {
         b2bMFAAuthenticateResponse = nil
-        secret = nil
-        recoveryCodes = nil
+        totpResponse = nil
+        b2bAuthenticateResponse = nil
         didSaveRecoveryCodes = false
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/B2BPasswordsViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/B2BPasswordsViewModel.swift
@@ -29,6 +29,8 @@ final class B2BPasswordsViewModel {
             return
         }
 
+        StytchB2BUIClient.startLoading()
+
         Task {
             do {
                 let member = try? await AuthenticationOperations.searchMember(emailAddress: emailAddress, organizationId: organizationId)
@@ -40,14 +42,16 @@ final class B2BPasswordsViewModel {
                         locale: .en
                     )
                     let response = try await StytchB2BClient.passwords.authenticate(parameters: parameters)
-                    B2BAuthenticationManager.handleMFAReponse(b2bMFAAuthenticateResponse: response)
+                    B2BAuthenticationManager.handlePrimaryMFAReponse(b2bMFAAuthenticateResponse: response)
                     delegate?.didAuthenticateWithPassword()
                 } else {
                     try await AuthenticationOperations.sendEmailMagicLinkIfPossible(emailAddress: emailAddress, organizationId: organizationId, redirectUrl: state.configuration.redirectUrl)
                     delegate?.didSendEmailMagicLink()
                 }
+                StytchB2BUIClient.stopLoading()
             } catch {
                 delegate?.didError(error: error)
+                StytchB2BUIClient.stopLoading()
             }
         }
     }

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController+MFA.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController+MFA.swift
@@ -12,9 +12,9 @@ extension BaseViewController {
             if b2bMFAAuthenticateResponse?.primaryRequired != nil {
                 viewController = B2BAuthHomeViewController(state: .init(configuration: configuration))
             } else if b2bMFAAuthenticateResponse?.member.mfaEnrolled == true {
-                if b2bMFAAuthenticateResponse?.mfaRequired?.memberOptions?.mfaPhoneNumber != nil {
+                if b2bMFAAuthenticateResponse?.mfaRequired?.secondaryAuthInitiated == "sms_otp" {
                     viewController = SMSOTPEntryViewController(state: .init(configuration: configuration))
-                } else if b2bMFAAuthenticateResponse?.mfaRequired?.memberOptions?.totpRegistrationId == nil {
+                } else if b2bMFAAuthenticateResponse?.mfaRequired?.memberOptions?.totpRegistrationId != nil {
                     viewController = TOTPEntryViewController(state: .init(configuration: configuration))
                 }
             } else {

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/DiscoveryManager.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/DiscoveryManager.swift
@@ -14,7 +14,7 @@ struct DiscoveryManager {
                 sessionDuration: configuration.sessionDurationMinutes
             )
         )
-        B2BAuthenticationManager.handleMFAReponse(b2bMFAAuthenticateResponse: response)
+        B2BAuthenticationManager.handlePrimaryMFAReponse(b2bMFAAuthenticateResponse: response)
     }
 
     static func reset() {

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/MemberManager.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/MemberManager.swift
@@ -30,6 +30,7 @@ struct MemberManager {
     }
 
     static func updateMemberEmailAddress(_ emailAddress: String) {
+        StytchB2BUIClient.reset()
         _emailAddress = emailAddress
     }
 

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BEmailMagicLinksViewController/B2BEmailMagicLinksViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BEmailMagicLinksViewController/B2BEmailMagicLinksViewModel.swift
@@ -14,6 +14,7 @@ final class B2BEmailMagicLinksViewModel {
         completion: @escaping (Error?) -> Void
     ) {
         MemberManager.updateMemberEmailAddress(emailAddress)
+        StytchB2BUIClient.startLoading()
         Task {
             do {
                 if state.configuration.authFlowType == .discovery {
@@ -36,8 +37,10 @@ final class B2BEmailMagicLinksViewModel {
                     )
                 }
                 completion(nil)
+                StytchB2BUIClient.stopLoading()
             } catch {
                 completion(error)
+                StytchB2BUIClient.stopLoading()
             }
         }
     }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BOAuthViewController/B2BOAuthViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BOAuthViewController/B2BOAuthViewModel.swift
@@ -33,7 +33,7 @@ extension B2BOAuthViewModel {
         )
         let response = try await StytchB2BClient.oauth.authenticate(parameters: authenticateParameters)
 
-        B2BAuthenticationManager.handleMFAReponse(b2bMFAAuthenticateResponse: response)
+        B2BAuthenticationManager.handlePrimaryMFAReponse(b2bMFAAuthenticateResponse: response)
     }
 
     func startDiscoveryOAuth(

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BSSOViewController/B2BSSOViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BSSOViewController/B2BSSOViewController.swift
@@ -40,13 +40,16 @@ final class B2BSSOViewController: BaseViewController<SSOState, SSOViewModel> {
             return
         }
 
+        StytchB2BUIClient.startLoading()
         Task {
             do {
                 try await viewModel.startSSO(connectionId: ssoActiveConnection.connectionId)
                 delegate?.ssoDidAuthenticatie()
+                StytchB2BUIClient.stopLoading()
             } catch {
                 try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
                 presentErrorAlert(error: error)
+                StytchB2BUIClient.stopLoading()
             }
         }
     }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BSSOViewController/B2BSSOViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BSSOViewController/B2BSSOViewModel.swift
@@ -27,7 +27,7 @@ final class SSOViewModel {
             locale: .en
         )
         let response = try await StytchB2BClient.sso.authenticate(parameters: authenticateParameters)
-        B2BAuthenticationManager.handleMFAReponse(b2bMFAAuthenticateResponse: response)
+        B2BAuthenticationManager.handlePrimaryMFAReponse(b2bMFAAuthenticateResponse: response)
     }
 }
 

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
@@ -84,7 +84,7 @@ extension B2BAuthRootViewController {
 
             let loadingView = UIView()
             // swiftlint:disable:next object_literal
-            loadingView.backgroundColor = UIColor(white: 1.0, alpha: 0.8)
+            loadingView.backgroundColor = UIColor(white: 1.0, alpha: 0.2)
             loadingView.translatesAutoresizingMaskIntoConstraints = false
 
             let activityIndicator = UIActivityIndicatorView(style: .large)

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAEnrollmentSelectionTableViewCell.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAEnrollmentSelectionTableViewCell.swift
@@ -6,7 +6,7 @@ class MFAEnrollmentSelectionTableViewCell: UITableViewCell {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.systemFont(ofSize: 16)
-        label.textColor = .black
+        label.textColor = .primaryText
         return label
     }()
 
@@ -38,6 +38,8 @@ class MFAEnrollmentSelectionTableViewCell: UITableViewCell {
             disclosureImageView.widthAnchor.constraint(equalToConstant: 12),
             disclosureImageView.heightAnchor.constraint(equalToConstant: 12),
         ])
+
+        backgroundColor = .background
     }
 
     @available(*, unavailable)

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAEnrollmentSelectionViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAEnrollmentSelectionViewController.swift
@@ -34,6 +34,8 @@ final class MFAEnrollmentSelectionViewController: BaseViewController<MFAEnrollme
         NSLayoutConstraint.activate(
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
+
+        view.backgroundColor = .background
     }
 }
 

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAMethodSelectionViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAMethodSelectionViewController.swift
@@ -22,7 +22,7 @@ class MFAMethodSelectionViewController: UIViewController, UITableViewDataSource,
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        view.backgroundColor = .background
 
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeEntryViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeEntryViewController.swift
@@ -7,6 +7,18 @@ final class RecoveryCodeEntryViewController: BaseViewController<RecoveryCodeEntr
         text: NSLocalizedString("stytchRecoveryCodeEntryTitle", value: "Enter backup code", comment: "")
     )
 
+    private let subtitleLabel: UILabel = .makeSubtitleLabel(
+        text: NSLocalizedString("stytchRecoveryCodeEntrySubtitle", value: "Enter one of the backup codes you saved when setting up your authenticator app.", comment: "")
+    )
+
+    private lazy var recoveryCodeInput: RecoveryCodeInput = .init()
+
+    private lazy var continueButton: Button = .primary(
+        title: NSLocalizedString("stytch.pwContinueTitle", value: "Continue", comment: "")
+    ) { [weak self] in
+        self?.recoveryCodeEntered()
+    }
+
     init(state: RecoveryCodeEntryState) {
         super.init(viewModel: RecoveryCodeEntryViewModel(state: state))
     }
@@ -14,14 +26,32 @@ final class RecoveryCodeEntryViewController: BaseViewController<RecoveryCodeEntr
     override func configureView() {
         super.configureView()
 
-        stackView.spacing = .spacingRegular
+        stackView.spacing = .spacingLarge
 
         stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(subtitleLabel)
+        stackView.addArrangedSubview(recoveryCodeInput)
+        stackView.addArrangedSubview(continueButton)
+        stackView.addArrangedSubview(SpacerView())
 
         attachStackView(within: view)
 
         NSLayoutConstraint.activate(
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
+    }
+
+    @objc func recoveryCodeEntered() {
+        guard let recoveryCode = recoveryCodeInput.text else {
+            return
+        }
+
+        Task {
+            do {
+                try await viewModel.recover(recoveryCode: recoveryCode)
+            } catch {
+                presentErrorAlert(error: error)
+            }
+        }
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeEntryViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeEntryViewModel.swift
@@ -8,6 +8,24 @@ final class RecoveryCodeEntryViewModel {
     ) {
         self.state = state
     }
+
+    func recover(recoveryCode: String) async throws {
+        guard let organizationId = OrganizationManager.organizationId else {
+            throw StytchSDKError.noOrganziationId
+        }
+
+        guard let memberId = MemberManager.memberId else {
+            throw StytchSDKError.noMemberId
+        }
+
+        let parameters = StytchB2BClient.RecoveryCodes.RecoveryCodesRecoverParameters(
+            sessionDurationMinutes: .defaultSessionDuration,
+            organizationId: organizationId,
+            memberId: memberId,
+            recoveryCode: recoveryCode
+        )
+        let response = try await StytchB2BClient.recoveryCodes.recover(parameters: parameters)
+    }
 }
 
 struct RecoveryCodeEntryState {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeInput.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeInput.swift
@@ -1,0 +1,50 @@
+import UIKit
+
+final class RecoveryCodeInput: TextInputView<RecoveryCodeTextField> {
+    var text: String? { textInput.text }
+
+    var onReturn: (Bool) -> Void = { _ in }
+
+    // swiftlint:disable:next overridden_super_call
+    override func setUp() {
+        NotificationCenter.default.addObserver(forName: UITextField.textDidChangeNotification, object: textInput, queue: .main) { [weak self] _ in
+            guard let self else { return }
+            self.onTextChanged(self.isValid)
+        }
+        textInput.textContentType = .none
+        textInput.delegate = self
+        textInput.accessibilityLabel = "recoveryCodeEntry"
+    }
+}
+
+final class RecoveryCodeTextField: BorderedTextField, TextInputType {
+    var isValid: Bool {
+        true
+    }
+
+    var fields: [UIView] { [self] }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        placeholder = NSLocalizedString("stytch.recoveryCodePlaceholder", value: "Enter backup code", comment: "")
+        autocapitalizationType = .none
+        autocorrectionType = .no
+        background = UIColor.clear.image()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension RecoveryCodeInput: UITextFieldDelegate {
+    func textField(_: UITextField, shouldChangeCharactersIn _: NSRange, replacementString _: String) -> Bool {
+        true
+    }
+
+    func textFieldShouldReturn(_: UITextField) -> Bool {
+        onReturn(isValid)
+        return true
+    }
+}

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeSaveViewController/RecoveryCodeSaveViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeSaveViewController/RecoveryCodeSaveViewController.swift
@@ -7,6 +7,22 @@ final class RecoveryCodeSaveViewController: BaseViewController<RecoveryCodeSaveS
         text: NSLocalizedString("stytchRecoveryCodeSaveTitle", value: "Save your backup codes!", comment: "")
     )
 
+    private let subtitleLabel: UILabel = .makeSubtitleLabel(
+        text: NSLocalizedString("stytchRecoveryCodeSaveSubtitle", value: "This is the only time you will be able to access and save your backup codes.", comment: "")
+    )
+
+    private lazy var saveButton: Button = .primary(
+        title: NSLocalizedString("stytchRecoveryCodeSaveButton", value: "Save", comment: "")
+    ) { [weak self] in
+        self?.saveTapped()
+    }
+
+    private lazy var copyButton: Button = .primary(
+        title: NSLocalizedString("stytchRecoveryCodeSaveCopy", value: "Copy", comment: "")
+    ) { [weak self] in
+        self?.copyTapped()
+    }
+
     init(state: RecoveryCodeSaveState) {
         super.init(viewModel: RecoveryCodeSaveViewModel(state: state))
     }
@@ -17,11 +33,46 @@ final class RecoveryCodeSaveViewController: BaseViewController<RecoveryCodeSaveS
         stackView.spacing = .spacingRegular
 
         stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(subtitleLabel)
+        let recoveryCodesListView = RecoveryCodesListView(codes: B2BAuthenticationManager.recoveryCodes)
+        stackView.addArrangedSubview(recoveryCodesListView)
+
+        let doneButton = Button.createTextButton(
+            withPlainText: "",
+            boldText: "Done",
+            action: #selector(doneTapped),
+            target: self
+        )
+
+        let buttonStackView = UIStackView()
+        buttonStackView.axis = .horizontal
+        buttonStackView.distribution = .fillEqually
+        buttonStackView.spacing = 8
+        buttonStackView.addArrangedSubview(saveButton)
+        buttonStackView.addArrangedSubview(copyButton)
+        stackView.addArrangedSubview(buttonStackView)
+
+        stackView.addArrangedSubview(doneButton)
+
+        stackView.addArrangedSubview(SpacerView())
 
         attachStackView(within: view)
 
         NSLayoutConstraint.activate(
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
+    }
+
+    @objc func doneTapped() {
+        B2BAuthenticationManager.recoveryCodesSaved()
+    }
+
+    @objc func saveTapped() {
+        presentShareSheet(text: B2BAuthenticationManager.recoveryCodes.joined(separator: "\n"))
+    }
+
+    @objc func copyTapped() {
+        UIPasteboard.general.string = B2BAuthenticationManager.recoveryCodes.joined(separator: "\n")
+        presentAlert(title: "Recovery Codes Copied!")
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeSaveViewController/RecoveryCodesListView.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeSaveViewController/RecoveryCodesListView.swift
@@ -1,0 +1,68 @@
+import UIKit
+
+// swiftlint:disable type_contents_order
+
+class RecoveryCodesListView: UIView {
+    var codes: [String] = []
+
+    init(codes: [String]) {
+        self.codes = codes
+        super.init(frame: .zero)
+        setupView(codes: codes)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView(codes: codes)
+    }
+
+    // Override intrinsicContentSize to fit content height
+    override var intrinsicContentSize: CGSize {
+        // Calculate the height based on the number of codes, spacing, and padding
+        let numberOfCodes = codes.count
+        let labelHeight: CGFloat = 20 // Estimated height of each label
+        let spacing: CGFloat = 8 // Stack view spacing
+        let padding: CGFloat = 32 // Top + bottom padding (16 + 16)
+        let totalHeight = CGFloat(numberOfCodes) * labelHeight + CGFloat(numberOfCodes - 1) * spacing + padding
+        return CGSize(width: UIView.noIntrinsicMetric, height: totalHeight)
+    }
+}
+
+extension RecoveryCodesListView {
+    private func setupView(codes: [String]) {
+        // Set up self
+        backgroundColor = UIColor.systemGray6
+        layer.cornerRadius = 8
+        translatesAutoresizingMaskIntoConstraints = false
+
+        // Create a stack view
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .fill // Ensure full width
+        stackView.distribution = .equalSpacing
+        stackView.spacing = 8
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stackView)
+
+        // Add constraints to stack view
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            stackView.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16),
+        ])
+
+        // Add labels to the stack view
+        for code in codes {
+            let label = UILabel()
+            label.text = code
+            label.textColor = .primaryText
+            label.textAlignment = .center
+            label.font = UIFont.systemFont(ofSize: 16)
+            label.numberOfLines = 1 // Ensure single line per code
+            stackView.addArrangedSubview(label)
+        }
+
+        layoutMargins = .default
+    }
+}

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPEnrollmentViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPEnrollmentViewModel.swift
@@ -20,7 +20,7 @@ final class TOTPEnrollmentViewModel {
 
         let parameters = StytchB2BClient.TOTP.CreateParameters(organizationId: organizationId, memberId: memberId, expirationMinutes: 30)
         let response = try await StytchB2BClient.totp.create(parameters: parameters)
-        B2BAuthenticationManager.updateTotpState(totpResponse: response.wrapped)
+        B2BAuthenticationManager.handleTOTPResponse(totpResponse: response.wrapped)
         return response.wrapped.secret
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEntryViewController/TOTPEntryViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEntryViewController/TOTPEntryViewController.swift
@@ -53,12 +53,15 @@ final class TOTPEntryViewController: BaseViewController<TOTPEntryState, TOTPEntr
 
 extension TOTPEntryViewController: OTPCodeEntryViewDelegate {
     func didEnterOTPCode(_ code: String) {
+        StytchB2BUIClient.startLoading()
         Task { [weak self] in
             do {
                 try await self?.viewModel.authenticateTOTP(code: code)
                 self?.continueWithTOTP()
+                StytchB2BUIClient.stopLoading()
             } catch {
                 self?.presentErrorAlert(error: error)
+                StytchB2BUIClient.stopLoading()
             }
         }
     }


### PR DESCRIPTION
[[iOS] Build RecoveryCodeSave](https://linear.app/stytch/issue/SDK-2269/[ios]-build-recoverycodesavel)

## Changes:

1. Modify the logic for when to dismiss the ui, works correctly there are still bugs in the way we present things on SwiftUI. The only flow that is built but not working properly is the recovery codes save screen.
2. The `B2BAuthenticationManager` now has a publisher for `dismissUI` where the logic runs internally.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
