### PR TITLE
Make error handling code in NetworkingRouter more readable.

### DIFF
--- a/Sources/StytchCore/SharedModels/Errors/StytchAPIError.swift
+++ b/Sources/StytchCore/SharedModels/Errors/StytchAPIError.swift
@@ -37,6 +37,23 @@ public class StytchAPIError: StytchError, Decodable {
         super.init(name: "StytchAPIError", message: errorMessage)
     }
 
+    public convenience init(unknownErrorWithStatusCode statusCode: Int, debugInfo: String) {
+        var message: String
+        if (500..<600).contains(statusCode) {
+            message = "Server networking error - "
+        } else {
+            message = "Client networking error - "
+        }
+
+        message.append("Debug info: \(debugInfo)")
+
+        self.init(
+            statusCode: statusCode,
+            errorType: .unknownError,
+            errorMessage: message
+        )
+    }
+
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         statusCode = try container.decode(Int.self, forKey: .statusCode)


### PR DESCRIPTION
Linear Ticket: [LINEAR_NUMBER](https://linear.app/stytch/issue/YOUR_TICKET)

## Changes:

1. This PR is not mission critical, it just makes some things around error checking in `NetworkingRouter` slightly more readable.
2. It also creates a convenience initializer for `StytchAPIError` to create a `unknownErrorWithStatusCode` and `debugInfo`. Logic that was previously in the `NetworkingRouter`.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A
