### PR TITLE
Block multiple calls to configure

### DIFF
--- a/Sources/StytchCore/SharedModels/Configuration.swift
+++ b/Sources/StytchCore/SharedModels/Configuration.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // swiftlint:disable type_contents_order
 
-struct Configuration {
+struct Configuration: Equatable {
     private enum CodingKeys: String, CodingKey {
         case publicToken = "StytchPublicToken"
         case hostUrl = "StytchHostURL"

--- a/Sources/StytchCore/StytchClientType.swift
+++ b/Sources/StytchCore/StytchClientType.swift
@@ -53,7 +53,13 @@ extension StytchClientType {
 
     // swiftlint:disable:next type_contents_order
     mutating func configure(publicToken: String, hostUrl: URL?, dfppaDomain: String?) {
-        configuration = .init(publicToken: publicToken, hostUrl: hostUrl, dfppaDomain: dfppaDomain)
+        let newConfiguration = Configuration(publicToken: publicToken, hostUrl: hostUrl, dfppaDomain: dfppaDomain)
+
+        guard newConfiguration != configuration else {
+            return
+        }
+
+        configuration = newConfiguration
 
         updateNetworkingClient()
         resetKeychainOnFreshInstall()

--- a/Tests/StytchCoreTests/KeychainClientTestCase.swift
+++ b/Tests/StytchCoreTests/KeychainClientTestCase.swift
@@ -95,8 +95,22 @@ final class KeychainClientTestCase: BaseTestCase {
         XCTAssertEqual(try Current.keychainClient.get(.sessionToken), "token")
         XCTAssertEqual(try Current.keychainClient.get(.sessionJwt), "token_jwt")
         Current.defaults.removeObject(forKey: installIdKey)
-        StytchClient.configure(publicToken: "some public token")
+        StytchClient.configure(publicToken: "another public token")
         XCTAssertNil(try Current.keychainClient.get(.sessionToken))
         XCTAssertNil(try Current.keychainClient.get(.sessionJwt))
+    }
+
+    func testKeychainDoesNotResetWhenConfigureIsCalledAgainWithSamePublicToken() throws {
+        let installIdKey = "stytch_install_id_defaults_key"
+        Current.defaults.set(Current.uuid().uuidString, forKey: installIdKey)
+        try Current.keychainClient.set("token", for: .sessionToken)
+        try Current.keychainClient.set("token_jwt", for: .sessionJwt)
+        StytchClient.configure(publicToken: "some public token")
+        XCTAssertEqual(try Current.keychainClient.get(.sessionToken), "token")
+        XCTAssertEqual(try Current.keychainClient.get(.sessionJwt), "token_jwt")
+        Current.defaults.removeObject(forKey: installIdKey)
+        StytchClient.configure(publicToken: "some public token")
+        XCTAssertNotNil(try Current.keychainClient.get(.sessionToken))
+        XCTAssertNotNil(try Current.keychainClient.get(.sessionJwt))
     }
 }


### PR DESCRIPTION
[[iOS] Add checking/early return for multiple configure calls being made](https://linear.app/stytch/issue/SDK-2391/[ios]-add-checkingearly-return-for-multiple-configure-calls-being-made)

## Changes:

1. Add `Equatable` conformance to the `Configuration` object.
2. In `StytchClientType` change logic to create a new configuration from the passed in values for `mutating func configure(publicToken: String, hostUrl: URL?, dfppaDomain: String?)` and only assign a new configuration and proceed with set up steps if the configuration is different.
3. Add a unit test in `KeychainClientTestCase` to make sure the keychain client values don't reset when the same public token is used to call configure multiple times.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
