### PR TITLE
[B2B UI] SMS OTP Flows

### DIFF
--- a/Sources/StytchUI/Shared/OTPEntryViewControllerProtocol.swift
+++ b/Sources/StytchUI/Shared/OTPEntryViewControllerProtocol.swift
@@ -1,0 +1,69 @@
+import Foundation
+import UIKit
+
+protocol OTPEntryViewControllerProtocol: UIViewController {
+    var timer: Timer? { get }
+    var expirationDate: Date { get }
+    var expiryButton: Button { get }
+
+    func resendCode()
+    func presentCodeResetConfirmation()
+}
+
+extension OTPEntryViewControllerProtocol {
+    var dateFormatter: DateComponentsFormatter {
+        let dateFormatter = DateComponentsFormatter()
+        dateFormatter.allowedUnits = [.minute, .second]
+        return dateFormatter
+    }
+
+    func makeExpiryButton() -> Button {
+        let button = Button.tertiary(
+            title: ""
+        ) { [weak self] in
+            self?.presentCodeResetConfirmation()
+        }
+        button.setTitleColor(.secondaryText, for: .normal)
+        button.contentHorizontalAlignment = .leading
+        button.titleLabel?.numberOfLines = 0
+        button.accessibilityLabel = "expiryButton"
+        return button
+    }
+
+    func expiryAttributedText(initialSegment: String) -> NSAttributedString {
+        let attributedString = NSMutableAttributedString(string: initialSegment + NSLocalizedString("stytch.otpDidntGetIt", value: " Didn't get it?", comment: ""), attributes: [.font: UIFont.systemFont(ofSize: 16)])
+        let appendedAttributedString = NSAttributedString(string: NSLocalizedString("stytch.otpResendIt", value: " Resend it.", comment: ""), attributes: [.font: UIFont.systemFont(ofSize: 16, weight: .semibold)])
+        attributedString.append(appendedAttributedString)
+        return attributedString
+    }
+
+    func presentCodeResetConfirmation(message: String?) {
+        let controller = UIAlertController(
+            title: NSLocalizedString("stytch.otpResendCode", value: "Resend code", comment: ""),
+            message: message,
+            preferredStyle: .alert
+        )
+        controller.addAction(.init(title: NSLocalizedString("stytch.otpCancel", value: "Cancel", comment: ""), style: .default))
+        controller.addAction(.init(title: NSLocalizedString("stytch.otpConfirm", value: "Send code", comment: ""), style: .default) { [weak self] _ in
+            self?.resendCode()
+        })
+        controller.view.tintColor = .primaryText
+        present(controller, animated: true)
+    }
+
+    func updateExpirationText() {
+        if case let currentDate = Date(), expirationDate > currentDate, let dateString = dateFormatter.string(from: currentDate, to: expirationDate) {
+            expiryButton.setAttributedTitle(
+                expiryAttributedText(initialSegment: .localizedStringWithFormat(NSLocalizedString("stytch.otpCodeExpiresIn", value: "Your code expires in %@.", comment: ""), dateString)),
+                for: .normal
+            )
+        } else {
+            expiryButton.setAttributedTitle(
+                expiryAttributedText(initialSegment: NSLocalizedString("stytch.otpCodeExpired", value: "Your code has expired.", comment: "")),
+                for: .normal
+            )
+            timer?.invalidate()
+            return
+        }
+    }
+}

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/AuthenticationOperations.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/AuthenticationOperations.swift
@@ -45,4 +45,22 @@ struct AuthenticationOperations {
         )
         _ = try await StytchB2BClient.magicLinks.email.loginOrSignup(parameters: parameters)
     }
+
+    static func smsSend(phoneNumberE164: String) async throws {
+        guard let organizationId = OrganizationManager.organizationId else {
+            throw StytchSDKError.noOrganziationId
+        }
+
+        guard let memberId = MemberManager.memberId else {
+            throw StytchSDKError.noMemberId
+        }
+
+        let parameters = StytchB2BClient.OTP.SMS.SendParameters(
+            organizationId: organizationId,
+            memberId: memberId,
+            mfaPhoneNumber: phoneNumberE164,
+            locale: nil
+        )
+        _ = try await StytchB2BClient.otp.sms.send(parameters: parameters)
+    }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAMethodSelectionViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAMethodSelectionViewController.swift
@@ -23,6 +23,7 @@ class MFAMethodSelectionViewController: UIViewController, UITableViewDataSource,
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .background
+        tableView.backgroundColor = .background
 
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEnrollmentViewController/SMSOTPEnrollmentViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEnrollmentViewController/SMSOTPEnrollmentViewController.swift
@@ -1,4 +1,5 @@
 import AuthenticationServices
