### PR TITLE
Session Manager Refactor

### DIFF
--- a/Sources/StytchCore/StartupClient.swift
+++ b/Sources/StytchCore/StartupClient.swift
@@ -43,7 +43,7 @@ struct StartupClient {
         }
         #endif
 
-        if Current.sessionManager.persistedSessionIdentifiersExist {
+        if Current.sessionManager.hasValidSessionToken {
             if clientType == .consumer {
                 _ = try? await StytchClient.sessions.authenticate(parameters: .init(sessionDurationMinutes: nil))
             } else if clientType == .b2b {

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Discovery.swift
@@ -85,7 +85,8 @@ public extension StytchB2BClient.Discovery {
         /// - Parameters:
         ///   - organizationId: Globally unique UUID that identifies a specific Organization. The `organization_id` is critical to perform operations on an Organization, so be sure to preserve this value.
         ///   - sessionDuration: The duration, in minutes, for the requested session. Defaults to 5 minutes.
-        ///   - locale: XYZ
+        ///   - locale: The locale is used to determine which language to use in the email. Parameter is a https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag, e.g. "en".
+        ///     Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
         public init(
             organizationId: Organization.ID,
             sessionDuration: Minutes = .defaultSessionDuration,

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP+SMS.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP+SMS.swift
@@ -57,7 +57,7 @@ public extension StytchB2BClient.OTP.SMS {
         ///   - mfaPhoneNumber: The phone number to send the OTP to. If the member already has a phone number, this argument is not needed.
         ///     If the member does not have a phone number and this argument is not provided, an error will be thrown.
         ///   - locale: The locale is used to determine which language to use in the email. Parameter is a https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag, e.g. "en".
-        ///      Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
+        ///     Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
         ///   - enableAutofill: indicates whether the SMS message should include autofill metadata
         public init(organizationId: String, memberId: String, mfaPhoneNumber: String? = nil, locale: StytchLocale = .en, enableAutofill: Bool = false) {
             self.organizationId = organizationId

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Passwords/StytchB2BClient+Passwords+Discovery.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Passwords/StytchB2BClient+Passwords+Discovery.swift
@@ -100,7 +100,8 @@ public extension StytchB2BClient.Passwords.Discovery {
         ///   - resetPasswordTemplateId: The email template ID to use for password reset. If not provided, your default email
         ///     template will be sent. If providing a template ID, it must be either a template using Stytch's customizations or a
         ///     Passwords reset custom HTML template.
-        ///   - locale: XYZ
+        ///   - locale: The locale is used to determine which language to use in the email. Parameter is a https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag, e.g. "en".
+        ///     Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
         public init(
             emailAddress: String,
             discoveryRedirectUrl: URL? = nil,
@@ -126,7 +127,8 @@ public extension StytchB2BClient.Passwords.Discovery {
         /// - Parameters:
         ///   - passwordResetToken: The token to authenticate.
         ///   - password: The new password for the Member.
-        ///   - locale: XYZ
+        ///   - locale: The locale is used to determine which language to use in the email. Parameter is a https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag, e.g. "en".
+        ///     Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
         public init(
             passwordResetToken: String,
             password: String,

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Passwords/StytchB2BClient+Passwords.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Passwords/StytchB2BClient+Passwords.swift
@@ -198,7 +198,8 @@ public extension StytchB2BClient.Passwords {
         ///   - resetPasswordUrl: The url that the member clicks from the password reset email to finish the reset password flow. This should be a url that your app receives and parses and subsequently send an API request to authenticate the magic link and log in the member. If this value is not passed, the default login redirect URL that you set in your Dashboard is used. If you have not set a default login redirect URL, an error is returned.
         ///   - resetPasswordExpiration: Set the expiration for the password reset, in minutes. By default, it expires in 1 hour. The minimum expiration is 5 minutes and the maximum is 7 days (10080 mins).
         ///   - resetPasswordTemplateId: Use a custom template for password reset emails. If omitted, your default email template will be used. The template must be a template using our built-in customizations or a custom HTML email for Passwords - Password reset.
-        ///   - locale: Used to determine which language to use when sending the member this delivery method. Parameter is a IETF BCP 47 language tag, e.g. "en"
+        ///   - locale: The locale is used to determine which language to use in the email. Parameter is a https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag, e.g. "en".
+        ///     Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
         public init(
             organizationId: Organization.ID,
             emailAddress: String,
@@ -238,7 +239,8 @@ public extension StytchB2BClient.Passwords {
         ///   - token: The reset token as parsed from the resulting reset deeplink. NOTE: - You must parse this manually.
         ///   - password: The members's updated password.
         ///   - sessionDuration: The duration of the requested session.
-        ///   - locale: Used to determine which language to use when sending the member this delivery method. Parameter is a IETF BCP 47 language tag, e.g. "en"
+        ///   - locale: The locale is used to determine which language to use in the email. Parameter is a https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag, e.g. "en".
+        ///     Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
         public init(
             token: String,
             password: String,
@@ -278,7 +280,8 @@ public extension StytchB2BClient.Passwords {
         ///   - existingPassword: The members's existing password.
         ///   - newPassword: The members's new password.
         ///   - sessionDuration: The duration of the requested session.
-        ///   - locale: Used to determine which language to use when sending the member this delivery method. Parameter is a IETF BCP 47 language tag, e.g. "en"
+        ///   - locale: The locale is used to determine which language to use in the email. Parameter is a https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag, e.g. "en".
+        ///     Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
         public init(
             organizationId: Organization.ID,
             emailAddress: String,
@@ -320,7 +323,8 @@ public extension StytchB2BClient.Passwords {
         /// - Parameters:
         ///   - organizationId: The ID of the intended organization.
         ///   - password: The members's new password.
-        ///   - locale: Used to determine which language to use when sending the member this delivery method. Parameter is a IETF BCP 47 language tag, e.g. "en"
+        ///   - locale: The locale is used to determine which language to use in the email. Parameter is a https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag, e.g. "en".
+        ///     Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
         public init(organizationId: Organization.ID, password: String, locale: StytchLocale = .en) {
             self.organizationId = organizationId
             self.password = password

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+SSO/StytchB2BClient+SSO.swift
@@ -160,7 +160,8 @@ public extension StytchB2BClient.SSO {
         /// - Parameters:
         ///   - token: The token to authenticate.
         ///   - sessionDuration: The duration, in minutes, for the requested session. Defaults to 5 minutes.
-        ///   - locale: Used to determine which language to use when sending the member this delivery method. Parameter is a IETF BCP 47 language tag, e.g. "en"
+        ///   - locale: The locale is used to determine which language to use in the email. Parameter is a https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag, e.g. "en".
+        ///     Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
         public init(token: String, sessionDuration: Minutes = .defaultSessionDuration, locale: StytchLocale = .en) {
             self.token = token
             self.sessionDuration = sessionDuration

--- a/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
@@ -82,7 +82,7 @@ public extension StytchClient {
         /// NOTE: - You should ensure the `accessPolicy` parameters match your particular needs, defaults to `deviceOwnerWithBiometrics`.
         public func register(parameters: RegisterParameters) async throws -> RegisterCompleteResponse {
             // Early out if not authenticated
-            guard sessionManager.persistedSessionIdentifiersExist else {
+            guard sessionManager.hasValidSessionToken else {
                 throw StytchSDKError.noCurrentSession
             }
 

--- a/Sources/StytchCore/StytchClient/CryptoWallets/StytchClient+CryptoWallets.swift
+++ b/Sources/StytchCore/StytchClient/CryptoWallets/StytchClient+CryptoWallets.swift
@@ -15,7 +15,7 @@ public extension StytchClient {
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's Crypto wallet [authenticate_start](https://stytch.com/docs/api/crypto-wallet-authenticate-start) endpoint. Call this method to load the challenge data. Pass this challenge to your user's wallet for signing.
         public func authenticateStart(parameters: AuthenticateStartParameters) async throws -> AuthenticateStartResponse {
-            let route: CryptoWalletsRoute = sessionManager.persistedSessionIdentifiersExist ? .authenticateStartSecondary : .authenticateStartPrimary
+            let route: CryptoWalletsRoute = sessionManager.hasValidSessionToken ? .authenticateStartSecondary : .authenticateStartPrimary
             return try await router.post(to: route, parameters: parameters)
         }
 

--- a/Sources/StytchCore/StytchClient/MagicLinks/StytchClient.MagicLinks+Email.swift
+++ b/Sources/StytchCore/StytchClient/MagicLinks/StytchClient.MagicLinks+Email.swift
@@ -10,7 +10,7 @@ public extension StytchClient.MagicLinks {
     struct Email: MagicLinksEmailProtocol {
         let router: NetworkingRouter<StytchClient.MagicLinksRoute.EmailRoute>
 
-        @Dependency(\.sessionManager.persistedSessionIdentifiersExist) private var activeSessionExists
+        @Dependency(\.sessionManager.hasValidSessionToken) private var activeSessionExists
         @Dependency(\.pkcePairManager) private var pkcePairManager
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)

--- a/Sources/StytchCore/StytchClient/OTP/SytchClient+OTP.swift
+++ b/Sources/StytchCore/StytchClient/OTP/SytchClient+OTP.swift
@@ -25,7 +25,7 @@ public extension StytchClient {
         /// Wraps Stytch's OTP [sms/send](https://stytch.com/docs/api/send-otp-by-sms), [whatsapp/send](https://stytch.com/docs/api/whatsapp-send), and [email/send](https://stytch.com/docs/api/send-otp-by-email) endpoints. Requests a one-time passcode for an existing user to log in or attach the included factor to their current account.
         public func send(parameters: Parameters) async throws -> OTPResponse {
             try await router.post(
-                to: sessionManager.persistedSessionIdentifiersExist ? .sendSecondary(parameters.deliveryMethod) : .sendPrimary(parameters.deliveryMethod),
+                to: sessionManager.hasValidSessionToken ? .sendSecondary(parameters.deliveryMethod) : .sendPrimary(parameters.deliveryMethod),
                 parameters: parameters,
                 useDFPPA: parameters.deliveryMethod.shouldUseDFPPA
             )

--- a/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
+++ b/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
@@ -52,7 +52,7 @@ public extension StytchClient {
         /// Provides second-factor authentication for the authenticated-user via an existing passkey.
         public func authenticate(parameters: AuthenticateParameters) async throws -> AuthenticateResponse {
             let destination: PasskeysRoute
-            if sessionManager.persistedSessionIdentifiersExist {
+            if sessionManager.hasValidSessionToken {
                 destination = .authenticateStartSecondary
             } else {
                 destination = .authenticateStartPrimary

--- a/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient+Configuration.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient+Configuration.swift
@@ -108,7 +108,8 @@ public extension StytchB2BUIClient {
         ///     In addition, if a member is enrolled in MFA compatible with their organization's policies, their enrolled methods will always be made available.
         ///   - navigation: A configureable way to control the appearance of the dismiss button if you wish to show one
         ///   - theme: A configureable way to control the appearance of the UI, has default values provided
-        ///   - locale: XYZ
+        ///   - locale: The locale is used to determine which language to use in the email. Parameter is a https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag, e.g. "en".
+        ///     Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
         public init(
             stytchClientConfiguration: StytchClientConfiguration,
             products: [B2BProducts],

--- a/Sources/StytchUI/StytchUIClient/StytchUIClient+Configuration.swift
+++ b/Sources/StytchUI/StytchUIClient/StytchUIClient+Configuration.swift
@@ -53,7 +53,8 @@ public extension StytchUIClient {
         ///   - magicLinkOptions: The email magic link options to use if you have a custom configuration.
         ///   - otpOptions: The otp options to use if you have a custom configuration.
         ///   - theme: A configureable way to control the appearance of the UI, has default values provided
-        ///   - locale: XYZ
+        ///   - locale: The locale is used to determine which language to use in the email. Parameter is a https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag, e.g. "en".
+        ///     Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
         public init(
             stytchClientConfiguration: StytchClientConfiguration,
             products: [Products],

--- a/Tests/StytchCoreTests/B2BDiscoveryTestCase.swift
+++ b/Tests/StytchCoreTests/B2BDiscoveryTestCase.swift
@@ -26,6 +26,7 @@ final class B2BDiscoveryTestCase: BaseTestCase {
         }
 
         Current.sessionManager.updateSession(intermediateSessionToken: intermediateSessionToken)
+        XCTAssertTrue(Current.sessionManager.hasValidIntermediateSessionToken)
 
         _ = try await client.listOrganizations()
 
@@ -43,6 +44,7 @@ final class B2BDiscoveryTestCase: BaseTestCase {
         Current.timer = { _, _, _ in .init() }
 
         Current.sessionManager.updateSession(intermediateSessionToken: intermediateSessionToken)
+        XCTAssertTrue(Current.sessionManager.hasValidIntermediateSessionToken)
 
         _ = try await client.exchangeIntermediateSession(parameters: .init(organizationId: Organization.mock.id))
 
@@ -62,6 +64,7 @@ final class B2BDiscoveryTestCase: BaseTestCase {
         Current.timer = { _, _, _ in .init() }
 
         Current.sessionManager.updateSession(intermediateSessionToken: intermediateSessionToken)
+        XCTAssertTrue(Current.sessionManager.hasValidIntermediateSessionToken)
 
         _ = try await client.createOrganization(
             parameters: .init(

--- a/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
+++ b/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
@@ -7,7 +7,7 @@ final class CryptoWalletsTestCase: BaseTestCase {
             StytchClient.CryptoWallets.AuthenticateStartResponse(requestId: "mock-request-id", statusCode: 200, wrapped: .init(challenge: "mock-challenge"))
         }
 
-        XCTAssertFalse(Current.sessionManager.persistedSessionIdentifiersExist)
+        XCTAssertFalse(Current.sessionManager.hasValidSessionToken)
 
         _ = try await StytchClient.cryptoWallets.authenticateStart(parameters: .init(cryptoWalletType: .ethereum, cryptoWalletAddress: "mock-crypto-address"))
 
@@ -31,7 +31,7 @@ final class CryptoWalletsTestCase: BaseTestCase {
 
         try Current.keychainClient.set("123", for: .sessionToken)
 
-        XCTAssertTrue(Current.sessionManager.persistedSessionIdentifiersExist)
+        XCTAssertTrue(Current.sessionManager.hasValidSessionToken)
 
         _ = try await StytchClient.cryptoWallets.authenticateStart(parameters: .init(cryptoWalletType: .ethereum, cryptoWalletAddress: "mock-crypto-address"))
 

--- a/Tests/StytchCoreTests/MagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/MagicLinksTestCase.swift
@@ -54,7 +54,7 @@ final class MagicLinksTestCase: BaseTestCase {
             locale: .en
         )
 
-        XCTAssertFalse(Current.sessionManager.persistedSessionIdentifiersExist)
+        XCTAssertFalse(Current.sessionManager.hasValidSessionToken)
         XCTAssertTrue(try Current.keychainClient.get(.codeVerifierPKCE).isEmpty)
 
         let response = try await StytchClient.magicLinks.email.send(parameters: parameters)
@@ -89,7 +89,7 @@ final class MagicLinksTestCase: BaseTestCase {
 
         try Current.keychainClient.set("123", for: .sessionToken)
 
-        XCTAssertTrue(Current.sessionManager.persistedSessionIdentifiersExist)
+        XCTAssertTrue(Current.sessionManager.hasValidSessionToken)
         XCTAssertTrue(try Current.keychainClient.get(.codeVerifierPKCE).isEmpty)
 
         let response = try await StytchClient.magicLinks.email.send(parameters: parameters)

--- a/Tests/StytchCoreTests/OTPTestCase.swift
+++ b/Tests/StytchCoreTests/OTPTestCase.swift
@@ -61,7 +61,7 @@ final class OTPTestCase: BaseTestCase {
             response
         }
 
-        XCTAssertFalse(Current.sessionManager.persistedSessionIdentifiersExist)
+        XCTAssertFalse(Current.sessionManager.hasValidSessionToken)
 
         try await [
             ExpectedValues(
@@ -111,7 +111,7 @@ final class OTPTestCase: BaseTestCase {
 
         try Current.keychainClient.set("123", for: .sessionToken)
 
-        XCTAssertTrue(Current.sessionManager.persistedSessionIdentifiersExist)
+        XCTAssertTrue(Current.sessionManager.hasValidSessionToken)
 
         try await [
             ExpectedValues(


### PR DESCRIPTION
[[iOS] Refactor Session Manager](https://linear.app/stytch/issue/SDK-2491/[ios]-refactor-session-manager)

This refactor was brought on by investigating: [[iOS] Intermediate Session Token Error (Prebuilt B2B UI Components)](https://linear.app/stytch/issue/SDK-2370/[ios]-intermediate-session-token-error-prebuilt-b2b-ui-components) I think that issue still exists but this will make it easier to find and fix.

## Changes:

1. Refactor and restructure the `SessionManager` class that is the internal interface for both verticals and their logic around session objects and session tokens. The actual persistence happens in the `KeychainClient` which I want to refactor also but in a subsequent PR.
2. The values that the `SessionManager` exposes internally from the keychain are: `sessionToken`, `sessionJwt`, `intermediateSessionToken`, `b2bLastAuthMethodUsed` and `consumerLastAuthMethodUsed`, these are all logically grouped in individual extension for readability and the `intermediateSessionToken` logic changed to be able to log errors around setting and getting whereas before the errors were intentionally ignored. We don't have a great way of handling the errors but at least we will know now if an error in retrieval or setting of the IST happens.
3. Change the name of `persistedSessionIdentifiersExist` to `hasValidSessionToken` and create respective var's for `hasValidSessionJwt` and `hasValidIntermediateSessionToken`. Before the logic for `persistedSessionIdentifiersExist` checked for the jwt first and then the session token. This made no sense to me since for the mobile SDK the only relevant value in subsequent requests is the session token and we only expose the jwt as a convenience for devs that want to use it. So if a session exists we will only ever look for a non-nil non-empty string session token.
4. Bonus: Add missing comments to places where we use `locale` and I had placeholder comments that I missed filling in.


## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
