### PR TITLE
Fix Oauth provider params (take 2)

### DIFF
--- a/Sources/StytchCore/Extensions/Dictionary+Stytch.swift
+++ b/Sources/StytchCore/Extensions/Dictionary+Stytch.swift
@@ -6,3 +6,11 @@ extension Dictionary where Key == CFString, Value == Any {
         merging(other) { $1 } as CFDictionary
     }
 }
+
+extension Dictionary where Key == String, Value == String {
+    func appendingPrefix(_ prefix: String) -> [String: String] {
+        reduce(into: [String: String]()) { result, pair in
+            result["\(prefix)_\(pair.key)"] = pair.value
+        }
+    }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty+Discovery.swift
@@ -80,7 +80,8 @@ public extension StytchB2BClient.OAuth.ThirdParty.Discovery {
             }
 
             if let providerParams {
-                queryParameters.merge(providerParams) { _, new in new }
+                let modifiedProviderParams = providerParams.appendingPrefix("provider")
+                queryParameters.merge(modifiedProviderParams) { _, new in new }
             }
 
             if let discoveryRedirectUrl = discoveryRedirectUrl?.absoluteString {

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth+ThirdParty.swift
@@ -114,7 +114,8 @@ public extension StytchB2BClient.OAuth.ThirdParty {
             }
 
             if let providerParams {
-                queryParameters.merge(providerParams) { _, new in new }
+                let modifiedProviderParams = providerParams.appendingPrefix("provider")
+                queryParameters.merge(modifiedProviderParams) { _, new in new }
             }
 
             if let loginRedirectUrl = loginRedirectUrl?.absoluteString {

--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+ThirdParty.swift
@@ -79,7 +79,8 @@ public extension StytchClient.OAuth.ThirdParty {
             }
 
             if let providerParams {
-                queryParameters.merge(providerParams) { _, new in new }
+                let modifiedProviderParams = providerParams.appendingPrefix("provider")
+                queryParameters.merge(modifiedProviderParams) { _, new in new }
             }
 
             if let loginRedirectUrl = loginRedirectUrl?.absoluteString {

--- a/Tests/StytchCoreTests/OAuthTestCase.swift
+++ b/Tests/StytchCoreTests/OAuthTestCase.swift
@@ -72,13 +72,16 @@ extension OAuthTestCase {
         }
         var baseUrl = try XCTUnwrap(URL(string: "https://blah"))
 
-        let providerParams = ["provider_prompt": "select_account"]
+        // The internals prepend "provider_" to each key.
+        // For example, if the developer passes in ["foo": "bar"],
+        // the resulting dictionary will be:
+        let providerParams = ["provider_foo": "bar"]
 
         let createConfiguration: (URL) -> StytchClient.OAuth.ThirdParty.WebAuthenticationConfiguration = { url in
             .init(
                 loginRedirectUrl: url.appendingPathComponent("/login"),
                 signupRedirectUrl: url.appendingPathComponent("/signup"),
-                providerParams: ["provider_prompt": "select_account"]
+                providerParams: ["foo": "bar"]
             )
         }
 


### PR DESCRIPTION
[iOS: OAuth provider params don't work](https://linear.app/stytch/issue/SDK-2435/ios-oauth-provider-params-dont-work)

## Changes:

1. I had misunderstood how the provider params need to be formatted in a previous pr, so we are fixing them in this one.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
