### PR TITLE
Fix issues with prebuilt UI being manually dismissed

### DIFF
--- a/Sources/StytchUI/Shared/BaseViewController.swift
+++ b/Sources/StytchUI/Shared/BaseViewController.swift
@@ -110,6 +110,28 @@ class BaseViewController<State, ViewModel>: UIViewController, BaseViewController
         navigationItem.hidesBackButton = true
     }
 
+    @objc func dismissAuth() {
+        presentingViewController?.dismiss(animated: true)
+    }
+
+    func configureCloseButton(_ navigation: Navigation?) {
+        guard let closeButton = navigation?.closeButtonStyle else {
+            return
+        }
+
+        let closeBarButton = UIBarButtonItem(
+            barButtonSystemItem: closeButton.barButtonSystemItem,
+            target: self,
+            action: #selector(dismissAuth)
+        )
+
+        if closeButton.position == .left {
+            navigationItem.leftBarButtonItem = closeBarButton
+        } else if closeButton.position == .right {
+            navigationItem.rightBarButtonItem = closeBarButton
+        }
+    }
+
     func setupPoweredByStytchView() {
         view.addSubview(poweredByStytchView)
 

--- a/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient+Configuration.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/StytchB2BUIClient/StytchB2BUIClient+Configuration.swift
@@ -106,7 +106,8 @@ public extension StytchB2BUIClient {
         ///   - mfaProductInclude: MFA products to include in the UI. If specified, the list of available products will be limited to those included. Defaults to all available products.
         ///     Note that if an organization restricts the available MFA methods, the organization's settings will take precedence.
         ///     In addition, if a member is enrolled in MFA compatible with their organization's policies, their enrolled methods will always be made available.
-        ///   - navigation: A configureable way to control the appearance of the dismiss button if you wish to show one
+        ///   - navigation: A configureable way to control the appearance of the dismiss button if you wish to show one.
+        ///     Without a navigation configuration the UI can only be dismissed by completing authentication or manually calling StytchB2BUIClient.dismiss().
         ///   - theme: A configureable way to control the appearance of the UI, has default values provided
         ///   - locale: The locale is used to determine which language to use in the email. Parameter is a https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag, e.g. "en".
         ///     Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BAuthHomeViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BAuthHomeViewController.swift
@@ -42,6 +42,8 @@ final class B2BAuthHomeViewController: BaseViewController<B2BAuthHomeState, B2BA
                 StytchB2BUIClient.stopLoading()
             }
         }
+
+        configureCloseButton(viewModel.state.configuration.navigation)
     }
 
     func configureView(productComponents: [StytchB2BUIClient.ProductComponent]) {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
@@ -43,17 +43,6 @@ final class B2BAuthRootViewController: UIViewController {
             state: .init(configuration: configuration)
         )
 
-        if let closeButton = configuration.navigation?.closeButtonStyle {
-            let keyPath: ReferenceWritableKeyPath<UIViewController, UIBarButtonItem?>
-            switch closeButton.position {
-            case .left:
-                keyPath = \.navigationItem.leftBarButtonItem
-            case .right:
-                keyPath = \.navigationItem.rightBarButtonItem
-            }
-            homeController[keyPath: keyPath] = .init(barButtonSystemItem: closeButton.barButtonSystemItem, target: self, action: #selector(dismissAuth))
-        }
-
         let navigationController = UINavigationController(rootViewController: homeController)
         navigationController.navigationBar.tintColor = .primaryText
         navigationController.navigationBar.barTintColor = .background

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/ErrorViewController/ErrorViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/ErrorViewController/ErrorViewController.swift
@@ -43,5 +43,7 @@ final class ErrorViewController: BaseViewController<ErrorState, ErrorViewModel> 
         if viewModel.state.type == .noOrganziationFound {
             hideBackButton()
         }
+
+        configureCloseButton(viewModel.state.configuration.navigation)
     }
 }

--- a/Sources/StytchUI/StytchUIClient/StytchUIClient+Configuration.swift
+++ b/Sources/StytchUI/StytchUIClient/StytchUIClient+Configuration.swift
@@ -46,7 +46,8 @@ public extension StytchUIClient {
         /// - Parameters:
         ///   - stytchClientConfiguration: A flexible and extensible object used to configure the core `StychClient` requiring at least a public token, with optional additional settings.
         ///   - products: The products array allows you to specify the authentication methods that you would like to expose to your users.
-        ///   - navigation: A configureable way to control the appearance of the dismiss button if you wish to show one
+        ///   - navigation: A configureable way to control the appearance of the dismiss button if you wish to show one.
+        ///     Without a navigation configuration the UI can only be dismissed by completing authentication or manually calling StytchUIClient.dismiss().
         ///   - sessionDurationMinutes: The session duration you would like the authentication endpoints to use.
         ///   - oauthProviders: The array of OAuth providers. If you have .oauth in your products array you must specify the list of providers.
         ///   - passwordOptions: The password options to use if you have a custom configuration.

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/AuthHomeViewController/AuthHomeViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/AuthHomeViewController/AuthHomeViewController.swift
@@ -75,5 +75,7 @@ final class AuthHomeViewController: BaseViewController<AuthHomeState, AuthHomeVi
         Task {
             try await viewModel.logRenderScreen()
         }
+
+        configureCloseButton(viewModel.state.config.navigation)
     }
 }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/AuthRootViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/AuthRootViewController.swift
