### PR TITLE
Add lastAuthMethod used to clients

### DIFF
--- a/Sources/StytchCore/KeychainClient/KeychainClient+Item.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient+Item.swift
@@ -75,6 +75,9 @@ extension KeychainClient.Item {
     static let user: Self = .init(kind: .object, name: "stytch_user_object")
     static let member: Self = .init(kind: .object, name: "stytch_member_object")
     static let organization: Self = .init(kind: .object, name: "stytch_organization_object")
+
+    static let b2bLastAuthMethodUsed: Self = .init(kind: .object, name: "b2b_last_auth_method_used")
+    static let consumerLastAuthMethodUsed: Self = .init(kind: .object, name: "consumer_last_auth_method_used")
 }
 
 extension KeychainClient.Item {
@@ -92,6 +95,8 @@ extension KeychainClient.Item {
             .user,
             .member,
             .organization,
+            .b2bLastAuthMethodUsed,
+            .consumerLastAuthMethodUsed,
         ]
     }
 }

--- a/Sources/StytchCore/SessionManager.swift
+++ b/Sources/StytchCore/SessionManager.swift
@@ -93,6 +93,32 @@ final class SessionManager {
         }
     }
 
+    var b2bLastAuthMethodUsed: StytchB2BClient.B2BAuthMethod {
+        get {
+            if let string = try? keychainClient.get(.b2bLastAuthMethodUsed) {
+                return StytchB2BClient.B2BAuthMethod(rawValue: string) ?? .unknown
+            } else {
+                return StytchB2BClient.B2BAuthMethod.unknown
+            }
+        }
+        set {
+            try? keychainClient.set(newValue.rawValue, for: .b2bLastAuthMethodUsed)
+        }
+    }
+
+    var consumerLastAuthMethodUsed: StytchClient.ConsumerAuthMethod {
+        get {
+            if let string = try? keychainClient.get(.consumerLastAuthMethodUsed) {
+                return StytchClient.ConsumerAuthMethod(rawValue: string) ?? .unknown
+            } else {
+                return StytchClient.ConsumerAuthMethod.unknown
+            }
+        }
+        set {
+            try? keychainClient.set(newValue.rawValue, for: .consumerLastAuthMethodUsed)
+        }
+    }
+
     init() {
         NotificationCenter.default
             .addObserver(

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+AuthMethod.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+AuthMethod.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public extension StytchB2BClient {
+    enum B2BAuthMethod: String, Codable {
+        case emailMagicLinks
+        case emailOtp
+        case oauth
+        case passwords
+        case sso
+        case unknown
+    }
+}

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+MagicLinks.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+MagicLinks.swift
@@ -41,15 +41,17 @@ public extension StytchB2BClient {
                         wrapped: parameters
                     )
                 )
-                return try await router.post(
+                let mfaAuthenticateResponse: B2BMFAAuthenticateResponse = try await router.post(
                     to: .authenticate,
                     parameters: intermediateSessionTokenParameters,
                     useDFPPA: true
                 )
+                sessionManager.b2bLastAuthMethodUsed = .emailMagicLinks
+                return mfaAuthenticateResponse
             }
             // For authenticating if inviteSend was called, in which case we will not have a PKCE challenge code
             else {
-                return try await router.post(
+                let mfaAuthenticateResponse: B2BMFAAuthenticateResponse = try await router.post(
                     to: .authenticate,
                     parameters: IntermediateSessionTokenParameters(
                         intermediateSessionToken: sessionManager.intermediateSessionToken,
@@ -57,6 +59,8 @@ public extension StytchB2BClient {
                     ),
                     useDFPPA: true
                 )
+                sessionManager.b2bLastAuthMethodUsed = .emailMagicLinks
+                return mfaAuthenticateResponse
             }
         }
 

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
@@ -42,13 +42,14 @@ public extension StytchB2BClient {
                     )
                 )
 
-                let result = try await router.post(
+                let oauthAuthenticateResponse = try await router.post(
                     to: .authenticate,
                     parameters: intermediateSessionTokenParameters,
                     useDFPPA: true
                 ) as OAuthAuthenticateResponse
                 try? await EventsClient.logEvent(parameters: .init(eventName: "b2b_oauth_success"))
-                return result
+                sessionManager.b2bLastAuthMethodUsed = .oauth
+                return oauthAuthenticateResponse
             } catch {
                 try? await EventsClient.logEvent(parameters: .init(eventName: "b2b_oauth_failure", error: error))
                 throw error

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP+Email.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP+Email.swift
@@ -12,6 +12,7 @@ public extension StytchB2BClient.OTP {
 public extension StytchB2BClient.OTP {
     struct Email {
         let router: NetworkingRouter<StytchB2BClient.OTPRoute.EmailRoute>
+        @Dependency(\.sessionManager) private var sessionManager
 
         // sourcery: AsyncVariants
         /// Send a one-time passcode (OTP) to a user using email address.
@@ -22,7 +23,9 @@ public extension StytchB2BClient.OTP {
         // sourcery: AsyncVariants
         /// Authenticate a one-time passcode (OTP) sent to a user via Email.
         public func authenticate(parameters: AuthenticateParameters) async throws -> AuthenticateResponse {
-            try await router.post(to: .authenticate, parameters: parameters, useDFPPA: true)
+            let authenticateResponse: AuthenticateResponse = try await router.post(to: .authenticate, parameters: parameters, useDFPPA: true)
+            sessionManager.b2bLastAuthMethodUsed = .emailOtp
+            return authenticateResponse
         }
     }
 }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Passwords/StytchB2BClient+Passwords.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Passwords/StytchB2BClient+Passwords.swift
@@ -25,7 +25,7 @@ public extension StytchB2BClient {
         /// 2. The member used email based authentication (e.g. Magic Links, Google OAuth) for the first time, and had not previously verified their email address for password based login.
         ///   a. We force a password reset in this instance in order to safely deduplicate the account by email address, without introducing the risk of a pre-hijack account-takeover attack.
         public func authenticate(parameters: AuthenticateParameters) async throws -> B2BMFAAuthenticateResponse {
-            try await router.post(
+            let mfaAuthenticateResponse: B2BMFAAuthenticateResponse = try await router.post(
                 to: .authenticate,
                 parameters: IntermediateSessionTokenParameters(
                     intermediateSessionToken: sessionManager.intermediateSessionToken,
@@ -33,6 +33,10 @@ public extension StytchB2BClient {
                 ),
                 useDFPPA: true
             )
+
+            sessionManager.b2bLastAuthMethodUsed = .passwords
+
+            return mfaAuthenticateResponse
         }
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
@@ -72,13 +76,15 @@ public extension StytchB2BClient {
                 )
             )
 
-            let response: B2BMFAAuthenticateResponse = try await router.post(
+            let mfaAuthenticateResponse: B2BMFAAuthenticateResponse = try await router.post(
                 to: .resetByEmail(.complete),
                 parameters: intermediateSessionTokenParameters,
                 useDFPPA: true
             )
 
-            return response
+            sessionManager.b2bLastAuthMethodUsed = .passwords
+
+            return mfaAuthenticateResponse
         }
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
@@ -86,7 +92,7 @@ public extension StytchB2BClient {
         ///
         /// The provided password needs to meet our password strength requirements, which can be checked in advance with the password strength endpoint. If the password and accompanying parameters are accepted, the password is securely stored for future authentication and the member is authenticated.
         public func resetByExistingPassword(parameters: ResetByExistingPasswordParameters) async throws -> B2BMFAAuthenticateResponse {
-            try await router.post(
+            let mfaAuthenticateResponse: B2BMFAAuthenticateResponse = try await router.post(
                 to: .resetByExistingPassword,
                 parameters: IntermediateSessionTokenParameters(
                     intermediateSessionToken: sessionManager.intermediateSessionToken,
@@ -94,6 +100,10 @@ public extension StytchB2BClient {
                 ),
                 useDFPPA: true
             )
+
+            sessionManager.b2bLastAuthMethodUsed = .passwords
+
+            return mfaAuthenticateResponse
         }
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO.swift
@@ -47,11 +47,15 @@ public extension StytchB2BClient {
                 )
             )
 
-            return try await router.post(
+            let mfaAuthenticateResponse: B2BMFAAuthenticateResponse = try await router.post(
                 to: .authenticate,
                 parameters: intermediateSessionTokenParameters,
                 useDFPPA: true
             )
+
+            sessionManager.b2bLastAuthMethodUsed = .sso
+
+            return mfaAuthenticateResponse
         }
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -16,6 +16,10 @@ public struct StytchB2BClient: StytchClientType {
     static let router: NetworkingRouter<BaseRoute> = .init { instance.configuration }
     public static var isInitialized: AnyPublisher<Bool, Never> { StartupClient.isInitialized }
 
+    public static var lastAuthMethodUsed: B2BAuthMethod {
+        Current.sessionManager.b2bLastAuthMethodUsed
+    }
+
     public static var createOrganizationEnabled: Bool {
         Current.localStorage.bootstrapData?.createOrganizationEnabled ?? false
     }

--- a/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
@@ -28,7 +28,7 @@ public extension StytchClient {
 
         @Dependency(\.keychainClient) private var keychainClient
 
-        @Dependency(\.sessionManager.persistedSessionIdentifiersExist) private var activeSessionExists
+        @Dependency(\.sessionManager) private var sessionManager
 
         @Dependency(\.jsonDecoder) private var jsonDecoder
 
@@ -82,7 +82,7 @@ public extension StytchClient {
         /// NOTE: - You should ensure the `accessPolicy` parameters match your particular needs, defaults to `deviceOwnerWithBiometrics`.
         public func register(parameters: RegisterParameters) async throws -> RegisterCompleteResponse {
             // Early out if not authenticated
-            guard activeSessionExists else {
+            guard sessionManager.persistedSessionIdentifiersExist else {
                 throw StytchSDKError.noCurrentSession
             }
 
@@ -158,6 +158,9 @@ public extension StytchClient {
                 parameters: authenticateCompleteParameters,
                 useDFPPA: true
             )
+
+            sessionManager.consumerLastAuthMethodUsed = .biometrics
+
             return authenticateResponse
         }
 

--- a/Sources/StytchCore/StytchClient/MagicLinks/StytchClient+MagicLinks.swift
+++ b/Sources/StytchCore/StytchClient/MagicLinks/StytchClient+MagicLinks.swift
@@ -4,6 +4,7 @@ public extension StytchClient {
         let router: NetworkingRouter<MagicLinksRoute>
 
         @Dependency(\.pkcePairManager) private var pkcePairManager
+        @Dependency(\.sessionManager) private var sessionManager
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps the magic link [authenticate](https://stytch.com/docs/api/authenticate-magic-link) API endpoint which validates the magic link token passed in. If this method succeeds, the user will be logged in, granted an active session, and the session cookies will be minted and stored in `HTTPCookieStorage.shared`.
@@ -16,10 +17,14 @@ public extension StytchClient {
                 throw StytchSDKError.missingPKCE
             }
 
-            return try await router.post(
+            let authenticateResponse: AuthenticateResponse = try await router.post(
                 to: .authenticate,
                 parameters: CodeVerifierParameters(codeVerifier: pkcePair.codeVerifier, wrapped: parameters)
             )
+
+            sessionManager.consumerLastAuthMethodUsed = .emailMagicLinks
+
+            return authenticateResponse
         }
     }
 }

--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+Apple.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+Apple.swift
@@ -11,8 +11,8 @@ public extension StytchClient.OAuth {
         let userRouter: NetworkingRouter<UsersRoute>
 
         @Dependency(\.cryptoClient) private var cryptoClient
-
         @Dependency(\.appleOAuthClient) private var appleOAuthClient
+        @Dependency(\.sessionManager) private var sessionManager
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Initiates the OAuth flow by using the included parameters to start a Sign In With Apple request. If the authentication is successful this method will return a new session object.
@@ -50,6 +50,9 @@ public extension StytchClient.OAuth {
                     ]
                 )
             )
+
+            sessionManager.consumerLastAuthMethodUsed = .oauthApple
+
             return authenticateResponse
         }
     }

--- a/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
+++ b/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
@@ -68,7 +68,7 @@ public extension StytchClient {
                 requestBehavior: parameters.requestBehavior
             )
 
-            return try await router.post(
+            let authenticateResponse: AuthenticateResponse = try await router.post(
                 to: .authenticate,
                 parameters: Credential<AssertionResponse>(
                     id: credential.credentialID,
@@ -82,6 +82,10 @@ public extension StytchClient {
                 ).wrapped(sessionDuration: parameters.sessionDuration),
                 useDFPPA: true
             )
+
+            sessionManager.consumerLastAuthMethodUsed = .passkeys
+
+            return authenticateResponse
         }
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)

--- a/Sources/StytchCore/StytchClient/StytchClient+AuthMethod.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient+AuthMethod.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public extension StytchClient {
+    enum ConsumerAuthMethod: String, Codable {
+        case biometrics
+        case crypto
+        case emailMagicLinks
+        case oauthApple
+        case oauth
+        case otp
+        case passkeys
+        case passwords
+        case totp
+        case unknown
+    }
+}

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -19,6 +19,10 @@ public struct StytchClient: StytchClientType {
     // swiftlint:disable:next identifier_name
     public static var _uiRouter: NetworkingRouter<UIRoute> { router.scopedRouter { $0.ui } }
 
+    public static var lastAuthMethodUsed: ConsumerAuthMethod {
+        Current.sessionManager.consumerLastAuthMethodUsed
+    }
+
     public static var disableSdkWatermark: Bool {
         Current.localStorage.bootstrapData?.disableSdkWatermark ?? true
     }

--- a/Sources/StytchCore/StytchClient/TOTP/StytchClient+TOTP.swift
+++ b/Sources/StytchCore/StytchClient/TOTP/StytchClient+TOTP.swift
@@ -4,6 +4,7 @@ public extension StytchClient {
     /// Time-based One-time Passcodes (TOTPs) are one-time passcodes that are generated based on a shared secret and the current time. TOTPs are also often referred to as Authenticator Apps and are a common form of secondary authentication. Creating a Stytch instance of a TOTP for a User creates a shared secret. This secret is shared by Stytch with the end user's authenticator application of choice (e.g. Google Authenticator). The authenticator app can then generate TOTPs that are valid for a specific amount of time (generally 30 seconds). The end user inputs the TOTP and the developer can use the authenticate method to verify that the TOTP is valid. To call these methods, TOTPs must be enabled in the [SDK Configuration page](https://stytch.com/dashboard/sdk-configuration) of the Stytch dashboard.
     struct TOTP {
         let router: NetworkingRouter<TOTPRoute>
+        @Dependency(\.sessionManager) private var sessionManager
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's [create](https://stytch.com/docs/api/totp-create) endpoint. Call this method to create a new TOTP instance for a user. The user can use the authenticator application of their choice to scan the QR code or enter the secret.
@@ -14,7 +15,9 @@ public extension StytchClient {
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's [authenticate](https://stytch.com/docs/api/totp-authenticate) endpoint. Call this method to authenticate a TOTP code entered by a user.
         public func authenticate(parameters: AuthenticateParameters) async throws -> AuthenticateResponse {
-            try await router.post(to: .authenticate, parameters: parameters, useDFPPA: true)
+            let authenticateResponse: AuthenticateResponse = try await router.post(to: .authenticate, parameters: parameters, useDFPPA: true)
+            sessionManager.consumerLastAuthMethodUsed = .totp
+            return authenticateResponse
         }
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)

--- a/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
@@ -138,6 +138,8 @@ final class B2BMagicLinksTestCase: BaseTestCase {
         )
 
         XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
+
+        XCTAssertEqual(StytchB2BClient.lastAuthMethodUsed, StytchB2BClient.B2BAuthMethod.emailMagicLinks)
     }
 
     func testDiscoveryAuthenticate() async throws {

--- a/Tests/StytchCoreTests/B2BOAuthTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOAuthTestCase.swift
@@ -31,6 +31,8 @@ final class B2BOAuthTestCase: BaseTestCase {
         )
 
         XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
+
+        XCTAssertEqual(StytchB2BClient.lastAuthMethodUsed, StytchB2BClient.B2BAuthMethod.oauth)
     }
 
     func testAuthenticateFailsWithPKCE() async throws {

--- a/Tests/StytchCoreTests/B2BOTPTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOTPTestCase.swift
@@ -176,6 +176,8 @@ final class B2BOTPTestCase: BaseTestCase {
                 "session_duration_minutes": JSON(integerLiteral: 5),
             ])
         )
+
+        XCTAssertEqual(StytchB2BClient.lastAuthMethodUsed, StytchB2BClient.B2BAuthMethod.emailOtp)
     }
 
     func testDiscoverySend() async throws {

--- a/Tests/StytchCoreTests/B2BPasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BPasswordsTestCase.swift
@@ -34,6 +34,8 @@ final class B2BPasswordsTestCase: BaseTestCase {
                 "locale": "en",
             ])
         )
+
+        XCTAssertEqual(StytchB2BClient.lastAuthMethodUsed, StytchB2BClient.B2BAuthMethod.passwords)
     }
 
     func testStrengthCheck() async throws {
@@ -133,6 +135,8 @@ final class B2BPasswordsTestCase: BaseTestCase {
         )
 
         XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
+
+        XCTAssertEqual(StytchB2BClient.lastAuthMethodUsed, StytchB2BClient.B2BAuthMethod.passwords)
     }
 
     func testResetByExistingPassword() async throws {
@@ -164,6 +168,8 @@ final class B2BPasswordsTestCase: BaseTestCase {
                 "locale": "en",
             ])
         )
+
+        XCTAssertEqual(StytchB2BClient.lastAuthMethodUsed, StytchB2BClient.B2BAuthMethod.passwords)
     }
 
     func testResetBySession() async throws {

--- a/Tests/StytchCoreTests/B2BSSOTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSSOTestCase.swift
@@ -66,6 +66,8 @@ final class B2BSSOTestCase: BaseTestCase {
         )
 
         XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
+
+        XCTAssertEqual(StytchB2BClient.lastAuthMethodUsed, StytchB2BClient.B2BAuthMethod.sso)
     }
 
     func testGetConnections() async throws {

--- a/Tests/StytchCoreTests/BaseTestCase.swift
+++ b/Tests/StytchCoreTests/BaseTestCase.swift
@@ -43,6 +43,9 @@ class BaseTestCase: XCTestCase {
         ))
 
         networkInterceptor.reset()
+
+        Current.sessionManager.consumerLastAuthMethodUsed = StytchClient.ConsumerAuthMethod.unknown
+        Current.sessionManager.b2bLastAuthMethodUsed = StytchB2BClient.B2BAuthMethod.unknown
     }
 }
 

--- a/Tests/StytchCoreTests/BiometricsTestCase.swift
+++ b/Tests/StytchCoreTests/BiometricsTestCase.swift
@@ -85,6 +85,8 @@ final class BiometricsTestCase: BaseTestCase {
             parameters.signature,
             try Current.cryptoClient.signChallengeWithPrivateKey(challenge, privateKey.rawRepresentation)
         )
+
+        XCTAssertEqual(StytchClient.lastAuthMethodUsed, StytchClient.ConsumerAuthMethod.biometrics)
     }
 
     func testRegistrationRemoval() async throws {

--- a/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
+++ b/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
@@ -67,5 +67,7 @@ final class CryptoWalletsTestCase: BaseTestCase {
                 "signature": "mock-signature",
             ])
         )
+
+        XCTAssertEqual(StytchClient.lastAuthMethodUsed, StytchClient.ConsumerAuthMethod.crypto)
     }
 }

