### PR TITLE
Add org slug to generic OrganizationType

### DIFF
--- a/Sources/StytchCore/StytchB2BClient/Models/OrganizationType.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/OrganizationType.swift
@@ -4,6 +4,8 @@ import Foundation
 public protocol OrganizationType: Codable, Sendable {
     /// Globally unique UUID that identifies an organization in the Stytch API.
     var organizationId: Organization.ID { get }
+    /// The unique URL slug of the Organization. The slug only accepts alphanumeric characters and the following reserved characters: - . _ ~. Must be between 2 and 128 characters in length.
+    var slug: String { get }
     /// An array of active SSO Connection references.
     var ssoActiveConnections: [StytchB2BClient.SSOActiveConnection]? { get }
     /// The default connection used for SSO when there are multiple active connections.

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SearchManager.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SearchManager.swift
@@ -81,6 +81,8 @@ public extension StytchB2BClient.SearchManager {
         public let organizationId: Organization.ID
         /// The name of the organization.
         public let organizationName: String
+        /// The unique URL slug of the Organization. The slug only accepts alphanumeric characters and the following reserved characters: - . _ ~. Must be between 2 and 128 characters in length.
+        public let organizationSlug: String
         /// A URL of the organization's logo.
         public let organizationLogoUrl: String?
         /// An array of active SSO Connection references.
@@ -102,6 +104,10 @@ public extension StytchB2BClient.SearchManager {
 
         public var name: String {
             organizationName
+        }
+
+        public var slug: String {
+            organizationSlug
         }
 
         public var logoUrl: URL? {

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/StateManagement/OrganizationManager.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/StateManagement/OrganizationManager.swift
@@ -4,8 +4,6 @@ import StytchCore
 struct OrganizationManager {
     private static var organization: OrganizationType?
 
-    private static var _organizationSlug: String?
-
     static var organizationId: String? {
         organization?.organizationId.rawValue
     }
@@ -42,6 +40,10 @@ struct OrganizationManager {
         organization?.name
     }
 
+    static var slug: String? {
+        organization?.slug
+    }
+
     static var logoUrl: URL? {
         organization?.logoUrl
     }
@@ -49,7 +51,6 @@ struct OrganizationManager {
     static func getOrganizationBySlug(organizationSlug: String) async throws {
         let parameters = StytchB2BClient.SearchManager.SearchOrganizationParameters(organizationSlug: organizationSlug)
         let response = try await StytchB2BClient.searchManager.searchOrganization(searchOrganizationParameters: parameters)
-        _organizationSlug = organizationSlug
         organization = response.organization
     }
 
@@ -58,7 +59,6 @@ struct OrganizationManager {
     }
 
     static func reset() {
-        _organizationSlug = nil
         organization = nil
     }
 }
@@ -86,14 +86,6 @@ extension OrganizationManager {
             return org.allMFAMethodsAllowed
         } else {
             return nil
-        }
-    }
-
-    static var organizationSlug: String? {
-        if let org = organization as? Organization {
-            return org.slug
-        } else {
-            return _organizationSlug
         }
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient+Configuration.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient+Configuration.swift
@@ -279,7 +279,7 @@ extension StytchB2BUIClient.Configuration {
     var computedAuthFlowType: StytchB2BUIClient.AuthFlowType {
         switch authFlowType {
         case .discovery:
-            if let organizationSlug = OrganizationManager.organizationSlug {
+            if let organizationSlug = OrganizationManager.slug {
                 return .organization(slug: organizationSlug)
             } else {
                 return .discovery

--- a/Tests/StytchCoreTests/B2BSearchManagerTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSearchManagerTestCase.swift
@@ -64,6 +64,7 @@ extension StytchB2BClient.SearchManager.OrganizationSearchResponse {
     static let mock: Self = .init(
         organizationId: "1234",
         organizationName: "org foo",
+        organizationSlug: "org slug foo",
         organizationLogoUrl: nil,
         ssoActiveConnections: nil,
         ssoDefaultConnectionId: nil,


### PR DESCRIPTION
[[iOS] Update org search by slug response to include slug in response object.](https://linear.app/stytch/issue/SDK-2464/[ios]-update-org-search-by-slug-response-to-include-slug-in-response)

## Changes:

1. Mirrors changes made in: https://github.com/stytchauth/api/pull/6888.
2. This allows me to unify logic between the full org object and the org object returned by the search by slug endpoint.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