@@ -59,17 +59,6 @@ final class AuthRootViewController: UIViewController {
             state: .init(config: config)
         )
 
-        if let closeButton = config.navigation?.closeButtonStyle {
-            let keyPath: ReferenceWritableKeyPath<UIViewController, UIBarButtonItem?>
-            switch closeButton.position {
-            case .left:
-                keyPath = \.navigationItem.leftBarButtonItem
-            case .right:
-                keyPath = \.navigationItem.rightBarButtonItem
-            }
-            homeController[keyPath: keyPath] = .init(barButtonSystemItem: closeButton.barButtonSystemItem, target: self, action: #selector(dismissAuth))
-        }
-
         let navigationController = UINavigationController(rootViewController: homeController)
         navigationController.navigationBar.tintColor = .primaryText
         navigationController.navigationBar.barTintColor = .background

--- a/Stytch/DemoApps/B2BWorkbench/ViewControllers/AuthMethodControllers/B2BUIViewController.swift
+++ b/Stytch/DemoApps/B2BWorkbench/ViewControllers/AuthMethodControllers/B2BUIViewController.swift
@@ -32,7 +32,8 @@ class B2BUIViewController: UIViewController {
             products: [.emailMagicLinks, .sso, .passwords, .oauth],
             authFlowType: .organization(slug: "no-mfa"),
             // authFlowType: .discovery,
-            oauthProviders: [.init(provider: .google), .init(provider: .github)]
+            oauthProviders: [.init(provider: .google), .init(provider: .github)],
+            navigation: Navigation(closeButtonStyle: .close(.right))
         )
 
         StytchB2BUIClient.presentController(configuration: stytchB2BUIConfig, controller: self)

--- a/Stytch/DemoApps/StytchB2BUIDemo/ContentView.swift
+++ b/Stytch/DemoApps/StytchB2BUIDemo/ContentView.swift
@@ -134,7 +134,8 @@ class ContentViewModel: ObservableObject {
             authFlowType: authFlowType,
             oauthProviders: [.init(provider: .google), .init(provider: .github)],
             allowCreateOrganization: true,
-            directCreateOrganizationForNoMembership: true
+            directCreateOrganizationForNoMembership: true,
+            navigation: Navigation(closeButtonStyle: .close(.right))
         )
     }
 }

--- a/Stytch/DemoApps/StytchUIDemo/ContentView.swift
+++ b/Stytch/DemoApps/StytchUIDemo/ContentView.swift
@@ -9,6 +9,7 @@ struct ContentView: View {
     let configuration: StytchUIClient.Configuration = .init(
         stytchClientConfiguration: .init(publicToken: "your-public-token"),
         products: [.passwords, .emailMagicLinks, .otp, .oauth],
+        navigation: Navigation(closeButtonStyle: .close(.right)),
         oauthProviders: [.apple, .thirdParty(.google)],
         otpOptions: .init(methods: [.sms, .whatsapp])
     )


### PR DESCRIPTION
[[iOS] Prebuilt UI can be manually dismissed on both SwiftUI and UIKit.](https://linear.app/stytch/issue/SDK-2303/[ios]-prebuilt-ui-can-be-manually-dismissed-on-both-swiftui-and-uikit)

This is a good start but there is some follow up work needed here: [[iOS] Consider ways to surface authentication events better from the pre built ui](https://linear.app/stytch/issue/SDK-2498/[ios]-consider-ways-to-surface-authentication-events-better-from-the). Right now we don't have a good way of surfacing events to the calling developer where they may choose to log errors or dismiss the UI manually and we should add that next.

## Changes:

1. Each of the UI clients `StytchUIClient` and `StytchB2BUIClient` have methods for showing the prebuilt UI from SwiftUI and UIKit.
2. For SwiftUI I added `.interactiveDismissDisabled(true)` which will prevent the modal from being manually dismissed.
3. For UIKit I added `navigationController.isModalInPresentation = true` which will prevent the modal from being manually dismissed.
4. Added `public static func dismiss()` to each of the UI clients so that the developer can programmatically dismiss the UI if they want, this will become increasingly useful once I do the above ticket about authentication events.
5. Refactored the logic around the "Navigation" configuration, which is a bad name for it really and should be called something like "closeButton". Before it was duplicate logic and only in the container view. The close button is still only on the home screen but the refactor gives way for the close button to be added to other views in the prebuilt UI very easily if need be.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
