### PR TITLE
Prevent biometric registration if the user is already enrolled.

### DIFF
--- a/Sources/StytchCore/SharedModels/Errors/StytchSDKError.swift
+++ b/Sources/StytchCore/SharedModels/Errors/StytchSDKError.swift
@@ -57,6 +57,12 @@ public extension StytchSDKError {
             errorType: "no_biometric_registration_id"
         )
     )
+    static let biometricsAlreadyEnrolled = StytchSDKError(
+        message: "There is already a biometric factor enrolled on this device. Fully authenticate with all factors and remove the existing registration before attempting to register again.",
+        options: .init(
+            errorType: "biometric_already_enrolled"
+        )
+    )
     static let invalidAuthorizationCredential = StytchSDKError(
         message: "The authorization credential is invalid. Verify that OAuth is set up correctly in the developer console, and call the start flow method.",
         options: .init(

--- a/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
@@ -86,6 +86,11 @@ public extension StytchClient {
                 throw StytchSDKError.noCurrentSession
             }
 
+            // Early return if the user is already enrolled in biometrics
+            guard registrationAvailable == false else {
+                throw StytchSDKError.biometricsAlreadyEnrolled
+            }
+
             let (privateKey, publicKey) = cryptoClient.generateKeyPair()
 
             let startResponse: RegisterStartResponse = try await router.post(


### PR DESCRIPTION
[[iOS] Biometrics - don't allow register to be called if local registration exists.](https://linear.app/stytch/issue/SDK-2369/[ios]-biometrics-dont-allow-register-to-be-called-if-local)

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
