### PR TITLE
Respect the order of products for the b2c ui

### DIFF
--- a/Sources/StytchUI/Extensions/Array+StytchUI.swift
+++ b/Sources/StytchUI/Extensions/Array+StytchUI.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension Array where Element: Equatable {
+    mutating func appendIfNotPresent(_ element: Element) {
+        if contains(element) == false {
+            append(element)
+        }
+    }
+}

--- a/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient+ProductOrdering.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient+ProductOrdering.swift
@@ -80,11 +80,3 @@ extension StytchB2BUIClient {
         case divider
     }
 }
-
-private extension Array where Element: Equatable {
-    mutating func appendIfNotPresent(_ element: Element) {
-        if contains(element) == false {
-            append(element)
-        }
-    }
-}

--- a/Sources/StytchUI/StytchUIClient/StytchUIClient+Configuration.swift
+++ b/Sources/StytchUI/StytchUIClient/StytchUIClient+Configuration.swift
@@ -141,13 +141,13 @@ public extension StytchUIClient {
     /// `loginTemplateId` is the ID of the custom login template you have created in your Stytch Dashboard. This is only used for Email OTP.
     /// `signupTemplateId` is the ID of the custom signup template you have created in your Stytch Dashboard. This is only used for Email OTP.
     struct OTPOptions: Codable {
-        let methods: Set<OTPMethod>
+        let methods: [OTPMethod]
         let expiration: Minutes?
         let loginTemplateId: String?
         let signupTemplateId: String?
 
         public init(
-            methods: Set<OTPMethod>,
+            methods: [OTPMethod],
             expiration: Minutes? = nil,
             loginTemplateId: String? = nil,
             signupTemplateId: String? = nil

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/AuthHomeViewController/AuthHomeViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/AuthHomeViewController/AuthHomeViewController.swift
@@ -46,29 +46,31 @@ final class AuthHomeViewController: BaseViewController<AuthHomeState, AuthHomeVi
         attachStackViewToScrollView()
 
         stackView.addArrangedSubview(titleLabel)
-        var constraints: [NSLayoutConstraint] = []
-        if !viewModel.state.config.oauthProviders.isEmpty {
-            let oauthController = OAuthViewController(state: .init(config: viewModel.state.config))
-            addChild(oauthController)
-            stackView.addArrangedSubview(oauthController.view)
-            constraints.append(oauthController.view.widthAnchor.constraint(equalTo: stackView.widthAnchor))
+
+        for productComponent in viewModel.productComponents {
+            switch productComponent {
+            case .inputProducts:
+                let inputController = AuthInputViewController(state: .init(config: viewModel.state.config))
+                addChild(inputController)
+                stackView.addArrangedSubview(inputController.view)
+            case .oAuthButtons:
+                let oauthController = OAuthViewController(state: .init(config: viewModel.state.config))
+                addChild(oauthController)
+                stackView.addArrangedSubview(oauthController.view)
+            case .divider:
+                stackView.addArrangedSubview(separatorView)
+            }
         }
-        if showOrSeparator {
-            stackView.addArrangedSubview(separatorView)
-            constraints.append(separatorView.widthAnchor.constraint(equalTo: stackView.widthAnchor))
-        }
-        if viewModel.state.config.inputProductsEnabled {
-            let inputController = AuthInputViewController(state: .init(config: viewModel.state.config))
-            addChild(inputController)
-            stackView.addArrangedSubview(inputController.view)
-            constraints.append(inputController.view.widthAnchor.constraint(equalTo: stackView.widthAnchor))
-        }
+
         if StytchClient.disableSdkWatermark == false {
             setupPoweredByStytchView()
         }
+
         stackView.addArrangedSubview(SpacerView())
 
-        NSLayoutConstraint.activate(constraints)
+        NSLayoutConstraint.activate(
+            stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
+        )
 
         Task {
             try await viewModel.logRenderScreen()

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/AuthHomeViewController/AuthHomeViewModel.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/AuthHomeViewController/AuthHomeViewModel.swift
@@ -14,6 +14,26 @@ final class AuthHomeViewModel {
     }
 }
 
+extension AuthHomeViewModel {
+    var productComponents: [StytchUIClient.ProductComponent] {
+        var productComponents = [StytchUIClient.ProductComponent]()
+        for component in state.config.products {
+            switch component {
+            case .oauth:
+                productComponents.appendIfNotPresent(.oAuthButtons)
+            case .emailMagicLinks, .passwords, .otp:
+                productComponents.appendIfNotPresent(.inputProducts)
+            }
+        }
+
+        if productComponents.count == 2 {
+            productComponents.insert(.divider, at: 1)
+        }
+
+        return productComponents
+    }
+}
+
 extension AuthHomeViewModel: AuthHomeViewModelProtocol {
     func logRenderScreen() async throws {
         try await EventsClient.logEvent(
@@ -33,4 +53,12 @@ extension AuthHomeViewModel: AuthHomeViewModelProtocol {
 
 struct AuthHomeState {
     let config: StytchUIClient.Configuration
+}
+
+extension StytchUIClient {
+    enum ProductComponent: String, Equatable {
+        case inputProducts
+        case oAuthButtons
+        case divider
+    }
 }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/AuthInputViewController/AuthInputViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/AuthInputViewController/AuthInputViewController.swift
@@ -10,52 +10,58 @@ final class AuthInputViewController: BaseViewController<AuthInputState, AuthInpu
     }
 
     private lazy var segmentedControl: UISegmentedControl? = {
-        if inputs.count > 1 {
-            let segmentedControl = UISegmentedControl()
-            if inputs.contains(.whatsapp) {
-                segmentedControl.insertSegment(
-                    withTitle: NSLocalizedString("stytch.aivcWhatsApp", value: "WhatsApp", comment: ""),
-                    at: 0,
-                    animated: false
-                )
-            }
-            if inputs.contains(.phone) {
-                segmentedControl.insertSegment(
-                    withTitle: NSLocalizedString("stytch.aivcText", value: "Text", comment: ""),
-                    at: 0,
-                    animated: false
-                )
-            }
-            if inputs.contains(.email) {
+        guard inputs.count > 1 else { return nil }
+        let segmentedControl = UISegmentedControl()
+        for input in inputs {
+            switch input {
+            case .email:
                 segmentedControl.insertSegment(
                     withTitle: NSLocalizedString("stytch.aivcEmail", value: "Email", comment: ""),
-                    at: 0,
+                    at: segmentedControl.numberOfSegments,
+                    animated: false
+                )
+            case .phone:
+                segmentedControl.insertSegment(
+                    withTitle: NSLocalizedString("stytch.aivcText", value: "Text", comment: ""),
+                    at: segmentedControl.numberOfSegments,
+                    animated: false
+                )
+            case .whatsapp:
+                segmentedControl.insertSegment(
+                    withTitle: NSLocalizedString("stytch.aivcWhatsApp", value: "WhatsApp", comment: ""),
+                    at: segmentedControl.numberOfSegments,
                     animated: false
                 )
             }
-            segmentedControl.selectedSegmentIndex = 0
-            segmentedControl.accessibilityLabel = "emailTextSegmentedControl"
-            return segmentedControl
         }
-        return nil
+
+        segmentedControl.selectedSegmentIndex = 0
+        segmentedControl.accessibilityLabel = "emailTextSegmentedControl"
+        return segmentedControl
     }()
 
     private lazy var inputs: [Input] = {
         var inputs: [Input] = []
-        if viewModel.state.config.supportsEmailMagicLinks || viewModel.state.config.supportsPasswords {
-            inputs.append(.email)
-        }
+
         if let otpMethods = viewModel.state.config.otpOptions?.methods {
-            if otpMethods.contains(.email), !inputs.contains(.email) {
+            for method in otpMethods {
+                switch method {
+                case .sms:
+                    inputs.append(.phone)
+                case .email:
+                    inputs.append(.email)
+                case .whatsapp:
+                    inputs.append(.whatsapp)
+                }
+            }
+        }
+
+        if inputs.contains(.email) == false {
+            if viewModel.state.config.supportsEmailMagicLinks || viewModel.state.config.supportsPasswords {
                 inputs.append(.email)
             }
-            if otpMethods.contains(.sms) {
-                inputs.append(.phone)
-            }
-            if otpMethods.contains(.whatsapp) {
-                inputs.append(.whatsapp)
-            }
         }
+
         return inputs
     }()
 

--- a/Stytch/DemoApps/StytchUIDemo/ContentView.swift
+++ b/Stytch/DemoApps/StytchUIDemo/ContentView.swift
@@ -10,7 +10,7 @@ struct ContentView: View {
         stytchClientConfiguration: .init(publicToken: "your-public-token"),
         products: [.passwords, .emailMagicLinks, .otp, .oauth],
         oauthProviders: [.apple, .thirdParty(.google)],
-        otpOptions: .init(methods: [.sms])
+        otpOptions: .init(methods: [.sms, .whatsapp])
     )
 
     var body: some View {


### PR DESCRIPTION
[[iOS] Follow order of products in prebuilt UI components](https://linear.app/stytch/issue/SDK-2446/[ios]-follow-order-of-products-in-prebuilt-ui-components)

## Changes:

1. Bring component ordering to the B2C UI, including the ordering of the tab bar components.
2. In the tab bar OTP options go first and then if email was not an OTP option but EML was enabled it will be added last.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
