### PR TITLE
[B2B UI] Add password screens to B2B UI

### DIFF
--- a/Sources/StytchUI/Extensions/UILabel+StytchUI.swift
+++ b/Sources/StytchUI/Extensions/UILabel+StytchUI.swift
@@ -28,6 +28,22 @@ extension UILabel {
         return label
     }
 
+    static func makeEmailInputLabel() -> UILabel {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14)
+        label.textColor = .secondaryText
+        label.text = NSLocalizedString("stytch.emailInputLabel", value: "Email", comment: "")
+        return label
+    }
+
+    static func makePasswordInputLabel() -> UILabel {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14)
+        label.textColor = .secondaryText
+        label.text = NSLocalizedString("stytch.passwordInputLabel", value: "Password", comment: "")
+        return label
+    }
+
     static func makeComboLabel(
         withPlainText plainText: String,
         boldText: String? = nil,

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/AuthenticationOperations.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/AuthenticationOperations.swift
@@ -24,21 +24,6 @@ struct AuthenticationOperations {
         return response.member
     }
 
-    static func resetPassword(emailAddress: String, organizationId: String, redirectUrl: URL?) async throws {
-        let member = try await searchMember(emailAddress: emailAddress, organizationId: organizationId)
-        if member?.memberPasswordId != nil {
-            let parameters = StytchB2BClient.Passwords.ResetByEmailStartParameters(
-                organizationId: Organization.ID(rawValue: organizationId),
-                emailAddress: emailAddress,
-                resetPasswordUrl: redirectUrl,
-                locale: .en
-            )
-            _ = try await StytchB2BClient.passwords.resetByEmailStart(parameters: parameters)
-        } else {
-            try await sendEmailMagicLinkIfPossible(emailAddress: emailAddress, organizationId: organizationId, redirectUrl: redirectUrl)
-        }
-    }
-
     static func sendEmailMagicLinkIfPossible(emailAddress: String, organizationId: String, redirectUrl: URL?) async throws {
         let emailAllowedDomains = OrganizationManager.emailAllowedDomains
         let emailJitProvisioning = OrganizationManager.emailJitProvisioning
@@ -59,20 +44,5 @@ struct AuthenticationOperations {
             locale: .en
         )
         _ = try await StytchB2BClient.magicLinks.email.loginOrSignup(parameters: parameters)
-    }
-
-    static func createTOTP() async throws -> String {
-        guard let organizationId = OrganizationManager.organizationId else {
-            throw StytchSDKError.noOrganziationId
-        }
-
-        guard let memberId = MemberManager.memberId else {
-            throw StytchSDKError.noMemberId
-        }
-
-        let parameters = StytchB2BClient.TOTP.CreateParameters(organizationId: organizationId, memberId: memberId, expirationMinutes: 30)
-        let response = try await StytchB2BClient.totp.create(parameters: parameters)
-        B2BAuthenticationManager.handleTOTPResponse(totpResponse: response.wrapped)
-        return response.wrapped.secret
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController+MFA.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController+MFA.swift
@@ -32,4 +32,11 @@ extension BaseViewController {
             }
         }
     }
+
+    func showEmailConfirmation(configuration: StytchB2BUIClient.Configuration, type: EmailConfirmationType) {
+        Task { @MainActor in
+            let emailConfirmationViewController = EmailConfirmationViewController(state: .init(configuration: configuration, type: type))
+            navigationController?.pushViewController(emailConfirmationViewController, animated: true)
+        }
+    }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/MemberManager.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/MemberManager.swift
@@ -30,7 +30,9 @@ struct MemberManager {
     }
 
     static func updateMemberEmailAddress(_ emailAddress: String) {
-        StytchB2BUIClient.reset()
+        B2BAuthenticationManager.reset()
+        DiscoveryManager.reset()
+        reset()
         _emailAddress = emailAddress
     }
 

--- a/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient.swift
@@ -66,9 +66,17 @@ public enum StytchB2BUIClient {
                 }
             case .notHandled:
                 break