+import PhoneNumberKit
 import StytchCore
 import UIKit
 
@@ -6,6 +7,18 @@ final class SMSOTPEnrollmentViewController: BaseViewController<SMSOTPEnrollmentS
     private let titleLabel: UILabel = .makeTitleLabel(
         text: NSLocalizedString("stytchSMSOTPEnrollmentTitle", value: "Enter your phone number to set up Multi-Factor Authentication", comment: "")
     )
+
+    private let subtitleLabel: UILabel = .makeSubtitleLabel(
+        text: NSLocalizedString("stytchSMSOTPEnrollmentSubtitle", value: "Your organization requires an additional form of verification to make your account more secure.", comment: "")
+    )
+
+    private let phoneNumberInput: PhoneNumberInput = .init()
+
+    private lazy var continueButton: Button = .primary(
+        title: NSLocalizedString("stytch.pwContinueTitle", value: "Continue", comment: "")
+    ) { [weak self] in
+        self?.continueWithSMSOTP()
+    }
 
     init(state: SMSOTPEnrollmentState) {
         super.init(viewModel: SMSOTPEnrollmentViewModel(state: state))
@@ -17,11 +30,59 @@ final class SMSOTPEnrollmentViewController: BaseViewController<SMSOTPEnrollmentS
         stackView.spacing = .spacingRegular
 
         stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(subtitleLabel)
+        stackView.addArrangedSubview(phoneNumberInput)
+        stackView.addArrangedSubview(continueButton)
+        stackView.addArrangedSubview(SpacerView())
 
         attachStackView(within: view)
 
         NSLayoutConstraint.activate(
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
+
+        setupPhoneNumberInput(input: phoneNumberInput)
+    }
+
+    private func setupPhoneNumberInput(input: PhoneNumberInput) {
+        input.onButtonPressed = { [weak self] _ in
+            guard let self else { return }
+            let countryPickerViewController = CountryCodePickerViewController(phoneNumberKit: input.phoneNumberKit, options: .init())
+            countryPickerViewController.delegate = input
+            let navigationController = UINavigationController(rootViewController: countryPickerViewController)
+            present(navigationController, animated: true)
+        }
+
+        input.onTextChanged = { [weak self] isValid in
+            guard let self else { return }
+
+            self.continueButton.isEnabled = isValid
+
+            switch (input.hasBeenValid, isValid) {
+            case (_, true):
+                input.setFeedback(nil)
+            case (true, false):
+                input.setFeedback(
+                    .error(
+                        NSLocalizedString("stytch.invalidNumber", value: "Invalid number, please try again.", comment: "")
+                    )
+                )
+            case (false, false):
+                break
+            }
+        }
+    }
+
+    @objc func continueWithSMSOTP() {
+        if let phoneNumberE164 = phoneNumberInput.phoneNumberE164 {
+            Task {
+                do {
+                    try await AuthenticationOperations.smsSend(phoneNumberE164: phoneNumberE164)
+                    navigationController?.pushViewController(SMSOTPEntryViewController(state: .init(configuration: viewModel.state.configuration)), animated: true)
+                } catch {
+                    presentErrorAlert(error: error)
+                }
+            }
+        }
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEntryViewController/SMSOTPEntryViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEntryViewController/SMSOTPEntryViewController.swift
@@ -7,6 +7,10 @@ final class SMSOTPEntryViewController: BaseViewController<SMSOTPEntryState, SMSO
         text: NSLocalizedString("stytchSMSOTPEntryTitle", value: "Enter passcode", comment: "")
     )
 
+    var timer: Timer?
+
+    lazy var expiryButton: Button = makeExpiryButton()
+
     init(state: SMSOTPEntryState) {
         super.init(viewModel: SMSOTPEntryViewModel(state: state))
     }
@@ -17,13 +21,31 @@ final class SMSOTPEntryViewController: BaseViewController<SMSOTPEntryState, SMSO
         stackView.spacing = .spacingRegular
 
         stackView.addArrangedSubview(titleLabel)
+
+        let smsConfirmationLabel = UILabel.makeComboLabel(
+            withPlainText: "A 6-digit passcode was sent to you at",
+            boldText: MemberManager.phoneNumber,
+            fontSize: 18,
+            alignment: .left
+        )
+        stackView.addArrangedSubview(smsConfirmationLabel)
+
         let otpView = OTPCodeEntryView(frame: .zero)
         otpView.delegate = self
         stackView.addArrangedSubview(otpView)
 
+        stackView.addArrangedSubview(expiryButton)
+
         stackView.addArrangedSubview(SpacerView())
 
         attachStackView(within: view)
+
+        updateExpiryText()
+        timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(updateExpiryText), userInfo: nil, repeats: true)
+
+        NSLayoutConstraint.activate([
+            otpView.heightAnchor.constraint(equalToConstant: 50),
+        ])
 
         NSLayoutConstraint.activate(
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
@@ -31,6 +53,46 @@ final class SMSOTPEntryViewController: BaseViewController<SMSOTPEntryState, SMSO
     }
 }
 