--- a/Tests/StytchCoreTests/MagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/MagicLinksTestCase.swift
@@ -146,5 +146,7 @@ final class MagicLinksTestCase: BaseTestCase {
         )
 
         XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
+
+        XCTAssertEqual(StytchClient.lastAuthMethodUsed, StytchClient.ConsumerAuthMethod.emailMagicLinks)
     }
 }

--- a/Tests/StytchCoreTests/OAuthTestCase.swift
+++ b/Tests/StytchCoreTests/OAuthTestCase.swift
@@ -32,6 +32,8 @@ final class OAuthTestCase: BaseTestCase {
                 "name": ["first_name": "user"],
             ])
         )
+
+        XCTAssertEqual(StytchClient.lastAuthMethodUsed, StytchClient.ConsumerAuthMethod.oauthApple)
     }
 
     func testAuthenticate() async throws {
@@ -60,6 +62,8 @@ final class OAuthTestCase: BaseTestCase {
         )
 
         XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
+
+        XCTAssertEqual(StytchClient.lastAuthMethodUsed, StytchClient.ConsumerAuthMethod.oauth)
     }
 }
 

--- a/Tests/StytchCoreTests/OTPTestCase.swift
+++ b/Tests/StytchCoreTests/OTPTestCase.swift
@@ -169,5 +169,7 @@ final class OTPTestCase: BaseTestCase {
                 "session_duration_minutes": 20,
             ])
         )
