### PR TITLE
Fix OAuth provider params

### DIFF
--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty+Discovery.swift
@@ -79,8 +79,8 @@ public extension StytchB2BClient.OAuth.ThirdParty.Discovery {
                 queryParameters["custom_scopes"] = customScopes
             }
 
-            if let providerParams = providerParams?.toURLParameters() {
-                queryParameters["provider_params"] = providerParams
+            if let providerParams {
+                queryParameters.merge(providerParams) { _, new in new }
             }
 
             if let discoveryRedirectUrl = discoveryRedirectUrl?.absoluteString {

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
@@ -113,8 +113,8 @@ public extension StytchB2BClient.OAuth.ThirdParty {
                 queryParameters["custom_scopes"] = customScopes
             }
 
-            if let providerParams = providerParams?.toURLParameters() {
-                queryParameters["provider_params"] = providerParams
+            if let providerParams {
+                queryParameters.merge(providerParams) { _, new in new }
             }
 
             if let loginRedirectUrl = loginRedirectUrl?.absoluteString {

--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
@@ -78,8 +78,8 @@ public extension StytchClient.OAuth.ThirdParty {
                 queryParameters["custom_scopes"] = customScopes
             }
 
-            if let providerParams = providerParams?.toURLParameters() {
-                queryParameters["provider_params"] = providerParams
+            if let providerParams {
+                queryParameters.merge(providerParams) { _, new in new }
             }
 
             if let loginRedirectUrl = loginRedirectUrl?.absoluteString {

--- a/Tests/StytchCoreTests/BaseTestCase.swift
+++ b/Tests/StytchCoreTests/BaseTestCase.swift
@@ -155,3 +155,18 @@ extension PollingClient {
         XCTFail("Shouldn't execute")
     }
 }
+
+extension XCTestCase {
+    func assertURLContainsParameters(_ url: URL, expectedParameters: [String: String], file: StaticString = #file, line: UInt = #line) {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false), let queryItems = components.queryItems else {
+            XCTFail("Invalid URL or missing query parameters", file: file, line: line)
+            return
+        }
+
+        let queryDictionary = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value ?? "") })
+
+        for (key, expectedValue) in expectedParameters {
+            XCTAssertEqual(queryDictionary[key], expectedValue, "URL missing expected query parameter: \(key)", file: file, line: line)
+        }
+    }
+}


### PR DESCRIPTION
[iOS: OAuth provider params don't work](https://linear.app/stytch/issue/SDK-2435/ios-oauth-provider-params-dont-work)

## Changes:

1. We had the provider params being added a value with a key "provider_params" which was wrong, they should be just added to the dictionary of queryParameters that gets built.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
