### PR TITLE
Change timeout of email otp to 10 minutes

### DIFF
--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailOTPEntryViewController/EmailOTPEntryViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailOTPEntryViewController/EmailOTPEntryViewController.swift
@@ -10,8 +10,7 @@ final class EmailOTPEntryViewController: BaseViewController<EmailOTPEntryState, 
     )
 
     var timer: Timer?
-
-    var expirationDate = Date().addingTimeInterval(120)
+    var expirationDate = Date().addingTimeInterval(600)
 
     lazy var expiryButton: Button = makeExpiryButton()
 
@@ -68,7 +67,7 @@ final class EmailOTPEntryViewController: BaseViewController<EmailOTPEntryState, 
     }
 
     func resetExpirationDate() {
-        expirationDate = Date().addingTimeInterval(121)
+        expirationDate = Date().addingTimeInterval(600)
     }
 }
 


### PR DESCRIPTION
[iOS: Countdown for B2B Email OTP code expiry should be 10 minutes, not 2](https://linear.app/stytch/issue/SDK-2472/ios-countdown-for-b2b-email-otp-code-expiry-should-be-10-minutes-not-2)

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
