### PR TITLE
Hide keyboard on done/next and tapping outside

### DIFF
--- a/Sources/StytchUI/Inputs/EmailInput.swift
+++ b/Sources/StytchUI/Inputs/EmailInput.swift
@@ -34,7 +34,8 @@ final class EmailInput: TextInputView<EmailTextField> {
 }
 
 extension EmailInput: UITextFieldDelegate {
-    func textFieldShouldReturn(_: UITextField) -> Bool {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
         onReturn(isValid)
         return true
     }

--- a/Sources/StytchUI/Inputs/PhoneNumberInput.swift
+++ b/Sources/StytchUI/Inputs/PhoneNumberInput.swift
@@ -45,7 +45,8 @@ final class PhoneNumberInput: TextInputView<PhoneNumberInputContainer> {
 }
 
 extension PhoneNumberInput: UITextFieldDelegate {
-    func textFieldShouldReturn(_: UITextField) -> Bool {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
         onReturn(isValid)
         return true
     }

--- a/Sources/StytchUI/Inputs/SecureTextInput.swift
+++ b/Sources/StytchUI/Inputs/SecureTextInput.swift
@@ -78,7 +78,8 @@ final class SecureTextField: BorderedTextField, TextInputType {
 }
 
 extension SecureTextInput: UITextFieldDelegate {
-    func textFieldShouldReturn(_: UITextField) -> Bool {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
         onReturn(isValid)
         return true
     }

--- a/Sources/StytchUI/Shared/BaseViewController.swift
+++ b/Sources/StytchUI/Shared/BaseViewController.swift
@@ -33,6 +33,7 @@ class BaseViewController<State, ViewModel>: UIViewController, BaseViewController
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.setupHideKeyboardOnTap()
         configureView()
     }
 
@@ -82,5 +83,16 @@ class BaseViewController<State, ViewModel>: UIViewController, BaseViewController
 
     func hideBackButton() {
         navigationItem.hidesBackButton = true
+    }
+
+    private func setupHideKeyboardOnTap() {
+        self.view.addGestureRecognizer(self.endEditingRecognizer())
+        self.navigationController?.navigationBar.addGestureRecognizer(self.endEditingRecognizer())
+    }
+
+    private func endEditingRecognizer() -> UIGestureRecognizer {
+        let tap = UITapGestureRecognizer(target: self.view, action: #selector(self.view.endEditing(_:)))
+        tap.cancelsTouchesInView = false
+        return tap
     }
 }

--- a/Sources/StytchUI/Shared/BaseViewController.swift
+++ b/Sources/StytchUI/Shared/BaseViewController.swift
@@ -33,7 +33,7 @@ class BaseViewController<State, ViewModel>: UIViewController, BaseViewController
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.setupHideKeyboardOnTap()
+        setupHideKeyboardOnTap()
         configureView()
     }
 
@@ -86,12 +86,12 @@ class BaseViewController<State, ViewModel>: UIViewController, BaseViewController
     }
 
     private func setupHideKeyboardOnTap() {
-        self.view.addGestureRecognizer(self.endEditingRecognizer())
-        self.navigationController?.navigationBar.addGestureRecognizer(self.endEditingRecognizer())
+        view.addGestureRecognizer(endEditingRecognizer())
+        navigationController?.navigationBar.addGestureRecognizer(endEditingRecognizer())
     }
 
     private func endEditingRecognizer() -> UIGestureRecognizer {
-        let tap = UITapGestureRecognizer(target: self.view, action: #selector(self.view.endEditing(_:)))
+        let tap = UITapGestureRecognizer(target: view, action: #selector(view.endEditing(_:)))
         tap.cancelsTouchesInView = false
         return tap
     }

--- a/Sources/StytchUI/Shared/FontLoader.swift
+++ b/Sources/StytchUI/Shared/FontLoader.swift
@@ -25,6 +25,9 @@ public enum FontLoader {
             "IBMPlexSans-SemiBoldItalic",
             "IBMPlexSans-Bold",
             "IBMPlexSans-BoldItalic",
+            "IBMPlexSans-Thin",
+            "IBMPlexSans-ThinItalic",
+            "IBMPlexSans-Regular",
         ]
 
         for fontName in fonts {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
@@ -26,7 +26,6 @@ final class B2BAuthRootViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.setupHideKeyboardOnTap()
         render()
     }
 
@@ -81,17 +80,6 @@ final class B2BAuthRootViewController: UIViewController {
 
     func popToRootViewController(animated: Bool) {
         homeController?.navigationController?.popToRootViewController(animated: animated)
-    }
-
-    private func setupHideKeyboardOnTap() {
-        self.view.addGestureRecognizer(self.endEditingRecognizer())
-        self.navigationController?.navigationBar.addGestureRecognizer(self.endEditingRecognizer())
-    }
-
-    private func endEditingRecognizer() -> UIGestureRecognizer {
-        let tap = UITapGestureRecognizer(target: self.view, action: #selector(self.view.endEditing(_:)))
-        tap.cancelsTouchesInView = false
-        return tap
     }
 }
 

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
@@ -26,6 +26,7 @@ final class B2BAuthRootViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.setupHideKeyboardOnTap()
         render()
     }
 
@@ -80,6 +81,17 @@ final class B2BAuthRootViewController: UIViewController {
 
     func popToRootViewController(animated: Bool) {
         homeController?.navigationController?.popToRootViewController(animated: animated)
+    }
+
+    private func setupHideKeyboardOnTap() {
+        self.view.addGestureRecognizer(self.endEditingRecognizer())
+        self.navigationController?.navigationBar.addGestureRecognizer(self.endEditingRecognizer())
+    }
+
+    private func endEditingRecognizer() -> UIGestureRecognizer {
+        let tap = UITapGestureRecognizer(target: self.view, action: #selector(self.view.endEditing(_:)))
+        tap.cancelsTouchesInView = false
+        return tap
     }
 }
 

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeInput.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeInput.swift
@@ -44,7 +44,8 @@ extension RecoveryCodeInput: UITextFieldDelegate {
         true
     }
 
-    func textFieldShouldReturn(_: UITextField) -> Bool {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
         onReturn(isValid)
         return true
     }


### PR DESCRIPTION
## Changes:

1. Adds a gesture handler to detect taps outside of the view and autodismisses the keyboard
2. Adds a `resignFirstResponder()` call to the textfield when returning

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A
