### PR TITLE
DFP

### DIFF
--- a/Sources/StytchCore/DFPClient/DFPClient.swift
+++ b/Sources/StytchCore/DFPClient/DFPClient.swift
@@ -43,7 +43,7 @@ final class DFPClient: DFPProvider, Sendable {
     }
 }
 
-private final class MessageHandler: NSObject, WKScriptMessageHandler, Sendable {
+private final class MessageHandler: NSObject, WKScriptMessageHandler, Sendable, WKUIDelegate, WKNavigationDelegate {
     var continuations: [CheckedContinuation<String, Never>] = []
     var webviews: [WKWebView] = []
 
@@ -52,6 +52,10 @@ private final class MessageHandler: NSObject, WKScriptMessageHandler, Sendable {
     }
 
     func addWebView(_ webview: WKWebView) {
+        webview.uiDelegate = self
+        webview.allowsBackForwardNavigationGestures = true
+        webview.allowsLinkPreview = true
+        webview.navigationDelegate = self
         webviews.append(webview)
     }
 

--- a/Stytch/DemoApps/StytchBiometrics/ViewController.swift
+++ b/Stytch/DemoApps/StytchBiometrics/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        StytchClient.configure(publicToken: "")
+        StytchClient.configure(publicToken: "your-public-token")
 
         StytchClient.sessions.onSessionChange
             .receive(on: DispatchQueue.main)

--- a/Stytch/DemoApps/StytchDemo/Info.plist
+++ b/Stytch/DemoApps/StytchDemo/Info.plist
@@ -13,5 +13,11 @@
 			</array>
 		</dict>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>processing</string>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>

--- a/Stytch/DemoApps/StytchDemo/OTPAuthenticationManager.swift
+++ b/Stytch/DemoApps/StytchDemo/OTPAuthenticationManager.swift
@@ -39,7 +39,7 @@ public class OTPAuthenticationManager: ObservableObject {
     // Send a OTP (one time passcode) via SMS
     func sendOTP(phoneNumber: String) async throws {
         let parameters = StytchClient.OTP.Parameters(deliveryMethod: .sms(phoneNumber: phoneNumber))
-        let response = try await StytchClient.otps.send(parameters: parameters)
+        let response = try await StytchClient.otps.loginOrCreate(parameters: parameters)
         // save the methodId for the subsequent authenticate call
         methodId = response.methodId
         self.phoneNumber = phoneNumber
@@ -54,6 +54,21 @@ public class OTPAuthenticationManager: ObservableObject {
         _ = try await StytchClient.otps.authenticate(parameters: parameters)
         DispatchQueue.main.async { [weak self] in
             self?.didAuthenticateOTP = true
+        }
+    }
+
+    func getAlotOfTelemetrtIds() {
+        Task {
+            do {
+                for index in 0..<100 {
+                    print("getTelemetryID about to be called \(index)")
+                    let telemetryID = try await StytchClient.dfp.getTelemetryID()
+                    print("telemetryID: \(telemetryID)")
+                    print("--------------------------------------------")
+                }
+            } catch {
+                print(error.errorInfo)
+            }
         }
     }
 }

--- a/Stytch/DemoApps/StytchDemo/OTPView.swift
+++ b/Stytch/DemoApps/StytchDemo/OTPView.swift
@@ -22,6 +22,7 @@ struct OTPView: View {
 
             TextField(textFieldText, text: $inputText)
                 .textFieldStyle(RoundedBorderTextFieldStyle())
+                .keyboardType(.numberPad)
                 .padding()
 
             HStack {
@@ -49,6 +50,15 @@ struct OTPView: View {
                 .foregroundColor(.white)
                 .cornerRadius(10)
             }
+
+            Button("Generate Alot of Telemtery Ids") {
+                otpAuthenticationManager.getAlotOfTelemetrtIds()
+            }
+            .padding()
+            .frame(height: 40.0)
+            .background(Color.blue)
+            .foregroundColor(.white)
+            .cornerRadius(10)
         }
         .padding()
         .alert("Error", isPresented: $showAlert) {
@@ -67,6 +77,7 @@ struct OTPView: View {
                 textFieldText = "Enter The One Time Code"
                 inputText = ""
             } catch {
+                print(error.errorInfo)
                 showErrorAlert(error)
             }
         }
@@ -79,6 +90,7 @@ struct OTPView: View {
                 textFieldText = "Enter The One Time Code"
                 inputText = ""
             } catch {
+                print(error.errorInfo)
                 showErrorAlert(error)
             }
         }
@@ -89,6 +101,7 @@ struct OTPView: View {
             do {
                 try await otpAuthenticationManager.authenticateOTP(code: inputText)
             } catch {
+                print(error.errorInfo)
                 showErrorAlert(error)
             }
         }


### PR DESCRIPTION
From debugging I was frequently seeing this error: 

`Error acquiring assertion: <Error Domain=RBSServiceErrorDomain Code=1 "((target is not running or doesn't have entitlement com.apple.developer.web-browser-engine.rendering AND target is not running or doesn't have entitlement com.apple.developer.web-browser-engine.networking AND target is not running or doesn't have entitlement com.apple.developer.web-browser-engine.webcontent))" UserInfo={NSLocalizedFailureReason=((target is not running or doesn't have entitlement com.apple.developer.web-browser-engine.rendering AND target is not running or doesn't have entitlement com.apple.developer.web-browser-engine.networking AND target is not running or doesn't have entitlement com.apple.developer.web-browser-engine.webcontent))}>`

The changes in this PR are partially based on the following apple developer forums.
1. https://forums.developer.apple.com/forums/thread/709919
2. https://forums.developer.apple.com/forums/thread/762223?utm_source=chatgpt.com

Additional @shawn-stytch made the suggestion to move the `private let messageHandler = MessageHandler()` declaration to the file level and thus have the `DFPClient` retain the instance of it rather than create it each time we attempt to fetch the telemetry ID.

I am not sure if this change is needed right now with native DFP on the near horizon but I figured I would make the change just in case it was worth trying.

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A
