### PR TITLE
[B2B UI] OAuth Filtering

### DIFF
--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
@@ -167,6 +167,21 @@ public extension StytchB2BClient.OAuth.ThirdParty.Provider {
             return StytchB2BClient.oauth.github
         }
     }
+
+    var allowedAuthMethodType: StytchB2BClient.AllowedAuthMethods {
+        switch self {
+        case .google:
+            return .googleOAuth
+        case .microsoft:
+            return .microsoftOAuth
+        case .hubspot:
+            return .hubspotOAuth
+        case .slack:
+            return .slackOAuth
+        case .github:
+            return .githubOAuth
+        }
+    }
 }
 
 #endif

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BAuthHomeViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BAuthHomeViewModel.swift
@@ -42,7 +42,8 @@ extension B2BAuthHomeViewModel: B2BAuthHomeViewModelProtocol {
                         organizationAllowedAuthMethods: OrganizationManager.allowedAuthMethods,
                         organizationAuthMethods: OrganizationManager.authMethods,
                         primaryRequired: B2BAuthenticationManager.primaryRequired,
-                        configuration: state.configuration
+                        configurationProducts: state.configuration.products,
+                        oauthProviders: state.configuration.oauthProviders
                     )
                     let products = StytchB2BUIClient.productComponentsOrdering(
                         validProducts: validProducts,

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BOAuthViewController/B2BOAuthViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BOAuthViewController/B2BOAuthViewController.swift
@@ -21,10 +21,12 @@ final class B2BOAuthViewController: BaseViewController<B2BOAuthState, B2BOAuthVi
         view.layoutMargins = .zero
 
         viewModel.state.configuration.oauthProviders.enumerated().forEach { index, provider in
-            let button = Self.makeOauthButton(provider: provider.provider)
-            button.tag = index
-            button.addTarget(self, action: #selector(didTapOAuthButton(sender:)), for: .touchUpInside)
-            stackView.addArrangedSubview(button)
+            if StytchB2BUIClient.isAllowedOAuthProvider(allowedAuthMethods: OrganizationManager.allowedAuthMethods ?? [], oauthProviderOptions: provider) == true {
+                let button = Self.makeOauthButton(provider: provider.provider)
+                button.tag = index
+                button.addTarget(self, action: #selector(didTapOAuthButton(sender:)), for: .touchUpInside)
+                stackView.addArrangedSubview(button)
+            }
         }
 
         attachStackView(within: view)

--- a/Tests/StytchUIUnitTests/StytchB2BUIClientTests/StytchB2BUIClient+HomeScreenProductsTests.swift
+++ b/Tests/StytchUIUnitTests/StytchB2BUIClientTests/StytchB2BUIClient+HomeScreenProductsTests.swift
@@ -1,5 +1,0 @@
-import XCTest
-@testable import StytchCore
-@testable import StytchUI
-
-final class HomeScreenProductsTests: BaseTestCase {}

--- a/Tests/StytchUIUnitTests/StytchB2BUIClientTests/StytchB2BUIClient+ProductOrderingTests.swift
+++ b/Tests/StytchUIUnitTests/StytchB2BUIClientTests/StytchB2BUIClient+ProductOrderingTests.swift
@@ -2,4 +2,27 @@ import XCTest
 @testable import StytchCore
 @testable import StytchUI
 
-final class ProductOrderingTests: BaseTestCase {}
+final class ProductOrderingTests: B2BBaseTestCase {
+    func configuration(
+        products: [StytchB2BUIClient.B2BProducts],
+        authFlowType: StytchB2BUIClient.AuthFlowType
+    ) -> StytchB2BUIClient.Configuration {
+        .init(
+            publicToken: "public-token",
+            hostUrl: nil,
+            products: products,
+            authFlowType: authFlowType,
+            sessionDurationMinutes: .defaultSessionDuration,
+            emailMagicLinksOptions: nil,
+            passwordOptions: nil,
+            oauthProviders: [],
+            emailOtpOptions: nil,
+            directLoginForSingleMembershipOptions: nil,
+            disableCreateOrganization: nil,
+            mfaProductOrder: nil,
+            mfaProductInclude: nil,
+            navigation: nil,
+            theme: StytchTheme()
+        )
+    }
+}

--- a/Tests/StytchUIUnitTests/StytchB2BUIClientTests/StytchB2BUIClient+ValidProductsTests.swift
+++ b/Tests/StytchUIUnitTests/StytchB2BUIClientTests/StytchB2BUIClient+ValidProductsTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import StytchCore
+@testable import StytchUI
+
+final class ValidProductsTests: B2BBaseTestCase {
+    let allAllowedAuthMethods: [StytchB2BClient.AllowedAuthMethods] = [
+        .sso,
+        .magicLink,
+        .password,
+        .googleOAuth,
+        .microsoftOAuth,
+        .hubspotOAuth,
+        .slackOAuth,
+        .githubOAuth,
+        .emailOtp,
+    ]
+
+    let allB2BProducts: [StytchB2BUIClient.B2BProducts] = [
+        .emailMagicLinks,
+        .emailOtp,
+        .sso,
+        .passwords,
+        .oauth,
+    ]
+
+    func testValidProducts() {
+        var validProducts: [StytchB2BUIClient.B2BProducts] = []
+
+        validProducts = StytchB2BUIClient.validProducts(
+            organizationAllowedAuthMethods: [],
+            organizationAuthMethods: .allAllowed,
+            primaryRequired: nil,
+            configurationProducts: [.emailMagicLinks],
+            oauthProviders: []
+        )
+        XCTAssertEqual(validProducts, [.emailMagicLinks])
+    }
+
+    func testValidProductsRestrictedAuthMethods() {
+        var validProducts: [StytchB2BUIClient.B2BProducts] = []
+
+        validProducts = StytchB2BUIClient.validProducts(
+            organizationAllowedAuthMethods: [.magicLink, .password, .sso],
+            organizationAuthMethods: .restricted,
+            primaryRequired: nil,
+            configurationProducts: [.emailMagicLinks, .sso],
+            oauthProviders: []
+        )
+        XCTAssertEqual(validProducts, [.emailMagicLinks, .sso])
+    }
+
+    func testValidProductsRestrictedAuthMethodsMismatchedOauthProviders() {
+        var validProducts: [StytchB2BUIClient.B2BProducts] = []
+
+        validProducts = StytchB2BUIClient.validProducts(
+            organizationAllowedAuthMethods: [.magicLink, .password, .sso, .githubOAuth],
+            organizationAuthMethods: .restricted,
+            primaryRequired: nil,
+            configurationProducts: [.emailMagicLinks, .sso, .oauth],
+            oauthProviders: [.init(provider: .google)]
+        )
+        // Oauth should be absent since .googleOAuth was not one of the organizationAllowedAuthMethods
+        XCTAssertEqual(validProducts, [.emailMagicLinks, .sso])
+    }
+
+    func testValidProductsRestrictedAuthMethodsMatchingOauthProviders() {
+        var validProducts: [StytchB2BUIClient.B2BProducts] = []
+
+        validProducts = StytchB2BUIClient.validProducts(
+            organizationAllowedAuthMethods: [.magicLink, .password, .sso, .googleOAuth],
+            organizationAuthMethods: .restricted,
+            primaryRequired: nil,
+            configurationProducts: [.emailMagicLinks, .sso, .oauth],
+            oauthProviders: [.init(provider: .google)]
+        )
+        // Oauth should be present since .googleOAuth is one of the organizationAllowedAuthMethods
+        XCTAssertEqual(validProducts, [.emailMagicLinks, .sso, .oauth])
+    }
+
+    func testAllowedB2BProducts() {
+        var allowedB2BProducts: [StytchB2BUIClient.B2BProducts] = []
+
+        allowedB2BProducts = StytchB2BUIClient.allowedB2BProducts(
+            allowedAuthMethods: [.magicLink, .password],
+            configurationProducts: [.passwords],
+            oauthProviders: []
+        )
+        XCTAssertEqual(allowedB2BProducts, [.passwords])
+
+        allowedB2BProducts = StytchB2BUIClient.allowedB2BProducts(
+            allowedAuthMethods: [.magicLink, .password, .googleOAuth],
+            configurationProducts: [.passwords, .oauth],
+            oauthProviders: [.init(provider: .google)]
+        )
+        XCTAssertEqual(allowedB2BProducts, [.passwords, .oauth])
+    }
+
+    func testIsValidOAuthConfiguration() {
+        XCTAssertTrue(StytchB2BUIClient.isValidOAuthConfiguration(allowedAuthMethods: [.googleOAuth], oauthProviders: [.init(provider: .google)]), "")
+        XCTAssertTrue(StytchB2BUIClient.isValidOAuthConfiguration(allowedAuthMethods: [.googleOAuth, .hubspotOAuth], oauthProviders: [.init(provider: .google)]), "")
+
+        XCTAssertFalse(StytchB2BUIClient.isValidOAuthConfiguration(allowedAuthMethods: [.hubspotOAuth], oauthProviders: [.init(provider: .google)]), "")
+        XCTAssertFalse(StytchB2BUIClient.isValidOAuthConfiguration(allowedAuthMethods: [.hubspotOAuth], oauthProviders: []), "")
+        XCTAssertFalse(StytchB2BUIClient.isValidOAuthConfiguration(allowedAuthMethods: [.magicLink, .password], oauthProviders: [.init(provider: .google)]), "")
+    }
+
+    func testIsAllowedOAuthProvider() {
+        XCTAssertTrue(StytchB2BUIClient.isAllowedOAuthProvider(allowedAuthMethods: [.googleOAuth], oauthProviderOptions: .init(provider: .google)), "")
+        XCTAssertTrue(StytchB2BUIClient.isAllowedOAuthProvider(allowedAuthMethods: [.microsoftOAuth], oauthProviderOptions: .init(provider: .microsoft)), "")
+        XCTAssertTrue(StytchB2BUIClient.isAllowedOAuthProvider(allowedAuthMethods: [.hubspotOAuth], oauthProviderOptions: .init(provider: .hubspot)), "")
+        XCTAssertTrue(StytchB2BUIClient.isAllowedOAuthProvider(allowedAuthMethods: [.slackOAuth], oauthProviderOptions: .init(provider: .slack)), "")
+        XCTAssertTrue(StytchB2BUIClient.isAllowedOAuthProvider(allowedAuthMethods: [.githubOAuth], oauthProviderOptions: .init(provider: .github)), "")
+
+        XCTAssertFalse(StytchB2BUIClient.isAllowedOAuthProvider(allowedAuthMethods: [.googleOAuth], oauthProviderOptions: .init(provider: .github)), "")
+        XCTAssertFalse(StytchB2BUIClient.isAllowedOAuthProvider(allowedAuthMethods: [.magicLink, .password], oauthProviderOptions: .init(provider: .github)), "")
+    }
+}


### PR DESCRIPTION
## Changes:

1. Add logic so that if the developer specifics `.oauth` as a product they would like to show, but the `B2BOAuthProviderOptions` array does not contain a provider that is in the current org's `AllowedAuthMethods` then we filter it out and potentially even remove `.oauth` from the developer specified products.
2. Add tests for all the product filtering and valid products logic.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