+
+        XCTAssertEqual(StytchClient.lastAuthMethodUsed, StytchClient.ConsumerAuthMethod.otp)
     }
 }

--- a/Tests/StytchCoreTests/PasskeysTestCase.swift
+++ b/Tests/StytchCoreTests/PasskeysTestCase.swift
@@ -2,6 +2,8 @@ import AuthenticationServices
 import XCTest
 @testable import StytchCore
 
+// swiftlint:disable function_body_length
+
 #if !os(watchOS)
 @available(macOS 12.0, iOS 16.0, tvOS 16.0, *)
 final class PasskeysTestCase: BaseTestCase {
@@ -90,6 +92,8 @@ final class PasskeysTestCase: BaseTestCase {
                 "session_duration_minutes": 5,
             ])
         )
+
+        XCTAssertEqual(StytchClient.lastAuthMethodUsed, StytchClient.ConsumerAuthMethod.passkeys)
     }
 
     func testUpdate() async throws {

--- a/Tests/StytchCoreTests/PasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/PasswordsTestCase.swift
@@ -39,6 +39,8 @@ final class PasswordsTestCase: BaseTestCase {
                 "password": "password123",
             ])
         )
+
+        XCTAssertEqual(StytchClient.lastAuthMethodUsed, StytchClient.ConsumerAuthMethod.passwords)
     }
 
     func testStrengthCheck() async throws {
@@ -122,6 +124,8 @@ final class PasswordsTestCase: BaseTestCase {
         )
 
         XCTAssertNil(Current.pkcePairManager.getPKCECodePair())
+
+        XCTAssertEqual(StytchClient.lastAuthMethodUsed, StytchClient.ConsumerAuthMethod.passwords)
     }
 
     func testResetBySession() async throws {
@@ -137,6 +141,8 @@ final class PasswordsTestCase: BaseTestCase {
                 "password": "password123",
             ])
         )
