### PR TITLE
Bump recaptcha-enterprise to 18.7 - Bump Github Xcode version to 16.2

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -40,6 +40,7 @@ runs:
       env:
         HOMEBREW_NO_AUTO_UPDATE: 1
         HOMEBREW_NO_INSTALL_CLEANUP: 1
+        NO_BUNDLE: 1
       run: |
-        NO_BUNDLE=1 make setup
-        make tools
+        arch -arm64 make setup
+        arch -arm64 make tools

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/main' || github.run_number }}
@@ -52,7 +52,7 @@ jobs:
           echo "matrix={\"include\":[${matrix_values}]}" >> $GITHUB_OUTPUT
 
   generate-docs:
-    runs-on: macos-13
+    runs-on: macos-15
 
     needs: set-matrix
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   release:
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.0.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/main' || github.run_number }}
@@ -43,7 +43,7 @@ jobs:
           echo "matrix={\"include\":[${matrix_values}]}" >> $GITHUB_OUTPUT
 
   test:
-    runs-on: macos-13
+    runs-on: macos-15
 
     needs: set-matrix
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ IOS_VERSION := $(shell xcodebuild -showsdks | grep -m 1 'sdk iphoneos' | sed 's/
 WATCHOS_VERSION := $(shell xcodebuild -showsdks | grep -m 1 'sdk watchos' | sed 's/\(.*watchos\)\(.*\)/\2/')
 
 IS_CI=$(shell [ ! -z "$$CI" ] && echo "1")
-ARCH=arch -$(shell [ $(IS_CI) ] && echo "x86_64" || echo "arm64")
+ARCH=arch -arm64
 PIPEFAIL=set -o pipefail
 XCPRETTY=bundle exec xcpretty
 TEST=$(PIPEFAIL) && $(ARCH) xcodebuild test -disableAutomaticPackageResolution -skipPackageUpdates -project Stytch/Stytch.xcodeproj -scheme StytchCoreTests -sdk
@@ -57,26 +57,26 @@ test-all: codegen
 test tests test-macos: codegen
 	@xcodebuild -showsdks
 	@xcrun simctl list devices
-	$(TEST) macosx14.0 -destination "OS=14.0,platform=macOS" -enableCodeCoverage YES -derivedDataPath .build | $(XCPRETTY)
+	$(TEST) macosx -destination "platform=macOS" -enableCodeCoverage YES -derivedDataPath .build | $(XCPRETTY)
 
 .PHONY: test-ios
 test-ios: codegen
 	@xcodebuild -showsdks
 	@xcrun simctl list devices
-	$(TEST) iphonesimulator17.0 -destination "OS=17.2,name=iPhone 15 Pro" | $(XCPRETTY)
-	$(UI_UNIT_TESTS) iphonesimulator17.0 -destination "OS=17.2,name=iPhone 15 Pro" | $(XCPRETTY)
+	$(TEST) iphonesimulator18.2 -destination "OS=18.2,name=iPhone 16 Pro" | $(XCPRETTY)
+	$(UI_UNIT_TESTS) iphonesimulator18.2 -destination "OS=18.2,name=iPhone 16 Pro" | $(XCPRETTY)
 
 .PHONY: test-tvos
 test-tvos: codegen
 	@xcodebuild -showsdks
 	@xcrun simctl list devices
-	$(TEST) appletvsimulator17.0 -destination "OS=17.0,name=Apple TV" | $(XCPRETTY)
+	$(TEST) appletvsimulator18.2 -destination "OS=18.2,name=Apple TV" | $(XCPRETTY)
 
 .PHONY: test-watchos
 test-watchos: codegen
 	@xcodebuild -showsdks
 	@xcrun simctl list devices
-	$(TEST) watchsimulator10.0 -destination "OS=10.0,name=Apple Watch Ultra (49mm)" | $(XCPRETTY)
+	$(TEST) watchsimulator11.2 -destination "OS=11.1,name=Apple Watch Ultra 2 (49mm)" | $(XCPRETTY)
 
 .PHONY: tools
 tools:

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/marmelroy/PhoneNumberKit", .exact("3.8.0")),
-        .package(url: "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk", .exact("18.4.0")),
+        .package(url: "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk", .exact("18.7.0")),
         .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", from: "5.0.2"),
     ],
     targets: [

--- a/Sources/StytchCore/DFPClient/CAPTCHA.swift
+++ b/Sources/StytchCore/DFPClient/CAPTCHA.swift
@@ -34,7 +34,7 @@ final class CaptchaClient: CaptchaProvider {
 
     func setCaptchaClient(siteKey: String) async {
         do {
-            recaptchaClient = try await Recaptcha.getClient(withSiteKey: siteKey)
+            recaptchaClient = try await Recaptcha.fetchClient(withSiteKey: siteKey)
         } catch let error as RecaptchaError {
             print("RecaptchaClient creation error: \(String(describing: error.errorMessage)).")
         } catch {

--- a/Stytch/Stytch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stytch/Stytch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/google/interop-ios-for-google-sdks.git",
         "state": {
           "branch": null,
-          "revision": "2d12673670417654f08f5f90fdd62926dc3a2648",
-          "version": "100.0.0"
+          "revision": "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+          "version": "101.0.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",
         "state": {
           "branch": null,
-          "revision": "30e4e28f2f87236372225c453140774f038302ad",
-          "version": "18.4.0"
+          "revision": "5ec74256124faa7e7814c574509723f49e1fccfb",
+          "version": "18.7.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "ff0f781cf7c6a22d52957e50b104f5768b50c779",
-          "version": "3.10.0"
+          "revision": "a6ce32a18b81b04ce7e897d1d98df6eb2da04786",
+          "version": "3.12.2"
         }
       },
       {


### PR DESCRIPTION
[[iOS] Bump recaptcha-enterprise to 18.7](https://linear.app/stytch/issue/SDK-2493/[ios]-bump-recaptcha-enterprise-to-187)

This resolves issue: https://github.com/stytchauth/stytch-ios/issues/412

## Changes:

1. Bumping the `recaptcha-enterprise-mobile-sdk` was simple and the one line change that went with it.
2. But the changes needed in the GitHub infra took a while to resolve.
3. Now we are on the most recent version of Xcode, 16.2, which matches the local dev environment.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
