### PR TITLE
Bump minimum supported os versions - iOS 15.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,12 @@ import PackageDescription
 
 let package = Package(
     name: "Stytch",
-    platforms: [.iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v12),
+        .tvOS(.v15),
+        .watchOS(.v8),
+    ],
     products: [
         .library(name: "StytchCore", targets: ["StytchCore"]),
         .library(name: "StytchUI", targets: ["StytchUI"]),

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Stytch iOS SDK](Resources/Assets/stytch-light.png#gh-light-mode-only)
 
 ![Test Status](https://github.com/stytchauth/stytch-ios/actions/workflows/test.yml/badge.svg)
-![iOS](https://img.shields.io/badge/iOS-13.0-blue) ![macOS](https://img.shields.io/badge/macOS-10.15-green) ![tvOS](https://img.shields.io/badge/tvOS-13.0-orange)
+![iOS](https://img.shields.io/badge/iOS-15.0-blue) ![macOS](https://img.shields.io/badge/macOS-12.0-green) ![tvOS](https://img.shields.io/badge/tvOS-15.0-orange) ![watchOS](https://img.shields.io/badge/watchOS-8.0-purple)
 ![Swift Package Manager](https://img.shields.io/badge/Swift_Package_Manager-compatible-4BC51D)
 
 </div>


### PR DESCRIPTION
[[iOS] Bump minimum supported os versions - iOS 15.0](https://linear.app/stytch/issue/SDK-2496/[ios]-bump-minimum-supported-os-versions-ios-150)

## Changes:

1. Bump the minimum supported versions in the `Package.swift` most importantly we bumped iOS to 15.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