+
+        XCTAssertEqual(StytchClient.lastAuthMethodUsed, StytchClient.ConsumerAuthMethod.passwords)
     }
 
     func testResetByExistingPassword() async throws {
@@ -155,5 +161,7 @@ final class PasswordsTestCase: BaseTestCase {
                 "session_duration_minutes": 5,
             ])
         )
+
+        XCTAssertEqual(StytchClient.lastAuthMethodUsed, StytchClient.ConsumerAuthMethod.passwords)
     }
 }

--- a/Tests/StytchCoreTests/TOTPTestCase.swift
+++ b/Tests/StytchCoreTests/TOTPTestCase.swift
@@ -20,6 +20,8 @@ final class TOTPTestCase: BaseTestCase {
         _ = try await StytchClient.totps.authenticate(parameters: .init(totpCode: "test-code"))
 
         try XCTAssertRequest(networkInterceptor.requests[0], urlString: "https://api.stytch.com/sdk/v1/totps/authenticate", method: .post(["totp_code": "test-code", "session_duration_minutes": 5]))
+
+        XCTAssertEqual(StytchClient.lastAuthMethodUsed, StytchClient.ConsumerAuthMethod.totp)
     }
 
     func testRecover() async throws {


### PR DESCRIPTION
[[iOS] Add last auth method used](https://linear.app/stytch/issue/SDK-2332/[ios]-add-last-auth-method-used)

## Changes:

1. Add 2 enums for the last auth method used `StytchB2BClient. B2BAuthMethod` and `StytchClient.ConsumerAuthMethod`
2. For B2B we only track primary auth methods as the last method used so in B2B you will never see OTP or TOTP as an auth method.
3. These values are stored in the keychain and persisted across launches.
4. Each respective client exposes the relevant value even though both are stored in the `SessionManager` class.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
