### PR TITLE
directCreateOrganizationForNoMembership for B2BUI

### DIFF
--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Common.swift
@@ -18,6 +18,8 @@ public extension StytchB2BClient {
         case restricted = "RESTRICTED"
         /// Disable JIT provisioning via Email Magic Link and OAuth.
         case notAllowed = "NOT_ALLOWED"
+        ///
+        case allAllowed = "ALL_ALLOWED"
     }
 
     /// The authentication setting that controls how a new Member can be invited to an organization by email.
@@ -160,6 +162,8 @@ public extension StytchB2BClient {
         case restricted = "RESTRICTED"
         /// JIT provisioning via OAuth is not allowed.
         case notAllowed = "NOT_ALLOWED"
+        ///
+        case allAllowed = "ALL_ALLOWED"
     }
 
     /// A struct representing a retired email address associated with a member.

--- a/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient+Configuration.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient+Configuration.swift
@@ -20,6 +20,7 @@ public extension StytchB2BUIClient {
         public let emailOtpOptions: B2BEmailOTPOptions?
         public let directLoginForSingleMembershipOptions: DirectLoginForSingleMembershipOptions?
         public let allowCreateOrganization: Bool
+        public let directCreateOrganizationForNoMembership: Bool
         public let mfaProductOrder: [StytchB2BClient.MfaMethod]?
         public let mfaProductInclude: [StytchB2BClient.MfaMethod]?
         public let navigation: Navigation?
@@ -78,6 +79,15 @@ public extension StytchB2BUIClient {
             }
         }
 
+        // swiftlint:disable:next identifier_name
+        public var allowsDirectCreateOrganizationIfNoneExist: Bool {
+            StytchB2BClient.createOrganizationEnabled && directCreateOrganizationForNoMembership
+        }
+
+        public var allowsUserCreateOrganizations: Bool {
+            StytchB2BClient.createOrganizationEnabled && allowCreateOrganization
+        }
+
         /// - Parameters:
         ///   - publicToken: Available via the Stytch dashboard in the `API keys` section
         ///   - hostUrl: Generally this is your backend's base url, where your apple-app-site-association file is hosted.
