### PR TITLE
Dont delete the previous biometric registration

### DIFF
--- a/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
@@ -79,11 +79,6 @@ public extension StytchClient {
                 throw StytchSDKError.noCurrentSession
             }
 
-            // Attempt to remove the current registration if it exists.
-            // If we don't remove the current one before creating a new one, the user record will retain an unused biometric registration indefinitely.
-            // The error thrown here can be safely ignored. If it fails, we don't want to prevent the creation of the new biometric registration.
-            try? await removeRegistration()
-
             let (privateKey, publicKey) = cryptoClient.generateKeyPair()
 
             let startResponse: RegisterStartResponse = try await router.post(


### PR DESCRIPTION
## Changes:

1. We determined that if you had previously authenticated with biometrics and then attempted to register a new biometric registration without authenticating with all factors, the attempt to delete a factor would cause a 401 and log the user out thus preventing them from registering the new factor. We deleted that nicety check for now meaning that you can once again register new biometrics registrations leaving the ones in the user object orphaned.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
