### PR TITLE
Refactor some bootstrap funk, consolidate code

### DIFF
--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -28,14 +28,8 @@ public struct StytchB2BClient: StytchClientType {
         Current.localStorage.bootstrapData?.passwordConfig
     }
 
-    private init() {
-        #if os(iOS)
-        NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: nil) { _ in
-            Task {
-                try await StartupClient.start(type: ClientType.b2b)
-            }
-        }
-        #endif
+    public static var clientType: ClientType {
+        .b2b
     }
 
     /**
@@ -61,19 +55,6 @@ public struct StytchB2BClient: StytchClientType {
     /// Retrieve the most recently created PKCE code pair from the device, if available
     public static func getPKCECodePair() -> PKCECodePair? {
         Self.instance.pkcePairManager.getPKCECodePair()
-    }
-}
-
-public extension StytchB2BClient {
-    func start() {
-        Task {
-            do {
-                try await StartupClient.start(type: ClientType.b2b)
-                try? await EventsClient.logEvent(parameters: .init(eventName: "client_initialization_success"))
-            } catch {
-                try? await EventsClient.logEvent(parameters: .init(eventName: "client_initialization_failure"))
-            }
-        }
     }
 }
 

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -27,14 +27,8 @@ public struct StytchClient: StytchClientType {
         Current.localStorage.bootstrapData?.passwordConfig
     }
 
-    private init() {
-        #if os(iOS)
-        NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: nil) { _ in
-            Task {
-                try await StartupClient.start(type: ClientType.consumer)
-            }
-        }
-        #endif
+    public static var clientType: ClientType {
+        .consumer
     }
 
     /**
@@ -59,19 +53,6 @@ public struct StytchClient: StytchClientType {
     /// Retrieve the most recently created PKCE code pair from the device, if available
     public static func getPKCECodePair() -> PKCECodePair? {
         Self.instance.pkcePairManager.getPKCECodePair()
-    }
-}
-
-public extension StytchClient {
-    func start() {
-        Task {
-            do {
-                try await StartupClient.start(type: ClientType.consumer)
-                try? await EventsClient.logEvent(parameters: .init(eventName: "client_initialization_success"))
-            } catch {
-                try? await EventsClient.logEvent(parameters: .init(eventName: "client_initialization_failure"))
-            }
-        }
     }
 }
 

--- a/Stytch/DemoApps/StytchDemo/ContentView.swift
+++ b/Stytch/DemoApps/StytchDemo/ContentView.swift
@@ -72,7 +72,7 @@ struct ContentView: View {
                     }
                 case .notHandled:
                     print("not handled")
-                case let .manualHandlingRequired(tokenType, token):
+                case let .manualHandlingRequired(tokenType, _, token):
                     print("manualHandlingRequired: tokenType: \(tokenType) - token: \(token)")
                 }
             } catch {


### PR DESCRIPTION
[[iOS] Don't override valid bootstrap data if coming to the foreground with no network connection](https://linear.app/stytch/issue/SDK-2434/[ios]-dont-override-valid-bootstrap-data-if-coming-to-the-foreground)

## Changes:

1. Modify logic in the bootstrap response where as before it was always overriding the bootstrap data stored locally if a call failed. Now it will only assign the default data if there is none saved.
2. Consolidate duplicate codes based on client type across `StytchB2BClient` and `StytchClient` into a single `start` function.
3. Check to make sure the captcha siteKey is not only not nil but also not an empty string.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A