+extension SMSOTPEntryViewController: OTPEntryViewControllerProtocol {
+    var expirationDate: Date {
+        viewModel.state.expirationDate
+    }
+
+    func resendCode() {
+        Task {
+            do {
+                if let phoneNumberE164 = MemberManager.phoneNumber {
+                    try await AuthenticationOperations.smsSend(phoneNumberE164: phoneNumberE164)
+                }
+            } catch {
+                presentErrorAlert(error: error)
+            }
+        }
+    }
+
+    func presentCodeResetConfirmation() {
+        guard let phoneNumber = MemberManager.phoneNumber else {
+            return
+        }
+
+        presentCodeResetConfirmation(message: .localizedStringWithFormat(
+            NSLocalizedString("stytch.otpNewCodeWillBeSent", value: "A new code will be sent to %@.", comment: ""), phoneNumber
+        ))
+    }
+
+    @objc private func updateExpiryText() {
+        updateExpirationText()
+    }
+}
+
 extension SMSOTPEntryViewController: OTPCodeEntryViewDelegate {
-    func didEnterOTPCode(_: String) {}
+    func didEnterOTPCode(_ code: String) {
+        Task {
+            do {
+                try await viewModel.smsAuthenticate(code: code)
+            } catch {
+                presentErrorAlert(error: error)
+            }
+        }
+    }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEntryViewController/SMSOTPEntryViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEntryViewController/SMSOTPEntryViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import StytchCore
 
 final class SMSOTPEntryViewModel {
@@ -8,8 +9,29 @@ final class SMSOTPEntryViewModel {
     ) {
         self.state = state
     }
+
+    func smsAuthenticate(code: String) async throws {
+        guard let organizationId = OrganizationManager.organizationId else {
+            throw StytchSDKError.noOrganziationId
+        }
+
+        guard let memberId = MemberManager.memberId else {
+            throw StytchSDKError.noMemberId
+        }
+
+        let parameters = StytchB2BClient.OTP.SMS.AuthenticateParameters(
+            sessionDurationMinutes: state.configuration.sessionDurationMinutes,
+            organizationId: organizationId,
+            memberId: memberId,
+            code: code,
+            setMfaEnrollment: nil
+        )
+        let response = try await StytchB2BClient.otp.sms.authenticate(parameters: parameters)
+        B2BAuthenticationManager.handleSecondaryReponse(b2bAuthenticateResponse: response)
+    }
 }
 
 struct SMSOTPEntryState {
     let configuration: StytchB2BUIClient.Configuration
+    let expirationDate = Date().addingTimeInterval(120)
 }


### PR DESCRIPTION
[[iOS] Build SMSOTPEnrollment](https://linear.app/stytch/issue/SDK-2268/[ios]-build-smsotpenrollment)
[[iOS] Build SMSOTPEntry](https://linear.app/stytch/issue/SDK-2267/[ios]-build-smsotpentry)

## Changes:

1. Abstract reusable parts of OTP entry into `OTPEntryViewControllerProtocol` that can be shared between B2C and B2B SMS OTP Entry.
2. Complete SMS OTP enrollment and entry flows.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