-            case let .manualHandlingRequired(tokenType, token):
-                print(tokenType)
-                print(token)
+            case let .manualHandlingRequired(_, token):
+                let email = MemberManager.emailAddress ?? .redactedEmail
+                if let currentController {
+                    currentController.handlePasswordReset(token: token, email: email)
+                } else {
+                    let rootController = B2BAuthRootViewController(configuration: configuration)
+                    currentController = rootController
+                    setUpDismissAuthListener()
+                    controller?.present(UINavigationController(rootViewController: rootController), animated: true)
+                    rootController.handlePasswordReset(token: token, email: email, animated: false)
+                }
             }
             stopLoading()
         }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BAuthHomeViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BAuthHomeViewController.swift
@@ -124,28 +124,12 @@ final class B2BAuthHomeViewController: BaseViewController<B2BAuthHomeState, B2BA
         NSLayoutConstraint.activate(constraints)
     }
 
-    func continueAuthenticationFlowIfNeeded() {
-        Task { @MainActor in
-            if viewModel.state.configuration.authFlowType == .discovery {
-                let discoveryViewController = DiscoveryViewController(state: .init(configuration: viewModel.state.configuration))
-                navigationController?.pushViewController(discoveryViewController, animated: true)
-            } else {
-                startMFAFlowIfNeeded(configuration: viewModel.state.configuration)
-            }
-        }
-    }
-
-    func showEmaiilConfirmation() {
-        Task { @MainActor in
-            let emailConfirmationViewController = EmailConfirmationViewController(state: .init(configuration: viewModel.state.configuration, type: .emailConfirmation))
-            navigationController?.pushViewController(emailConfirmationViewController, animated: true)
-        }
-    }
+    func continueAuthenticationFlowIfNeeded() {}
 }
 
 extension B2BAuthHomeViewController: B2BOAuthViewControllerDelegate {
     func oauthDidAuthenticatie() {
-        continueAuthenticationFlowIfNeeded()
+        startMFAFlowIfNeeded(configuration: viewModel.state.configuration)
     }
 
     func oauthDiscoveryDidAuthenticatie() {
@@ -155,7 +139,7 @@ extension B2BAuthHomeViewController: B2BOAuthViewControllerDelegate {
 
 extension B2BAuthHomeViewController: B2BEmailMagicLinksViewControllerDelegate {
     func emailMagicLinkSent() {
-        showEmaiilConfirmation()
+        showEmailConfirmation(configuration: viewModel.state.configuration, type: .emailConfirmation)
     }
 
     func usePasswordInstead() {
@@ -168,16 +152,16 @@ extension B2BAuthHomeViewController: B2BEmailMagicLinksViewControllerDelegate {
 
 extension B2BAuthHomeViewController: B2BPasswordsHomeViewControllerDelegate {
     func didAuthenticateWithPassword() {
-        continueAuthenticationFlowIfNeeded()
+        startMFAFlowIfNeeded(configuration: viewModel.state.configuration)
     }
 
     func didSendEmailMagicLink() {
-        showEmaiilConfirmation()
+        showEmailConfirmation(configuration: viewModel.state.configuration, type: .passwordResetVerify)
     }
 }
 
 extension B2BAuthHomeViewController: B2BSSOViewControllerDelegate {
     func ssoDidAuthenticatie() {
-        continueAuthenticationFlowIfNeeded()
+        startMFAFlowIfNeeded(configuration: viewModel.state.configuration)
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BPasswordsHomeViewController/B2BPasswordsHomeViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BPasswordsHomeViewController/B2BPasswordsHomeViewController.swift
@@ -10,23 +10,11 @@ protocol B2BPasswordsHomeViewControllerDelegate: AnyObject {
 final class B2BPasswordsHomeViewController: BaseViewController<B2BPasswordsState, B2BPasswordsViewModel> {
     weak var delegate: B2BPasswordsHomeViewControllerDelegate?
 
-    private let emailInputLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 14)
-        label.textColor = .secondaryText
-        label.text = NSLocalizedString("stytch.emailInputLabel", value: "Email", comment: "")
-        return label
-    }()
+    private let emailInputLabel = UILabel.makeEmailInputLabel()
 
     private lazy var emailInput: EmailInput = .init()
 
-    private let passwordInputLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 14)
-        label.textColor = .secondaryText
-        label.text = NSLocalizedString("stytch.passwordInputLabel", value: "Password", comment: "")
-        return label
-    }()
+    private let passwordInputLabel = UILabel.makePasswordInputLabel()
 
     private lazy var passwordInput: SecureTextInput = {
         let input: SecureTextInput = .init(frame: .zero)

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailConfirmationViewController/EmailConfirmationViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailConfirmationViewController/EmailConfirmationViewController.swift
@@ -46,9 +46,24 @@ final class EmailConfirmationViewController: BaseViewController<EmailConfirmatio
         case .emailConfirmation:
             navigationController?.popToRootViewController(animated: true)
         case .passwordSetNew:
-            break
+            resetByEmailStart()
         case .passwordResetVerify:
-            break
+            navigationController?.popToRootViewController(animated: true)
+        }
+    }
+
+    func resetByEmailStart() {
+        guard let emailAddress = MemberManager.emailAddress else {
+            return
+        }
+
+        Task {
+            do {
+                try await viewModel.resetByEmailStart(emailAddress: emailAddress)
+                presentAlert(title: "Email Sent!")
+            } catch {
+                presentErrorAlert(error: error)
+            }
         }
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailConfirmationViewController/EmailConfirmationViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailConfirmationViewController/EmailConfirmationViewModel.swift
@@ -8,6 +8,20 @@ final class EmailConfirmationViewModel {
     ) {
         self.state = state
     }
+
+    func resetByEmailStart(emailAddress: String) async throws {
+        guard let organizationId = OrganizationManager.organizationId else {
+            throw StytchSDKError.noOrganziationId
+        }
+
+        let parameters = StytchB2BClient.Passwords.ResetByEmailStartParameters(
+            organizationId: Organization.ID(rawValue: organizationId),
+            emailAddress: emailAddress,
+            resetPasswordUrl: state.configuration.redirectUrl,
+            locale: .en
+        )
+        _ = try await StytchB2BClient.passwords.resetByEmailStart(parameters: parameters)
+    }
 }
 
 extension EmailConfirmationViewModel {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordAuthenticateViewController/PasswordAuthenticateViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordAuthenticateViewController/PasswordAuthenticateViewController.swift
@@ -7,6 +7,38 @@ final class PasswordAuthenticateViewController: BaseViewController<B2BPasswordsS
         text: NSLocalizedString("stytchPasswordAuthenticateTitle", value: "Log in with email and password", comment: "")
     )
 
+    private let emailInputLabel = UILabel.makeEmailInputLabel()
+
+    private lazy var emailInput: EmailInput = .init()
+
+    private let passwordInputLabel = UILabel.makePasswordInputLabel()
+
+    private lazy var passwordInput: SecureTextInput = {
+        let input: SecureTextInput = .init(frame: .zero)
+        input.textInput.textContentType = .password
+        input.textInput.rightView = secureEntryToggleButton
+        input.textInput.rightViewMode = .always
+        return input
+    }()
+
+    private lazy var secureEntryToggleButton: UIButton = {
+        let button = UIButton(type: .custom)
+        button.adjustsImageWhenHighlighted = false
+        button.setImage(UIImage(systemName: "eye"), for: .normal)
+        button.imageView?.contentMode = .scaleAspectFit
+        button.tintColor = .secondaryText
+        button.addTarget(self, action: #selector(toggleSecureEntry(sender:)), for: .touchUpInside)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([button.heightAnchor.constraint(equalToConstant: 12.5)])
+        return button
+    }()
+
+    private lazy var continueButton: Button = .primary(
+        title: NSLocalizedString("stytch.pwContinueTitle", value: "Continue", comment: "")
+    ) { [weak self] in
+        self?.submit()
+    }
+
     init(state: B2BPasswordsState) {
         super.init(viewModel: B2BPasswordsViewModel(state: state))
         viewModel.delegate = self
@@ -17,7 +49,21 @@ final class PasswordAuthenticateViewController: BaseViewController<B2BPasswordsS
 
         stackView.spacing = .spacingRegular
 
+        let signUpOrResetPasswordButton = Button.createTextButton(
+            withPlainText: "",
+            boldText: "Sign up or reset password",
+            action: #selector(signUpOrResetPasswordButtonTapped),
+            target: self
+        )
+
         stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(emailInputLabel)
+        stackView.addArrangedSubview(emailInput)
+        stackView.addArrangedSubview(passwordInputLabel)
+        stackView.addArrangedSubview(passwordInput)
+        stackView.addArrangedSubview(continueButton)
+        stackView.addArrangedSubview(signUpOrResetPasswordButton)
+        stackView.addArrangedSubview(SpacerView())
 
         attachStackView(within: view)
 
@@ -25,12 +71,32 @@ final class PasswordAuthenticateViewController: BaseViewController<B2BPasswordsS
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
     }
+
+    @objc private func toggleSecureEntry(sender _: UIButton) {
+        passwordInput.textInput.isSecureTextEntry.toggle()
+    }
+
+    @objc private func signUpOrResetPasswordButtonTapped() {
+        navigationController?.pushViewController(PasswordForgotViewController(state: .init(configuration: viewModel.state.configuration)), animated: true)
+    }
+
+    private func submit() {
+        guard let emailAddress = emailInput.text, let password = passwordInput.text else {
+            // show error
+            return
+        }
+        viewModel.authenticateWithPasswordIfPossible(emailAddress: emailAddress, password: password)
+    }
 }
 
 extension PasswordAuthenticateViewController: B2BPasswordsViewModelDelegate {
-    func didAuthenticateWithPassword() {}
+    func didAuthenticateWithPassword() {
+        startMFAFlowIfNeeded(configuration: viewModel.state.configuration)
+    }
 
-    func didSendEmailMagicLink() {}
+    func didSendEmailMagicLink() {
+        showEmailConfirmation(configuration: viewModel.state.configuration, type: .passwordResetVerify)
+    }
 
     func didError(error: any Error) {
         presentErrorAlert(error: error)

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordForgotViewController/PasswordForgotViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordForgotViewController/PasswordForgotViewController.swift
@@ -3,11 +3,90 @@ import StytchCore
 import UIKit
 
 final class PasswordForgotViewController: BaseViewController<PasswordForgotState, PasswordForgotViewModel> {
+    private let titleLabel: UILabel = .makeTitleLabel(
+        text: NSLocalizedString("stytchPasswordForgotTitle", value: "Check your email for help signing in!", comment: "")
+    )
+
+    private let subtitleLabel: UILabel = .makeSubtitleLabel(
+        text: NSLocalizedString("stytchPasswordForgotSubtitle", value: "We'll email you a login link to sign in to your account directly or reset your password if you have one.", comment: "")
+    )
+
+    private let emailInputLabel = UILabel.makeEmailInputLabel()
+
+    private lazy var emailInput: EmailInput = .init()
+
+    private lazy var continueButton: Button = .primary(
+        title: NSLocalizedString("stytch.pwContinueTitle", value: "Continue", comment: "")
+    ) { [weak self] in
+        self?.continueWithPasswordResetIfPossible()
+    }
+
     init(state: PasswordForgotState) {
         super.init(viewModel: PasswordForgotViewModel(state: state))
+        viewModel.delegate = self
     }
 
     override func configureView() {
         super.configureView()
+
+        stackView.spacing = .spacingRegular
+
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(subtitleLabel)
+        stackView.addArrangedSubview(emailInputLabel)
+        stackView.addArrangedSubview(emailInput)
+        stackView.addArrangedSubview(continueButton)
+        stackView.addArrangedSubview(SpacerView())
+
+        attachStackView(within: view)
+
+        NSLayoutConstraint.activate(
+            stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
+        )
+
+        setupEmailInput(input: emailInput)
+    }
+
+    private func setupEmailInput(input: EmailInput) {
+        input.onTextChanged = { [weak self] isValid in
+            guard let self else { return }
+
+            self.continueButton.isEnabled = isValid
+
+            switch (input.hasBeenValid, isValid) {
+            case (_, true):
+                input.setFeedback(nil)
+            case (true, false):
+                input.setFeedback(
+                    .error(
+                        NSLocalizedString("stytch.invalidEmail", value: "Invalid email address, please try again.", comment: "")
+                    )
+                )
+            case (false, false):
+                break
+            }
+        }
+    }
+
+    @objc private func continueWithPasswordResetIfPossible() {
+        guard let emailAddress = emailInput.text else {
+            return
+        }
+
+        viewModel.resetPassword(emailAddress: emailAddress)
+    }
+}
+
+extension PasswordForgotViewController: PasswordForgotViewModelDelegate {
+    func didSendResetByEmailStart() {
+        showEmailConfirmation(configuration: viewModel.state.configuration, type: .passwordSetNew)
+    }
+
+    func didSendEmailMagicLink() {
+        showEmailConfirmation(configuration: viewModel.state.configuration, type: .passwordResetVerify)
+    }
+
+    func didError(error: any Error) {
+        presentErrorAlert(error: error)
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordForgotViewController/PasswordForgotViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordForgotViewController/PasswordForgotViewModel.swift
@@ -1,12 +1,49 @@
 import StytchCore
 
+protocol PasswordForgotViewModelDelegate: AnyObject {
+    func didSendResetByEmailStart()
+    func didSendEmailMagicLink()
+    func didError(error: Error)
+}
+
 final class PasswordForgotViewModel {
     let state: PasswordForgotState
+    weak var delegate: PasswordForgotViewModelDelegate?
 
     init(
         state: PasswordForgotState
     ) {
         self.state = state
+    }
+
+    func resetPassword(emailAddress: String) {
+        MemberManager.updateMemberEmailAddress(emailAddress)
+
+        guard let organizationId = OrganizationManager.organizationId else {
+            delegate?.didError(error: StytchSDKError.noOrganziationId)
+            return
+        }
+
+        Task {
+            do {
+                let member = try await AuthenticationOperations.searchMember(emailAddress: emailAddress, organizationId: organizationId)
+                if member?.memberPasswordId != nil {
+                    let parameters = StytchB2BClient.Passwords.ResetByEmailStartParameters(
+                        organizationId: Organization.ID(rawValue: organizationId),
+                        emailAddress: emailAddress,
+                        resetPasswordUrl: state.configuration.redirectUrl,
+                        locale: .en
+                    )
+                    _ = try await StytchB2BClient.passwords.resetByEmailStart(parameters: parameters)
+                    delegate?.didSendResetByEmailStart()
+                } else {
+                    try await AuthenticationOperations.sendEmailMagicLinkIfPossible(emailAddress: emailAddress, organizationId: organizationId, redirectUrl: state.configuration.redirectUrl)
+                    delegate?.didSendEmailMagicLink()
+                }
+            } catch {
+                delegate?.didError(error: error)
+            }
+        }
     }
 }
 

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordResetViewController/PasswordResetViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordResetViewController/PasswordResetViewController.swift
@@ -3,11 +3,76 @@ import StytchCore
 import UIKit
 
 final class PasswordResetViewController: BaseViewController<PasswordResetState, PasswordResetViewModel> {
+    private let titleLabel: UILabel = .makeTitleLabel(
+        text: NSLocalizedString("stytchPasswordResetTitle", value: "Set a new password", comment: "")
+    )
+
+    private let passwordInputLabel = UILabel.makePasswordInputLabel()
+
+    private lazy var passwordInput: SecureTextInput = {
+        let input: SecureTextInput = .init(frame: .zero)
+        input.textInput.textContentType = .password
+        input.textInput.rightView = secureEntryToggleButton
+        input.textInput.rightViewMode = .always
+        return input
+    }()
+
+    private lazy var secureEntryToggleButton: UIButton = {
+        let button = UIButton(type: .custom)
+        button.adjustsImageWhenHighlighted = false
+        button.setImage(UIImage(systemName: "eye"), for: .normal)
+        button.imageView?.contentMode = .scaleAspectFit
+        button.tintColor = .secondaryText
+        button.addTarget(self, action: #selector(toggleSecureEntry(sender:)), for: .touchUpInside)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([button.heightAnchor.constraint(equalToConstant: 12.5)])
+        return button
+    }()
+
+    private lazy var continueButton: Button = .primary(
+        title: NSLocalizedString("stytch.pwContinueTitle", value: "Continue", comment: "")
+    ) { [weak self] in
+        self?.continueWithPasswordResetIfPossible()
+    }
+
     init(state: PasswordResetState) {
         super.init(viewModel: PasswordResetViewModel(state: state))
     }
 
     override func configureView() {
         super.configureView()
+
+        stackView.spacing = .spacingRegular
+
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(passwordInputLabel)
+        stackView.addArrangedSubview(passwordInput)
+        stackView.addArrangedSubview(continueButton)
+        stackView.addArrangedSubview(SpacerView())
+
+        attachStackView(within: view)
+
+        NSLayoutConstraint.activate(
+            stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
+        )
+    }
+
+    @objc private func toggleSecureEntry(sender _: UIButton) {
+        passwordInput.textInput.isSecureTextEntry.toggle()
+    }
+
+    @objc private func continueWithPasswordResetIfPossible() {
+        guard let password = passwordInput.text else {
+            return
+        }
+
+        Task {
+            do {
+                try await viewModel.resetPassword(newPassword: password)
+                startMFAFlowIfNeeded(configuration: viewModel.state.configuration)
+            } catch {
+                presentErrorAlert(error: error)
+            }
+        }
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordResetViewController/PasswordResetViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordResetViewController/PasswordResetViewModel.swift
@@ -8,6 +8,17 @@ final class PasswordResetViewModel {
     ) {
         self.state = state
     }
+
+    func resetPassword(newPassword: String) async throws {
+        let response = try await StytchB2BClient.passwords.resetByEmail(
+            parameters: .init(
+                token: state.token,
+                password: newPassword,
+                locale: .en
+            )
+        )
+        B2BAuthenticationManager.handlePrimaryMFAReponse(b2bMFAAuthenticateResponse: response)
+    }
 }
 
 struct PasswordResetState {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeEntryViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeEntryViewModel.swift
@@ -25,6 +25,7 @@ final class RecoveryCodeEntryViewModel {
             recoveryCode: recoveryCode
         )
         let response = try await StytchB2BClient.recoveryCodes.recover(parameters: parameters)
+        B2BAuthenticationManager.handleSecondaryReponse(b2bAuthenticateResponse: response)
     }
 }
 

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/PasswordViewController/PasswordViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/PasswordViewController/PasswordViewController.swift
@@ -34,23 +34,11 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
         return label
     }()
 
-    private let emailInputLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 14)
-        label.textColor = .secondaryText
-        label.text = NSLocalizedString("stytch.emailInputLabel", value: "Email", comment: "")
-        return label
-    }()
+    private let emailInputLabel = UILabel.makeEmailInputLabel()
 
     private lazy var emailInput: EmailInput = .init()
 
-    private let passwordInputLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 14)
-        label.textColor = .secondaryText
-        label.text = NSLocalizedString("stytch.passwordInputLabel", value: "Password", comment: "")
-        return label
-    }()
+    private let passwordInputLabel = UILabel.makePasswordInputLabel()
 
     private lazy var passwordInput: SecureTextInput = {
         let input: SecureTextInput = .init(frame: .zero)

--- a/Stytch/DemoApps/B2BWorkbench/ViewControllers/AuthHomeViewController.swift
+++ b/Stytch/DemoApps/B2BWorkbench/ViewControllers/AuthHomeViewController.swift
@@ -117,7 +117,7 @@ final class AuthHomeViewController: UIViewController {
     static var allStytchB2BUIConfig: StytchB2BUIClient.Configuration = .init(
         publicToken: publicToken,
         products: [.emailMagicLinks, .sso, .passwords, .oauth],
-        authFlowType: .organization(slug: "no-mfa"),
+        authFlowType: .organization(slug: "mfa-required"),
         oauthProviders: [.init(provider: .google)]
     )
 


### PR DESCRIPTION
[[iOS] Build PasswordSetNew](https://linear.app/stytch/issue/SDK-2272/[ios]-build-passwordsetnew)
[[iOS] Build PasswordResetForm](https://linear.app/stytch/issue/SDK-2274/[ios]-build-passwordresetform)
[[iOS] Build PasswordForgotForm](https://linear.app/stytch/issue/SDK-2275/[ios]-build-passwordforgotform)
[[iOS] Build PasswordAuthenticate](https://linear.app/stytch/issue/SDK-2276/[ios]-build-passwordauthenticate)

## Changes:

1. Create centralized and parameterized place by which we show the `EmailConfirmationViewController`.
2. Centralize email and password label creation into one place.
3. Email reset and authentication flow.
4. Move more functionality into view models and out of the global place in `AuthenticationOperations`.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
