### PR TITLE
Safeguards on caching and reading empty tokens

### DIFF
--- a/Sources/StytchCore/SessionManager.swift
+++ b/Sources/StytchCore/SessionManager.swift
@@ -129,6 +129,16 @@ final class SessionManager {
             )
     }
 
+    func clearEmptyTokens() {
+        // Clear any successfully cached empty string on startup
+        if let value = sessionToken?.value, value.isEmpty == true {
+            sessionToken = nil
+        }
+        if let value = sessionJwt?.value, value.isEmpty == true {
+            sessionJwt = nil
+        }
+    }
+
     internal func updateSession(
         sessionType: SessionType? = nil,
         tokens: SessionTokens? = nil,

--- a/Sources/StytchCore/SharedModels/SessionToken.swift
+++ b/Sources/StytchCore/SharedModels/SessionToken.swift
@@ -80,7 +80,11 @@ public struct SessionTokens: Sendable {
     ///   - jwt: An instance of `SessionToken` with a `type` of `.jwt`
     ///   - opaque: An instance of `SessionToken` with a `type` of `.opaque`
     public init?(jwt: SessionToken, opaque: SessionToken) {
-        if jwt.kind != .jwt, opaque.kind != .opaque {
+        if jwt.kind != .jwt, jwt.value.isEmpty == true {
+            return nil
+        }
+
+        if opaque.kind != .opaque, opaque.value.isEmpty == true {
             return nil
         }
 


### PR DESCRIPTION
[[iOS SDK] request is from SDK and contains malformed credential errors during OTPsSMSLoginOrCreate requests](https://linear.app/stytch/issue/SDK-2488/[ios-sdk]-request-is-from-sdk-and-contains-malformed-credential-errors)

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
