### PR TITLE
Modify logic for biometrics registrationAvailable

### DIFF
--- a/Sources/StytchCore/SharedModels/Errors/StytchSDKError.swift
+++ b/Sources/StytchCore/SharedModels/Errors/StytchSDKError.swift
@@ -51,6 +51,12 @@ public extension StytchSDKError {
             errorType: "no_biometric_registration"
         )
     )
+    static let noBiometricRegistrationId = StytchSDKError(
+        message: "There is no biometric registration ID on the device.",
+        options: .init(
+            errorType: "no_biometric_registration_id"
+        )
+    )
     static let invalidAuthorizationCredential = StytchSDKError(
         message: "The authorization credential is invalid. Verify that OAuth is set up correctly in the developer console, and call the start flow method.",
         options: .init(

--- a/Stytch/DemoApps/StytchBiometrics/ViewController.swift
+++ b/Stytch/DemoApps/StytchBiometrics/ViewController.swift
@@ -26,6 +26,7 @@ class ViewController: UIViewController {
                 case .unavailable:
                     self.sessionLabel.text = "Session Unavailable"
                 }
+                self.logBiometricRegistrations(user: StytchClient.user.getSync(), identifier: "onSessionChange")
             }.store(in: &subscriptions)
     }
 
@@ -129,10 +130,12 @@ class ViewController: UIViewController {
     func logBiometricRegistrations(user: User?, identifier: String) {
         print(
             """
-            -------------------------------------------------------------------------
             \(identifier)
+            biometricsRegistrationAvailable: \(StytchClient.biometrics.registrationAvailable)
+            biometricRegistrationId: \(StytchClient.biometrics.biometricRegistrationId ?? "none")
             biometricRegistrations.count: \(user?.biometricRegistrations.count ?? 0)
-            biometricRegistrations: \(user?.biometricRegistrations.compactMap(\.id.rawValue).joined(separator: ", ") ?? "")
+            biometricRegistrations:             
+            \(user?.biometricRegistrations.compactMap(\.id.rawValue).joined(separator: "\n") ?? "")
             -------------------------------------------------------------------------
             """
         )


### PR DESCRIPTION
## Changes:

1. Found a bug in `registrationAvailable` where we were referring to the wrong keychain value, we should have been using `privateKeyRegistration` which is the value needed for authentication and not the `biometricKeyRegistration` which is simply the biometric registration id.
2. Expose the `biometricRegistrationId` from `StytchClient.Biometrics`.
3. Added some additional comments to the biometrics client.
4. Added some additional logging to the sample app for `registrationAvailable`.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