@@ -93,6 +103,8 @@ public extension StytchB2BUIClient {
         ///   - emailOtpOptions: The email otp options to use if you have a custom configuration.
         ///   - directLoginForSingleMembershipOptions: An optional config that allows you to skip the discover flow and log a member in directly only if they are a member of a single organization.
         ///   - allowCreateOrganization: Whether to allow users who are not members of any organization from creating a new organization during the discovery flow.
+        ///     This has no effect if the ability to create organizations from the frontend SDK is disabled in the Stytch dashboard. Defaults to `false`.
+        ///   - directCreateOrganizationForNoMembership: Whether or not an organization should be created directly when a user has no memberships, invitations, or organizations they could join via JIT provisioning.
         ///     This has no effect if the ability to create organizations from the frontend SDK is disabled in the Stytch dashboard. Defaults to `false`.
         ///   - mfaProductOrder: The order to present MFA products to a member when multiple choices are available, such as during enrollment.
         ///   - mfaProductInclude: MFA products to include in the UI. If specified, the list of available products will be limited to those included. Defaults to all available products.
@@ -113,6 +125,7 @@ public extension StytchB2BUIClient {
             emailOtpOptions: B2BEmailOTPOptions? = nil,
             directLoginForSingleMembershipOptions: DirectLoginForSingleMembershipOptions? = nil,
             allowCreateOrganization: Bool = true,
+            directCreateOrganizationForNoMembership: Bool = false,
             mfaProductOrder: [StytchB2BClient.MfaMethod]? = nil,
             mfaProductInclude: [StytchB2BClient.MfaMethod]? = nil,
             navigation: Navigation? = nil,
@@ -130,6 +143,7 @@ public extension StytchB2BUIClient {
             self.emailOtpOptions = emailOtpOptions
             self.directLoginForSingleMembershipOptions = directLoginForSingleMembershipOptions
             self.allowCreateOrganization = allowCreateOrganization
+            self.directCreateOrganizationForNoMembership = directCreateOrganizationForNoMembership
             self.mfaProductOrder = mfaProductOrder
             self.mfaProductInclude = mfaProductInclude
             self.navigation = navigation
@@ -263,6 +277,10 @@ extension StytchB2BUIClient.Configuration {
         }
     }
 
+    /// `computedAuthFlowType` serves as the primary source of truth for the current authentication state.
+    /// The `authFlowType` represents the initial authentication flow.
+    /// For example, you might pass in an `authFlowType` of `.discovery`, but once the user selects an organization,
+    /// the flow effectively transitions into an organization-based flow from the app's perspective.
     var computedAuthFlowType: StytchB2BUIClient.AuthFlowType {
         switch authFlowType {
         case .discovery:

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/Discovery/CreateOrganizationsViewController/CreateOrganizationsViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/Discovery/CreateOrganizationsViewController/CreateOrganizationsViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 
 class CreateOrganizationViewController: BaseViewController<CreateOrganizationsState, CreateOrganizationsViewModel> {
     private lazy var createOrganizationButton: Button = .primary(
-        title: NSLocalizedString("stytchCreateOrganizationCreateOrganizationButton", value: "Try a different email address", comment: "")
+        title: NSLocalizedString("stytchCreateOrganizationCreateOrganizationButton", value: "Create an organization", comment: "")
     ) { [weak self] in
         self?.createOrganization()
     }
@@ -39,18 +39,5 @@ class CreateOrganizationViewController: BaseViewController<CreateOrganizationsSt
         NSLayoutConstraint.activate(
             stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
         )
-    }
-
-    @objc func createOrganization() {
-        StytchB2BUIClient.startLoading()
-        Task {
-            do {
-                try await AuthenticationOperations.createOrganization()
-                StytchB2BUIClient.stopLoading()
-            } catch {
-                presentErrorAlert(error: error)
-                StytchB2BUIClient.stopLoading()
-            }
-        }
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/Discovery/DiscoveredOrganizations/DiscoveredOrganizationsViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/Discovery/DiscoveredOrganizations/DiscoveredOrganizationsViewController.swift
@@ -50,21 +50,8 @@ class DiscoveredOrganizationsViewController: BaseViewController<DiscoveredOrgani
 
         stackView.addArrangedSubview(tableView)
 
-        if viewModel.state.configuration.allowCreateOrganization == true, StytchB2BClient.createOrganizationEnabled == true {
+        if viewModel.state.configuration.allowsUserCreateOrganizations {
             stackView.addArrangedSubview(createOrganizationButton)
-        }
-    }
-
-    @objc func createOrganization() {
-        StytchB2BUIClient.startLoading()
-        Task {
-            do {
-                try await AuthenticationOperations.createOrganization()
-                StytchB2BUIClient.stopLoading()
-            } catch {
-                presentErrorAlert(error: error)
-                StytchB2BUIClient.stopLoading()
-            }
         }
     }
 }

--- a/Stytch/DemoApps/StytchB2BUIDemo/ContentView.swift
+++ b/Stytch/DemoApps/StytchB2BUIDemo/ContentView.swift
@@ -132,7 +132,9 @@ class ContentViewModel: ObservableObject {
             publicToken: publicToken,
             products: [.emailMagicLinks, .emailOtp, .sso, .passwords, .oauth],
             authFlowType: authFlowType,
-            oauthProviders: [.init(provider: .google), .init(provider: .github)]
+            oauthProviders: [.init(provider: .google), .init(provider: .github)],
+            allowCreateOrganization: true,
+            directCreateOrganizationForNoMembership: true
         )
     }
 }


### PR DESCRIPTION
[directOrgCreationOnZeroMemberships in iOS SDK UI](https://linear.app/stytch/issue/SDK-2381/directorgcreationonzeromemberships-in-ios-sdk-ui)

## Changes:

1. Add `directCreateOrganizationForNoMembership` to the B2B UI configuration object.
2. Consolidate create organization logic which was duplicated across 3 places.
3. Add some comments to the `computedAuthFlowType`.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
