### PR TITLE
[part of INFRA-2371] ci: remove unused coverage artifact upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,9 +75,3 @@ jobs:
         run: |
           make coverage
           Scripts/generate-coverage-summary .coverage/lcov.json >> $GITHUB_STEP_SUMMARY
-
-      - uses: actions/upload-artifact@v3
-        if: matrix.test-os == 'macos'
-        with:
-          name: Coverage
-          path: .coverage/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - "[0-9]+.[0-9]+.[0-9]+"
   pull_request:
 
 env:
@@ -51,33 +51,33 @@ jobs:
       matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Bootstrap
-      uses: ./.github/actions/bootstrap
+      - name: Bootstrap
+        uses: ./.github/actions/bootstrap
 
-    - name: Codegen
-      run: |
-        make codegen
-        if [[ ! -z $(git status --porcelain | grep -Ev 'Brewfile.lock.json|Gemfile.lock') ]]; then
-          echo 'Codegen produced uncommitted changes. Commit changes and re-push.'
-          exit 1
-        fi
+      - name: Codegen
+        run: |
+          make codegen
+          if [[ ! -z $(git status --porcelain | grep -Ev 'Brewfile.lock.json|Gemfile.lock') ]]; then
+            echo 'Codegen produced uncommitted changes. Commit changes and re-push.'
+            exit 1
+          fi
 
-    - name: Lint
-      run: make lint
+      - name: Lint
+        run: make lint
 
-    - name: Test
-      run: make test-${{ matrix.test-os }}
+      - name: Test
+        run: make test-${{ matrix.test-os }}
 
-    - name: Coverage
-      if: matrix.test-os == 'macos'
-      run: |
-        make coverage
-        Scripts/generate-coverage-summary .coverage/lcov.json >> $GITHUB_STEP_SUMMARY
+      - name: Coverage
+        if: matrix.test-os == 'macos'
+        run: |
+          make coverage
+          Scripts/generate-coverage-summary .coverage/lcov.json >> $GITHUB_STEP_SUMMARY
 
-    - uses: actions/upload-artifact@v3
-      if: matrix.test-os == 'macos'
-      with:
-        name: Coverage
-        path: .coverage/
+      - uses: actions/upload-artifact@v3
+        if: matrix.test-os == 'macos'
+        with:
+          name: Coverage
+          path: .coverage/


### PR DESCRIPTION
Linear Ticket: [INFRA-2371](https://linear.app/stytch/issue/INFRA-2371)

## Changes:

1. Removes unused `actions/upload-artifact@v3` step in the `test.yml` workflow. The version used is being phased out and we don't use the uploaded coverage report anywhere

See second commit for changes without editor formatting.
