### PR TITLE
Add missing redirect types to the ui readmes and update B2B UI sample app.

### DIFF
--- a/Stytch/DemoApps/StytchB2BUIDemo/ContentView.swift
+++ b/Stytch/DemoApps/StytchB2BUIDemo/ContentView.swift
@@ -49,8 +49,10 @@ struct ContentView: View {
 }
 
 class ContentViewModel: ObservableObject {
-    @Published var publicToken: String = "your-public-token"
+    // To hard-code the publicToken or orgSlug instead of inputting it through the UI, set it here.
+    @Published var publicToken: String = ""
     @Published var orgSlug: String = ""
+
     @Published var isShowingB2BUI: Bool = false
     @Published var isAuthenticated: Bool = false
     @Published var stytchB2BUIConfig: StytchB2BUIClient.Configuration = .empty
@@ -80,8 +82,13 @@ class ContentViewModel: ObservableObject {
     }
 
     func loadFromUserDefaults() {
-        publicToken = UserDefaults.standard.string(forKey: "publicToken") ?? "your-public-token"
-        orgSlug = UserDefaults.standard.string(forKey: "orgSlug") ?? ""
+        if publicToken.isEmpty == true {
+            publicToken = UserDefaults.standard.string(forKey: "publicToken") ?? ""
+        }
+
+        if orgSlug.isEmpty == true {
+            orgSlug = UserDefaults.standard.string(forKey: "orgSlug") ?? ""
+        }
     }
 
     func saveToUserDefaults() {

--- a/tutorials/B2B-UI.md
+++ b/tutorials/B2B-UI.md
@@ -1,7 +1,7 @@
 # StytchB2BUI Usage
 `StytchUI` creates a `StytchB2BUIClient` that offers the ability to show a configurable UI that abstracts the functionality of `StytchCore` and its B2B endpoints. You will still likely need to use the functionality embedded in `StytchCore` for retrieving the user or session, listening to observations on state change, logging the user out manually, etc. `StytchUI` can be integrated into either `UIKit` or `SwiftUI`, below are examples of both.
 
-The UI SDK automatically handles all necessary OAuth, Email Magic Link, and Password Reset deeplinks. To enable this functionality, you need to add a specific redirect URL in your Stytch Dashboard: stytchui-[YOUR_PUBLIC_TOKEN]://deeplink, and set it as valid for Signups, Logins, and Password Resets.
+The UI SDK automatically handles all necessary OAuth, Email Magic Link, and Password Reset deeplinks. To enable this functionality, you need to add a specific redirect URL in your Stytch Dashboard: `stytchui-[YOUR_PUBLIC_TOKEN]://deeplink`, and set it as valid for all redirect types: Login, Signup, Invite, Reset password and Discovery.
 
 When using `StytchUI` you must still [configure deeplinks for your application.](./Deeplinks.md)
 

--- a/tutorials/NavigatingTheProject.md
+++ b/tutorials/NavigatingTheProject.md
@@ -29,7 +29,7 @@ Bundle ID: `com.stytch.StytchUIDemo`
 
 * **StytchB2BUIDemo**  
 Bundle ID: `com.stytch.StytchB2BUIDemo`  
-[Configure the public token](../Stytch/DemoApps/StytchB2BUIDemo/ContentView.swift#L10)  
+[Configure the public token](../Stytch/DemoApps/StytchB2BUIDemo/ContentView.swift#L53)  
 [Configure the URL Scheme](../Stytch/DemoApps/StytchB2BUIDemo/Info.plist#L12)  
 
 * **ConsumerWorkbench**  

--- a/tutorials/UI.md
+++ b/tutorials/UI.md
@@ -1,7 +1,7 @@
 # StytchUI Usage
 `StytchUI` creates a `StytchUIClient` that offers the ability to show a configurable UI that abstracts the functionality of `StytchCore`. You will still likely need to use the functionality embedded in `StytchCore` for retrieving the user or session, listening to observations on state change, logging the user out manually, etc. `StytchUI` can be integrated into either `UIKit` or `SwiftUI`, below are examples of both.
 
-The UI SDK automatically handles all necessary OAuth, Email Magic Link, and Password Reset deeplinks. To enable this functionality, you need to add a specific redirect URL in your Stytch Dashboard: stytchui-[YOUR_PUBLIC_TOKEN]://deeplink, and set it as valid for Signups, Logins, and Password Resets.
+The UI SDK automatically handles all necessary OAuth, Email Magic Link, and Password Reset deeplinks. To enable this functionality, you need to add a specific redirect URL in your Stytch Dashboard: `stytchui-[YOUR_PUBLIC_TOKEN]://deeplink`, and set it as valid for all redirect types: Login, Signup, Invite, and Reset password.
 
 When using `StytchUI` you must still [configure deeplinks for your application.](./Deeplinks.md)
 


### PR DESCRIPTION
## Changes:

1. Add missing redirect types to the ui readmes.
2. Update B2B sample app so that you can hard code the public token and org id in code if you choose.
3. Update the navigating the project readme to point to the right line in the b2b sample app.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
