### PR TITLE
[B2B UI] Bugbashing

### DIFF
--- a/Sources/StytchCore/OAuthProviderValues.swift
+++ b/Sources/StytchCore/OAuthProviderValues.swift
@@ -5,7 +5,7 @@ public struct OAuthProviderValues: Codable, Sendable {
     public let accessToken: String
     /// The id_token returned by the OAuth provider. ID Tokens are JWTs that contain structured information about a user. The exact content of each ID Token varies from provider to provider.
     /// ID Tokens are returned from OAuth providers that conform to the OpenID Connect specification, which is based on OAuth.
-    public let idToken: String
+    public let idToken: String?
     /// The refresh_token that you may use to obtain a new access_token for the User within the provider's API.
     public let refreshToken: String?
     /// The OAuth scopes included for a given provider. See each provider's section above to see which scopes are included by default and how to add custom scopes.

--- a/Sources/StytchCore/SessionManager.swift
+++ b/Sources/StytchCore/SessionManager.swift
@@ -113,7 +113,7 @@ final class SessionManager {
 
         // If there is no session, it means that we are in MFA and all we need is the IST
         guard let sessionType else {
-            clearTokensCachedObjectsPolling()
+            resetSession()
             return
         }
 
@@ -146,14 +146,7 @@ final class SessionManager {
         sessionJwt = tokens.jwt
     }
 
-    // clear everything including the IST
     func resetSession() {
-        clearTokensCachedObjectsPolling()
-        intermediateSessionToken = nil
-    }
-
-    // clear everything but the IST
-    func clearTokensCachedObjectsPolling() {
         sessionStorage.update(nil)
         memberSessionStorage.update(nil)
         userStorage.update(nil)

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
@@ -137,7 +137,7 @@ public extension StytchB2BClient {
         /// The details of the membership.
         public let details: JSON?
         /// The member.
-        public let member: Member
+        public let member: Member?
     }
 
     enum MembershipType: String, Sendable, Codable {

--- a/Sources/StytchUI/Inputs/EmailInput.swift
+++ b/Sources/StytchUI/Inputs/EmailInput.swift
@@ -1,6 +1,8 @@
 import UIKit
 
 final class EmailInput: TextInputView<EmailTextField> {
+    var onReturn: (Bool) -> Void = { _ in }
+
     var isEnabled: Bool {
         get { textInput.isEnabled }
         set {
@@ -18,6 +20,23 @@ final class EmailInput: TextInputView<EmailTextField> {
             guard let self else { return }
             self.onTextChanged(self.isValid)
         }
+        textInput.delegate = self
+        textInput.returnKeyType = .done
+    }
+
+    func setReturnKeyType(returnKeyType: UIReturnKeyType) {
+        textInput.returnKeyType = returnKeyType
+    }
+
+    func assignFirstResponder() {
+        textInput.becomeFirstResponder()
+    }
+}
+
+extension EmailInput: UITextFieldDelegate {
+    func textFieldShouldReturn(_: UITextField) -> Bool {
+        onReturn(isValid)
+        return true
     }
 }
 

--- a/Sources/StytchUI/Inputs/PhoneNumberInput.swift
+++ b/Sources/StytchUI/Inputs/PhoneNumberInput.swift
@@ -4,6 +4,8 @@ import UIKit
 final class PhoneNumberInput: TextInputView<PhoneNumberInputContainer> {
     var onButtonPressed: (PhoneNumberKit) -> Void = { _ in }
 
+    var onReturn: (Bool) -> Void = { _ in }
+
     var phoneNumberE164: String? {
         isValid ? textField.phoneNumber.map { "+\($0.countryCode)\($0.nationalNumber)" } : nil
     }
@@ -25,10 +27,27 @@ final class PhoneNumberInput: TextInputView<PhoneNumberInputContainer> {
 
         textInput.countrySelectorButton.addTarget(self, action: #selector(didTapButton(sender:)), for: .primaryActionTriggered)
         PhoneNumberKit.CountryCodePicker.forceModalPresentation = true
+        textInput.textField.delegate = self
+        textInput.textField.returnKeyType = .done
     }
 
     @objc private func didTapButton(sender _: UIButton) {
         onButtonPressed(textField.phoneNumberKit)
+    }
+
+    func setReturnKeyType(returnKeyType: UIReturnKeyType) {
+        textInput.textField.returnKeyType = returnKeyType
+    }
+
+    func assignFirstResponder() {
+        textInput.textField.becomeFirstResponder()
+    }
+}
+
+extension PhoneNumberInput: UITextFieldDelegate {
+    func textFieldShouldReturn(_: UITextField) -> Bool {
+        onReturn(isValid)
+        return true
     }
 }
 

--- a/Sources/StytchUI/Inputs/SecureTextInput.swift
+++ b/Sources/StytchUI/Inputs/SecureTextInput.swift
@@ -31,6 +31,7 @@ final class SecureTextInput: TextInputView<SecureTextField> {
         supplementaryView = feedback
         feedback.isHidden = true
         textInput.delegate = self
+        textInput.returnKeyType = .done
     }
 
     func setZXCVBNFeedback(suggestions: [String]?, warning: String?, score: Int) {
@@ -47,6 +48,14 @@ final class SecureTextInput: TextInputView<SecureTextField> {
         ludsIndicatorView.isHidden = false
         ludsIndicator.setFeedback(feedback: ludsRequirement, breached: breached, passwordConfig: passwordConfig)
         didSetFeedback()
+    }
+
+    func setReturnKeyType(returnKeyType: UIReturnKeyType) {
+        textInput.returnKeyType = returnKeyType
+    }
+
+    func assignFirstResponder() {
+        textInput.becomeFirstResponder()
     }
 }
 

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/B2BPasswordsViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/B2BPasswordsViewModel.swift
@@ -34,7 +34,7 @@ final class B2BPasswordsViewModel {
         Task {
             do {
                 let member = try? await AuthenticationOperations.searchMember(emailAddress: emailAddress, organizationId: organizationId)
-                if member?.memberPasswordId != nil {
+                if let memberPasswordId = member?.memberPasswordId, memberPasswordId.isEmpty == false {
                     let parameters = StytchB2BClient.Passwords.AuthenticateParameters(
                         organizationId: Organization.ID(rawValue: organizationId),
                         emailAddress: emailAddress,

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/MemberManager.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/MemberManager.swift
@@ -1,3 +1,4 @@
+import PhoneNumberKit
 import StytchCore
 
 struct MemberManager {
@@ -18,11 +19,25 @@ struct MemberManager {
     }
 
     static var phoneNumber: String? {
-        if let memberPhoneNumber = member?.mfaPhoneNumber {
+        if let memberPhoneNumber = member?.mfaPhoneNumber, memberPhoneNumber.isEmpty == false {
             return memberPhoneNumber
         } else {
             return _phoneNumber
         }
+    }
+
+    static var formattedPhoneNumber: String {
+        let phoneNumberKit = PhoneNumberKit()
+        guard let memberPhoneNumber = phoneNumber else {
+            return ""
+        }
+
+        guard let parsedPhoneNumber = try? phoneNumberKit.parse(memberPhoneNumber) else {
+            return memberPhoneNumber
+        }
+
+        let formattedPhoneNumber = phoneNumberKit.format(parsedPhoneNumber, toType: .international)
+        return formattedPhoneNumber
     }
 
     static func updateMember(_ member: Member) {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BAuthHomeViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BAuthHomeViewController.swift
@@ -56,6 +56,11 @@ final class B2BAuthHomeViewController: BaseViewController<B2BAuthHomeState, B2BA
     }
 
     func configureView(productComponents: [StytchB2BUIClient.ProductComponent]) {
+        guard !productComponents.isEmpty else {
+            showError(configuration: viewModel.state.configuration, type: .invlaidProductConfiguration)
+            return
+        }
+
         view.addSubview(scrollView)
         scrollView.showsVerticalScrollIndicator = false
         scrollView.clipsToBounds = false

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BEmailMagicLinksViewController/B2BEmailMagicLinksViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BEmailMagicLinksViewController/B2BEmailMagicLinksViewController.swift
@@ -14,14 +14,14 @@ final class B2BEmailMagicLinksViewController: BaseViewController<B2BEmailMagicLi
     private lazy var emailInput: EmailInput = .init()
 
     private lazy var continueButton: Button = .primary(
-        title: NSLocalizedString("stytch.pwContinueTitle", value: "Continue With Email", comment: "")
+        title: NSLocalizedString("stytch.pwContinueTitle", value: "Continue with email", comment: "")
     ) { [weak self] in
         self?.continueButtonTapped()
     }
 
     private lazy var usePasswordInsteadButton: Button = {
         let button = Button.tertiary(
-            title: NSLocalizedString("stytch.forgotPassword", value: "Use Password Instead", comment: "")
+            title: NSLocalizedString("stytch.forgotPassword", value: "Use password instead", comment: "")
         ) { [weak self] in
             self?.usePasswordInsteadButtonTapped()
         }
@@ -78,19 +78,21 @@ final class B2BEmailMagicLinksViewController: BaseViewController<B2BEmailMagicLi
                 break
             }
         }
+
+        input.onReturn = { [weak self] isValid in
+            if isValid == true {
+                self?.continueButtonTapped()
+            }
+        }
     }
 
     private func continueButtonTapped() {
-        if let emailAddress = emailInput.text {
-            viewModel.sendEmailMagicLink(emailAddress: emailAddress) { [weak self] error in
-                if let error {
-                    self?.presentErrorAlert(error: error)
-                } else {
-                    self?.delegate?.emailMagicLinkSent()
-                }
+        viewModel.sendEmailMagicLink(emailAddress: emailInput.text ?? "") { [weak self] error in
+            if let error {
+                self?.presentErrorAlert(error: error)
+            } else {
+                self?.delegate?.emailMagicLinkSent()
             }
-        } else {
-            // Show Error??
         }
     }
 

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BOAuthViewController/B2BOAuthViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BOAuthViewController/B2BOAuthViewController.swift
@@ -13,6 +13,7 @@ final class B2BOAuthViewController: BaseViewController<B2BOAuthState, B2BOAuthVi
     var filteredOauthProviders: [StytchB2BUIClient.B2BOAuthProviderOptions] {
         let configuration = viewModel.state.configuration
         let oauthProviders = configuration.oauthProviders
+
         switch configuration.authFlowType {
         case .discovery:
             // If we are in discovery just return what is passed in the UI config since we have no org set yet
@@ -21,7 +22,14 @@ final class B2BOAuthViewController: BaseViewController<B2BOAuthState, B2BOAuthVi
             // If we are in the org flow we need to check if we are in restricted mode and we have allowedAuthMethods
             // In that case we need to filter the oauth provider options by whatever is in the allowedAuthMethods
             // Otherwise we just return the array as specific in the ui config
-            if let allowedAuthMethods = OrganizationManager.allowedAuthMethods, OrganizationManager.authMethods == .restricted {
+            var allowedAuthMethods: [StytchB2BClient.AllowedAuthMethods] = []
+            if let primaryRequiredAllowedAuthMethods = B2BAuthenticationManager.primaryRequired?.allowedAuthMethods {
+                allowedAuthMethods = primaryRequiredAllowedAuthMethods
+            } else if let organizationAllowedAuthMethods = OrganizationManager.allowedAuthMethods, OrganizationManager.authMethods == .restricted {
+                allowedAuthMethods = organizationAllowedAuthMethods
+            }
+
+            if allowedAuthMethods.isEmpty == false {
                 var filteredOauthProviders: [StytchB2BUIClient.B2BOAuthProviderOptions] = []
                 for oauthProvider in oauthProviders {
                     if allowedAuthMethods.contains(oauthProvider.provider.allowedAuthMethodType) {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BPasswordsHomeViewController/B2BPasswordsHomeViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BPasswordsHomeViewController/B2BPasswordsHomeViewController.swift
@@ -66,6 +66,20 @@ final class B2BPasswordsHomeViewController: BaseViewController<B2BPasswordsState
         NSLayoutConstraint.activate(
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
+
+        emailInput.setReturnKeyType(returnKeyType: .next)
+
+        emailInput.onReturn = { [weak self] isValid in
+            if isValid == true {
+                self?.passwordInput.assignFirstResponder()
+            }
+        }
+
+        passwordInput.onReturn = { [weak self] isValid in
+            if isValid == true {
+                self?.submit()
+            }
+        }
     }
 
     @objc private func toggleSecureEntry(sender _: UIButton) {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/ErrorViewController/ErrorViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/ErrorViewController/ErrorViewModel.swift
@@ -25,6 +25,8 @@ extension ErrorViewModel {
             return "Something went wrong. Your login link may have expired, been revoked, or been used more than once. Request a new login link to try again, or contact your admin for help."
         case .generic:
             return "Something went wrong. Try again later or contact your admin for help."
+        case .invlaidProductConfiguration:
+            return "Invalid product configuration detected"
         }
     }
 }
@@ -38,5 +40,6 @@ enum ErrorScreenType: Error {
     case noOrganziationFound
     case noPrimaryAuthMethods
     case emailAuthFailed
+    case invlaidProductConfiguration
     case generic
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAEnrollmentSelectionViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/MFAEnrollmentSelectionViewController/MFAEnrollmentSelectionViewController.swift
@@ -46,6 +46,8 @@ final class MFAEnrollmentSelectionViewController: BaseViewController<MFAEnrollme
         )
 
         view.backgroundColor = .background
+
+        hideBackButton()
     }
 
     func reorderMfaEnrollmentMethods(

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordAuthenticateViewController/PasswordAuthenticateViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordAuthenticateViewController/PasswordAuthenticateViewController.swift
@@ -70,6 +70,24 @@ final class PasswordAuthenticateViewController: BaseViewController<B2BPasswordsS
         NSLayoutConstraint.activate(
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
+
+        NSLayoutConstraint.activate([
+            continueButton.heightAnchor.constraint(equalToConstant: .buttonHeight),
+        ])
+
+        emailInput.setReturnKeyType(returnKeyType: .next)
+
+        emailInput.onReturn = { [weak self] isValid in
+            if isValid == true {
+                self?.passwordInput.assignFirstResponder()
+            }
+        }
+
+        passwordInput.onReturn = { [weak self] isValid in
+            if isValid == true {
+                self?.submit()
+            }
+        }
     }
 
     @objc private func toggleSecureEntry(sender _: UIButton) {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordForgotViewController/PasswordForgotViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordForgotViewController/PasswordForgotViewController.swift
@@ -66,6 +66,12 @@ final class PasswordForgotViewController: BaseViewController<PasswordForgotState
                 break
             }
         }
+
+        emailInput.onReturn = { [weak self] isValid in
+            if isValid == true {
+                self?.continueWithPasswordResetIfPossible()
+            }
+        }
     }
 
     @objc private func continueWithPasswordResetIfPossible() {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordForgotViewController/PasswordForgotViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordForgotViewController/PasswordForgotViewModel.swift
@@ -27,7 +27,7 @@ final class PasswordForgotViewModel {
         Task {
             do {
                 let member = try await AuthenticationOperations.searchMember(emailAddress: emailAddress, organizationId: organizationId)
-                if member?.memberPasswordId != nil {
+                if let memberPasswordId = member?.memberPasswordId, memberPasswordId.isEmpty == false {
                     let parameters = StytchB2BClient.Passwords.ResetByEmailStartParameters(
                         organizationId: Organization.ID(rawValue: organizationId),
                         emailAddress: emailAddress,

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordResetViewController/PasswordResetViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordResetViewController/PasswordResetViewController.swift
@@ -62,6 +62,12 @@ final class PasswordResetViewController: BaseViewController<PasswordResetState, 
             self?.setNeedsStrengthCheck()
             self?.continueButton.isEnabled = isValid
         }
+
+        passwordInput.onReturn = { [weak self] isValid in
+            if isValid == true {
+                self?.continueWithPasswordResetIfPossible()
+            }
+        }
     }
 
     @objc private func toggleSecureEntry(sender _: UIButton) {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeEntryViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeEntryViewController.swift
@@ -39,6 +39,12 @@ final class RecoveryCodeEntryViewController: BaseViewController<RecoveryCodeEntr
         NSLayoutConstraint.activate(
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
+
+        recoveryCodeInput.onReturn = { [weak self] isValid in
+            if isValid == true {
+                self?.recoveryCodeEntered()
+            }
+        }
     }
 
     @objc func recoveryCodeEntered() {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeInput.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeInput.swift
@@ -14,6 +14,7 @@ final class RecoveryCodeInput: TextInputView<RecoveryCodeTextField> {
         textInput.textContentType = .none
         textInput.delegate = self
         textInput.accessibilityLabel = "recoveryCodeEntry"
+        textInput.returnKeyType = .done
     }
 }
 

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeSaveViewController/RecoveryCodeSaveViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeSaveViewController/RecoveryCodeSaveViewController.swift
@@ -61,6 +61,8 @@ final class RecoveryCodeSaveViewController: BaseViewController<RecoveryCodeSaveS
         NSLayoutConstraint.activate(
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
+
+        hideBackButton()
     }
 
     @objc func doneTapped() {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEnrollmentViewController/SMSOTPEnrollmentViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEnrollmentViewController/SMSOTPEnrollmentViewController.swift
@@ -71,10 +71,17 @@ final class SMSOTPEnrollmentViewController: BaseViewController<SMSOTPEnrollmentS
                 break
             }
         }
+
+        phoneNumberInput.onReturn = { [weak self] isValid in
+            if isValid == true {
+                self?.continueWithSMSOTP()
+            }
+        }
     }
 
     @objc func continueWithSMSOTP() {
         if let phoneNumberE164 = phoneNumberInput.phoneNumberE164 {
+            MemberManager.updateMemberPhoneNumber(phoneNumberE164)
             StytchB2BUIClient.startLoading()
             Task {
                 do {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEntryViewController/SMSOTPEntryViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEntryViewController/SMSOTPEntryViewController.swift
@@ -3,6 +3,8 @@ import StytchCore
 import UIKit
 
 final class SMSOTPEntryViewController: BaseViewController<SMSOTPEntryState, SMSOTPEntryViewModel> {
+    let otpView = OTPCodeEntryView(frame: .zero)
+
     private let titleLabel: UILabel = .makeTitleLabel(
         text: NSLocalizedString("stytchSMSOTPEntryTitle", value: "Enter passcode", comment: "")
     )
@@ -26,13 +28,12 @@ final class SMSOTPEntryViewController: BaseViewController<SMSOTPEntryState, SMSO
 
         let smsConfirmationLabel = UILabel.makeComboLabel(
             withPlainText: "A 6-digit passcode was sent to you at",
-            boldText: MemberManager.phoneNumber,
+            boldText: MemberManager.formattedPhoneNumber,
             fontSize: 18,
             alignment: .left
         )
         stackView.addArrangedSubview(smsConfirmationLabel)
 
-        let otpView = OTPCodeEntryView(frame: .zero)
         otpView.delegate = self
         stackView.addArrangedSubview(otpView)
 
@@ -56,6 +57,10 @@ final class SMSOTPEntryViewController: BaseViewController<SMSOTPEntryState, SMSO
             resendCode()
         } else {
             startTimer()
+        }
+
+        if MemberManager.member?.mfaPhoneNumberVerified == true {
+            hideBackButton()
         }
     }
 
@@ -111,6 +116,7 @@ extension SMSOTPEntryViewController: OTPCodeEntryViewDelegate {
                 try await viewModel.smsAuthenticate(code: code)
                 StytchB2BUIClient.stopLoading()
             } catch {
+                otpView.clear()
                 presentErrorAlert(error: error)
                 StytchB2BUIClient.stopLoading()
             }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPSecretView.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPSecretView.swift
@@ -62,6 +62,8 @@ class TOTPSecretView: UIView {
             copyButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -15),
             copyButton.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
             copyButton.leadingAnchor.constraint(greaterThanOrEqualTo: textLabel.trailingAnchor, constant: 10),
+            copyButton.widthAnchor.constraint(equalToConstant: 30),
+            copyButton.heightAnchor.constraint(equalToConstant: 30),
         ])
     }
 


### PR DESCRIPTION
## Changes:

1. Make `idToken` optional in `OAuthProviderValues` so other OAuth types besides google will not fail in parsing.
2. Modify `OTPCodeEntryView` massively so that we can allow for pasting and a cursor and deleting values.
3. Add keyboard actions wherever needed.
4. Add a formatted phone number to the sms otp entry screen.
5. Hide back button logic. Basically if we already have a MFA response hide the back button, unless we are enrolling in mfa for the first time. Also hide it on the recovery code save screen.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
