### PR TITLE
Improve KeychainClient names and structure

### DIFF
--- a/Sources/StytchCore/KeychainClient/KeychainClient+Live.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient+Live.swift
@@ -7,8 +7,10 @@ import LocalAuthentication
 extension KeychainClient {
     static let live: Self = {
         #if !os(tvOS)
-        let updateQueryWithLAContext: (inout [CFString: Any]) -> LAContext = { query in
+        @discardableResult
+        func updateQueryWithLAContext(_ query: inout [CFString: Any]) -> LAContext {
             let context = LAContext()
+
             #if !os(watchOS)
             context.localizedReason = NSLocalizedString(
                 "keychain_client.la_context_reason",
@@ -16,15 +18,16 @@ extension KeychainClient {
                 comment: "The user-presented reason for biometric authentication prompts"
             )
             #endif
+
             // This could potentially cause prompting for secured items, so we'll pass in a reusable authentication context to minimize prompting
             query[kSecUseAuthenticationContext] = context
+
             return context
         }
         #endif
 
-        let valueExistsForItem: (Item) -> Bool = { item in
+        func valueExists(for item: Item) -> Bool {
             var result: CFTypeRef?
-
             var query = item.getQuery
 
             #if !os(tvOS)
@@ -37,125 +40,131 @@ extension KeychainClient {
             return [errSecSuccess, errSecInteractionNotAllowed].contains(status)
         }
 
-        return .init { item in
-            var result: CFTypeRef?
+        return .init(
+            getQueryResults: { item in
+                var result: CFTypeRef?
 
-            var query = item.getQuery
+                var query = item.getQuery
 
-            #if !os(tvOS)
-            _ = updateQueryWithLAContext(&query)
-            #endif
-            var status: OSStatus?
-            if item.kind == .privateKey {
-                // recursively check each potential type of access control flag
-                var potentialFlags: [SecAccessControlCreateFlags] = [
-                    [.userPresence],
-                    [.biometryCurrentSet],
-                ]
-                #if os(macOS)
-                potentialFlags.append([.biometryCurrentSet, .or, .watch])
+                #if !os(tvOS)
+                updateQueryWithLAContext(&query)
                 #endif
-                for flags in potentialFlags {
-                    var error: Unmanaged<CFError>?
-                    defer { error?.release() }
-                    let accessControl = SecAccessControlCreateWithFlags(
-                        nil,
-                        kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
-                        flags,
-                        &error
-                    )
-                    var newQuery = query
-                    newQuery[kSecAttrAccessControl] = accessControl
-                    status = SecItemCopyMatching(newQuery as CFDictionary, &result)
-                    if status == errSecSuccess {
-                        break
+                var status: OSStatus?
+                if item.kind == .privateKey {
+                    // recursively check each potential type of access control flag
+                    var potentialFlags: [SecAccessControlCreateFlags] = [
+                        [.userPresence],
+                        [.biometryCurrentSet],
+                    ]
+                    #if os(macOS)
+                    potentialFlags.append([.biometryCurrentSet, .or, .watch])
+                    #endif
+                    for flags in potentialFlags {
+                        var error: Unmanaged<CFError>?
+                        defer { error?.release() }
+                        let accessControl = SecAccessControlCreateWithFlags(
+                            nil,
+                            kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+                            flags,
+                            &error
+                        )
+                        var newQuery = query
+                        newQuery[kSecAttrAccessControl] = accessControl
+                        status = SecItemCopyMatching(newQuery as CFDictionary, &result)
+                        if status == errSecSuccess {
+                            break
+                        }
                     }
+                } else {
+                    status = SecItemCopyMatching(query as CFDictionary, &result)
                 }
-            } else {
-                status = SecItemCopyMatching(query as CFDictionary, &result)
-            }
 
-            guard case errSecSuccess = status else {
-                return []
-            }
-            guard let results = result as? [[CFString: Any]] else {
-                throw KeychainError.resultNotArray
-            }
+                guard case errSecSuccess = status else {
+                    return []
+                }
+                guard let results = result as? [[CFString: Any]] else {
+                    throw KeychainError.resultNotArray
+                }
 
-            return try results.compactMap { dict in
-                guard let data = dict[kSecValueData] as? Data else { throw KeychainError.resultNotData }
-                guard let account = dict[kSecAttrAccount] as? String else { throw KeychainError.resultMissingAccount }
-                guard
-                    let createdAt = dict[kSecAttrCreationDate] as? Date,
-                    let modifiedAt = dict[kSecAttrModificationDate] as? Date
-                else { throw KeychainError.resultMissingDates }
+                return try results.compactMap { dict in
+                    guard let data = dict[kSecValueData] as? Data else { throw KeychainError.resultNotData }
+                    guard let account = dict[kSecAttrAccount] as? String else { throw KeychainError.resultMissingAccount }
+                    guard
+                        let createdAt = dict[kSecAttrCreationDate] as? Date,
+                        let modifiedAt = dict[kSecAttrModificationDate] as? Date
+                    else { throw KeychainError.resultMissingDates }
 
-                return QueryResult(
-                    data: data,
-                    createdAt: createdAt,
-                    modifiedAt: modifiedAt,
-                    label: dict[kSecAttrLabel] as? String,
-                    account: account,
-                    generic: dict[kSecAttrGeneric] as? Data
-                )
-            }
-        } valueExistsForItem: { item in
-            valueExistsForItem(item)
-        } setValueForItem: { value, item in
-            let status: OSStatus
+                    return QueryResult(
+                        data: data,
+                        createdAt: createdAt,
+                        modifiedAt: modifiedAt,
+                        label: dict[kSecAttrLabel] as? String,
+                        account: account,
+                        generic: dict[kSecAttrGeneric] as? Data
+                    )
+                }
+            },
+            valueExistsForItem: { item in
+                valueExists(for: item)
+            },
+            setValueForItem: { value, item in
+                let status: OSStatus
 
-            var query = item.baseQuery
+                var query = item.baseQuery
 
-            #if !os(tvOS)
-            _ = updateQueryWithLAContext(&query)
-            #endif
+                #if !os(tvOS)
+                _ = updateQueryWithLAContext(&query)
+                #endif
 
-            if valueExistsForItem(item) {
-                status = SecItemUpdate(
-                    query as CFDictionary,
-                    item.updateQuerySegment(for: value) as CFDictionary
-                )
-            } else {
-                status = SecItemAdd(item.insertQuery(value: value), nil)
-            }
-            if status != errSecSuccess {
-                throw KeychainError.unhandledError(status: status)
-            }
-        } removeItem: { item in
-            let tryRemovingItem: (CFDictionary) throws -> Void = { query in
-                let status = SecItemDelete(query)
-                guard [errSecSuccess, errSecItemNotFound].contains(status) else {
+                if valueExists(for: item) {
+                    status = SecItemUpdate(
+                        query as CFDictionary,
+                        item.updateQuerySegment(for: value) as CFDictionary
+                    )
+                } else {
+                    status = SecItemAdd(item.insertQuery(value: value), nil)
+                }
+
+                if status != errSecSuccess {
                     throw KeychainError.unhandledError(status: status)
                 }
-            }
+            },
+            removeItem: { item in
+                let tryRemovingItem: (CFDictionary) throws -> Void = { query in
+                    let status = SecItemDelete(query)
+                    guard [errSecSuccess, errSecItemNotFound].contains(status) else {
+                        throw KeychainError.unhandledError(status: status)
+                    }
+                }
 
-            var parameters: [CFString: AnyObject] = [kSecAttrSynchronizable: kSecAttrSynchronizableAny]
-            if item.kind == .token {
-                parameters[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlock
-                try tryRemovingItem(item.baseQuery.merging(parameters))
-            } else {
-                // recursively check each potential type of access control flag
-                var potentialFlags: [SecAccessControlCreateFlags] = [
-                    [.userPresence],
-                    [.biometryCurrentSet],
-                ]
-                #if os(macOS)
-                potentialFlags.append([.biometryCurrentSet, .or, .watch])
-                #endif
-                try potentialFlags.forEach { flags in
-                    var newParameters = parameters
-                    var error: Unmanaged<CFError>?
-                    defer { error?.release() }
-                    let accessControl = SecAccessControlCreateWithFlags(
-                        nil,
-                        kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
-                        flags,
-                        &error
-                    )
-                    newParameters[kSecAttrAccessControl] = accessControl
-                    try tryRemovingItem(item.baseQuery.merging(newParameters))
+                var parameters: [CFString: AnyObject] = [kSecAttrSynchronizable: kSecAttrSynchronizableAny]
+                if item.kind == .token {
+                    parameters[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlock
+                    try tryRemovingItem(item.baseQuery.merging(parameters))
+                } else {
+                    // recursively check each potential type of access control flag
+                    var potentialFlags: [SecAccessControlCreateFlags] = [
+                        [.userPresence],
+                        [.biometryCurrentSet],
+                    ]
+                    #if os(macOS)
+                    potentialFlags.append([.biometryCurrentSet, .or, .watch])
+                    #endif
+                    try potentialFlags.forEach { flags in
+                        var newParameters = parameters
+                        var error: Unmanaged<CFError>?
+                        defer { error?.release() }
+                        let accessControl = SecAccessControlCreateWithFlags(
+                            nil,
+                            kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+                            flags,
+                            &error
+                        )
+                        newParameters[kSecAttrAccessControl] = accessControl
+                        try tryRemovingItem(item.baseQuery.merging(newParameters))
+                    }
                 }
             }
-        }
+        )
     }()
 }

--- a/Sources/StytchCore/KeychainClient/KeychainClient+Types.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient+Types.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+extension KeychainClient {
+    struct QueryResult {
+        let data: Data
+        let createdAt: Date
+        let modifiedAt: Date
+        let label: String?
+        let account: String?
+        let generic: Data?
+
+        var stringValue: String? {
+            String(data: data, encoding: .utf8)
+        }
+    }
+
+    struct KeyRegistration: Codable {
+        let userId: User.ID
+        let userLabel: String
+        let registrationId: User.BiometricRegistration.ID
+    }
+
+    enum KeychainError: Swift.Error {
+        case resultMissingAccount
+        case resultMissingDates
+        case resultNotArray
+        case resultNotData
+        case unableToCreateAccessControl
+        case unhandledError(status: OSStatus)
+    }
+}

--- a/Sources/StytchCore/KeychainClient/KeychainMigrations/KeychainMigration.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainMigrations/KeychainMigration.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 protocol KeychainMigration {
     static func run() throws
 }
@@ -5,8 +7,8 @@ protocol KeychainMigration {
 extension KeychainClient {
     // Migrations must only be added to the bottom of this list so they are run in order
     static let migrations: [KeychainMigration.Type] = [
-        Migration1.self,
-        Migration2.self,
-        Migration3.self,
+        KeychainMigration1.self,
+        KeychainMigration2.self,
+        KeychainMigration3.self,
     ]
 }

--- a/Sources/StytchCore/KeychainClient/KeychainMigrations/KeychainMigration1.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainMigrations/KeychainMigration1.swift
@@ -1,7 +1,7 @@
 import Security
 
 extension KeychainClient {
-    struct Migration1: KeychainMigration {
+    struct KeychainMigration1: KeychainMigration {
         static func run() throws {
             try [
                 KeychainClient.Item.sessionJwt,

--- a/Sources/StytchCore/KeychainClient/KeychainMigrations/KeychainMigration2.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainMigrations/KeychainMigration2.swift
@@ -1,7 +1,7 @@
 import Security
 
 extension KeychainClient {
-    struct Migration2: KeychainMigration {
+    struct KeychainMigration2: KeychainMigration {
         static func run() throws {
             try [
                 KeychainClient.Item.sessionJwt,

--- a/Sources/StytchCore/KeychainClient/KeychainMigrations/KeychainMigration3.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainMigrations/KeychainMigration3.swift
@@ -1,7 +1,7 @@
 import Security
 
 extension KeychainClient {
-    struct Migration3: KeychainMigration {
+    struct KeychainMigration3: KeychainMigration {
         static func run() throws {
             try [
                 KeychainClient.Item.privateKeyRegistration,

--- a/Sources/StytchCore/ObjectStorage.swift
+++ b/Sources/StytchCore/ObjectStorage.swift
@@ -32,7 +32,7 @@ extension ObjectStorageWrapper {
     }
 
     var queryResult: KeychainClient.QueryResult? {
-        try? keychainClient.getQueryResult(keychainItem)
+        try? keychainClient.getFirstQueryResult(keychainItem)
     }
 }
 

--- a/Sources/StytchCore/PKCE/PKCEPairManager.swift
+++ b/Sources/StytchCore/PKCE/PKCEPairManager.swift
@@ -37,14 +37,14 @@ internal class PKCEPairManagerImpl: PKCEPairManager {
     func generateAndReturnPKCECodePair() throws -> PKCECodePair {
         let codeVerifier = try cryptoClient.dataWithRandomBytesOfCount(32).toHexString()
         let codeChallenge = cryptoClient.sha256(codeVerifier).base64UrlEncoded()
-        try keychainClient.set(codeVerifier, for: .codeVerifierPKCE)
-        try keychainClient.set(codeChallenge, for: .codeChallengePKCE)
+        try keychainClient.setStringValue(codeVerifier, for: .codeVerifierPKCE)
+        try keychainClient.setStringValue(codeChallenge, for: .codeChallengePKCE)
         return PKCECodePair(codeChallenge: codeChallenge, codeVerifier: codeVerifier)
     }
 
     func getPKCECodePair() -> PKCECodePair? {
-        let codeChallenge = try? keychainClient.get(.codeChallengePKCE)
-        let codeVerifier = try? keychainClient.get(.codeVerifierPKCE)
+        let codeChallenge = try? keychainClient.getStringValue(.codeChallengePKCE)
+        let codeVerifier = try? keychainClient.getStringValue(.codeVerifierPKCE)
         if let codeChallenge = codeChallenge, let codeVerifier = codeVerifier {
             return PKCECodePair(codeChallenge: codeChallenge, codeVerifier: codeVerifier)
         } else {

--- a/Sources/StytchCore/SessionManager.swift
+++ b/Sources/StytchCore/SessionManager.swift
@@ -136,12 +136,12 @@ class SessionManager {
 extension SessionManager {
     private(set) var sessionToken: SessionToken? {
         get {
-            try? keychainClient.get(.sessionToken).map(SessionToken.opaque)
+            try? keychainClient.getStringValue(.sessionToken).map(SessionToken.opaque)
         }
         set {
             let keychainItem: KeychainClient.Item = .sessionToken
             if let newValue = newValue {
-                try? keychainClient.set(newValue.value, for: keychainItem)
+                try? keychainClient.setStringValue(newValue.value, for: keychainItem)
             } else {
                 try? keychainClient.removeItem(keychainItem)
                 cookieClient.deleteCookie(named: keychainItem.name)
@@ -151,12 +151,12 @@ extension SessionManager {
 
     private(set) var sessionJwt: SessionToken? {
         get {
-            try? keychainClient.get(.sessionJwt).map(SessionToken.jwt)
+            try? keychainClient.getStringValue(.sessionJwt).map(SessionToken.jwt)
         }
         set {
             let keychainItem: KeychainClient.Item = .sessionJwt
             if let newValue = newValue {
-                try? keychainClient.set(newValue.value, for: keychainItem)
+                try? keychainClient.setStringValue(newValue.value, for: keychainItem)
             } else {
                 try? keychainClient.removeItem(keychainItem)
                 cookieClient.deleteCookie(named: keychainItem.name)
@@ -173,7 +173,7 @@ extension SessionManager {
                 // Retrieve the IST from the keychain and check its age.
                 // If it's less than 10 minutes old, return it.
                 // Otherwise, remove it from the keychain and cookie storage.
-                guard let result = try keychainClient.getQueryResult(.intermediateSessionToken) else {
+                guard let result = try keychainClient.getFirstQueryResult(.intermediateSessionToken) else {
                     return nil
                 }
 
@@ -191,7 +191,7 @@ extension SessionManager {
         set {
             do {
                 if let newIST = newValue, newIST.isEmpty == false {
-                    try keychainClient.set(newIST, for: .intermediateSessionToken)
+                    try keychainClient.setStringValue(newIST, for: .intermediateSessionToken)
                 } else {
                     removeIntermediateSessionToken()
                 }
@@ -217,27 +217,27 @@ extension SessionManager {
 extension SessionManager {
     var b2bLastAuthMethodUsed: StytchB2BClient.B2BAuthMethod {
         get {
-            if let string = try? keychainClient.get(.b2bLastAuthMethodUsed) {
+            if let string = try? keychainClient.getStringValue(.b2bLastAuthMethodUsed) {
                 return StytchB2BClient.B2BAuthMethod(rawValue: string) ?? .unknown
             } else {
                 return StytchB2BClient.B2BAuthMethod.unknown
             }
         }
         set {
-            try? keychainClient.set(newValue.rawValue, for: .b2bLastAuthMethodUsed)
+            try? keychainClient.setStringValue(newValue.rawValue, for: .b2bLastAuthMethodUsed)
         }
     }
 
     var consumerLastAuthMethodUsed: StytchClient.ConsumerAuthMethod {
         get {
-            if let string = try? keychainClient.get(.consumerLastAuthMethodUsed) {
+            if let string = try? keychainClient.getStringValue(.consumerLastAuthMethodUsed) {
                 return StytchClient.ConsumerAuthMethod(rawValue: string) ?? .unknown
             } else {
                 return StytchClient.ConsumerAuthMethod.unknown
             }
         }
         set {
-            try? keychainClient.set(newValue.rawValue, for: .consumerLastAuthMethodUsed)
+            try? keychainClient.setStringValue(newValue.rawValue, for: .consumerLastAuthMethodUsed)
         }
     }
 }

--- a/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
@@ -38,7 +38,7 @@ public extension StytchClient {
         }
 
         public var biometricRegistrationId: String? {
-            guard let biometricKeyRegistrationQueryResult = try? keychainClient.get(.biometricKeyRegistration).first else {
+            guard let biometricKeyRegistrationQueryResult = try? keychainClient.getQueryResults(.biometricKeyRegistration).first else {
                 return nil
             }
             return biometricKeyRegistrationQueryResult.stringValue
@@ -117,14 +117,14 @@ public extension StytchClient {
             )
 
             // Set the .privateKeyRegistration
-            try keychainClient.set(
+            try keychainClient.setPrivateKeyRegistration(
                 key: privateKey,
                 registration: registration,
                 accessPolicy: parameters.accessPolicy.keychainValue
             )
 
             // Set the .biometricKeyRegistration
-            try keychainClient.set(registration.registrationId.rawValue, for: .biometricKeyRegistration)
+            try keychainClient.setStringValue(registration.registrationId.rawValue, for: .biometricKeyRegistration)
 
             return finishResponse
         }
@@ -132,7 +132,7 @@ public extension StytchClient {
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// If a valid biometric registration exists, this method confirms the current device owner via the device's built-in biometric reader and returns an updated session object by either starting a new session or adding a the biometric factor to an existing session.
         public func authenticate(parameters: AuthenticateParameters) async throws -> AuthenticateResponse {
-            guard let privateKeyRegistrationQueryResult: KeychainClient.QueryResult = try keychainClient.get(.privateKeyRegistration).first else {
+            guard let privateKeyRegistrationQueryResult: KeychainClient.QueryResult = try keychainClient.getQueryResults(.privateKeyRegistration).first else {
                 throw StytchSDKError.noBiometricRegistration
             }
 
@@ -205,9 +205,9 @@ public extension StytchClient {
          without prompting the user unnecessarily for biometric authentication.
          */
         func copyBiometricRegistrationIDToKeychainIfNeeded(_ privateKeyRegistrationQueryResult: KeychainClient.QueryResult) throws {
-            let biometricKeyRegistrationQueryResult = try? keychainClient.get(.biometricKeyRegistration).first
+            let biometricKeyRegistrationQueryResult = try? keychainClient.getQueryResults(.biometricKeyRegistration).first
             if biometricKeyRegistrationQueryResult == nil, let privateKeyRegistration = try privateKeyRegistrationQueryResult.generic.map({ try jsonDecoder.decode(KeychainClient.KeyRegistration.self, from: $0) }) {
-                try keychainClient.set(privateKeyRegistration.registrationId.rawValue, for: .biometricKeyRegistration)
+                try keychainClient.setStringValue(privateKeyRegistration.registrationId.rawValue, for: .biometricKeyRegistration)
             }
         }
     }

--- a/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
@@ -17,13 +17,13 @@ final class B2BMagicLinksTestCase: BaseTestCase {
             signupTemplateId: "mate"
         )
 
-        XCTAssertTrue(try Current.keychainClient.get(.codeVerifierPKCE).isEmpty)
+        XCTAssertTrue(try Current.keychainClient.getQueryResults(.codeVerifierPKCE).isEmpty)
 
         let response = try await StytchB2BClient.magicLinks.email.loginOrSignup(parameters: parameters)
         XCTAssertEqual(response.statusCode, 200)
         XCTAssertEqual(response.requestId, "1234")
 
-        XCTAssertEqual(try Current.keychainClient.get(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
+        XCTAssertEqual(try Current.keychainClient.getStringValue(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
@@ -53,7 +53,7 @@ final class B2BMagicLinksTestCase: BaseTestCase {
             locale: .en
         )
 
-        XCTAssertTrue(try Current.keychainClient.get(.codeVerifierPKCE).isEmpty)
+        XCTAssertTrue(try Current.keychainClient.getQueryResults(.codeVerifierPKCE).isEmpty)
 
         _ = try await StytchB2BClient.magicLinks.email.discoverySend(parameters: parameters)
 
@@ -105,10 +105,10 @@ final class B2BMagicLinksTestCase: BaseTestCase {
             locale: .en
         )
 
-        try Current.keychainClient.set(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
-        try Current.keychainClient.set(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
+        try Current.keychainClient.setStringValue(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
+        try Current.keychainClient.setStringValue(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
 
-        XCTAssertNotNil(try Current.keychainClient.get(.codeVerifierPKCE))
+        XCTAssertNotNil(try Current.keychainClient.getStringValue(.codeVerifierPKCE))
 
         Current.timer = { _, _, _ in .init() }
 
@@ -162,10 +162,10 @@ final class B2BMagicLinksTestCase: BaseTestCase {
             StytchSDKError.missingPKCE
         )
 
-        try Current.keychainClient.set(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
-        try Current.keychainClient.set(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
+        try Current.keychainClient.setStringValue(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
+        try Current.keychainClient.setStringValue(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
 
-        XCTAssertNotNil(try Current.keychainClient.get(.codeVerifierPKCE))
+        XCTAssertNotNil(try Current.keychainClient.getStringValue(.codeVerifierPKCE))
 
         Current.timer = { _, _, _ in .init() }
 

--- a/Tests/StytchCoreTests/BiometricsTestCase.swift
+++ b/Tests/StytchCoreTests/BiometricsTestCase.swift
@@ -12,7 +12,7 @@ final class BiometricsTestCase: BaseTestCase {
         let userId: User.ID = "user_123"
         let email = "example@stytch.com"
 
-        try Current.keychainClient.set(sessionToken, for: .sessionToken)
+        try Current.keychainClient.setStringValue(sessionToken, for: .sessionToken)
 
         let registerStartResponse = try StytchClient.Biometrics.RegisterStartResponse(
             biometricRegistrationId: regId,
@@ -38,7 +38,7 @@ final class BiometricsTestCase: BaseTestCase {
         _ = try await StytchClient.biometrics.register(parameters: .init(identifier: email))
 
         XCTAssertTrue(StytchClient.biometrics.registrationAvailable)
-        XCTAssertEqual(try Current.keychainClient.get(.privateKeyRegistration).first?.label, email)
+        XCTAssertEqual(try Current.keychainClient.getQueryResults(.privateKeyRegistration).first?.label, email)
     }
 
     func testAuthenticate() async throws {
@@ -55,14 +55,14 @@ final class BiometricsTestCase: BaseTestCase {
         }
 
         // Set the .privateKeyRegistration
-        try Current.keychainClient.set(
+        try Current.keychainClient.setPrivateKeyRegistration(
             key: privateKey.rawRepresentation,
             registration: .init(userId: userId, userLabel: email, registrationId: regId),
             accessPolicy: .deviceOwnerAuthenticationWithBiometrics
         )
 
         // Set the .biometricKeyRegistration
-        try Current.keychainClient.set(regId.rawValue, for: .biometricKeyRegistration)
+        try Current.keychainClient.setStringValue(regId.rawValue, for: .biometricKeyRegistration)
 
         XCTAssertTrue(StytchClient.biometrics.registrationAvailable)
 
@@ -102,14 +102,14 @@ final class BiometricsTestCase: BaseTestCase {
         }
 
         // Set the .privateKeyRegistration
-        try Current.keychainClient.set(
+        try Current.keychainClient.setPrivateKeyRegistration(
             key: privateKey.rawRepresentation,
             registration: .init(userId: userId, userLabel: email, registrationId: regId),
             accessPolicy: .deviceOwnerAuthenticationWithBiometrics
         )
 
         // Set the .biometricKeyRegistration
-        try Current.keychainClient.set(regId.rawValue, for: .biometricKeyRegistration)
+        try Current.keychainClient.setStringValue(regId.rawValue, for: .biometricKeyRegistration)
 
         XCTAssertTrue(StytchClient.biometrics.registrationAvailable)
 
@@ -126,10 +126,10 @@ final class BiometricsTestCase: BaseTestCase {
     }
 
     func testRegisterThrowsErrorWhenPrivateKeyExists() async throws {
-        try Current.keychainClient.set("session_token_123", for: .sessionToken)
+        try Current.keychainClient.setStringValue("session_token_123", for: .sessionToken)
 
         // Set the .privateKeyRegistration
-        try Current.keychainClient.set(
+        try Current.keychainClient.setPrivateKeyRegistration(
             key: Curve25519.Signing.PrivateKey().rawRepresentation,
             registration: .init(userId: "user_123", userLabel: "example@stytch.com", registrationId: "bio_reg_123"),
             accessPolicy: .deviceOwnerAuthenticationWithBiometrics

--- a/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
+++ b/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
@@ -29,7 +29,7 @@ final class CryptoWalletsTestCase: BaseTestCase {
             StytchClient.CryptoWallets.AuthenticateStartResponse(requestId: "mock-request-id", statusCode: 200, wrapped: .init(challenge: "mock-challenge"))
         }
 
-        try Current.keychainClient.set("123", for: .sessionToken)
+        try Current.keychainClient.setStringValue("123", for: .sessionToken)
 
         XCTAssertTrue(Current.sessionManager.hasValidSessionToken)
 

--- a/Tests/StytchCoreTests/DeeplinkHandlerTestCase.swift
+++ b/Tests/StytchCoreTests/DeeplinkHandlerTestCase.swift
@@ -21,8 +21,8 @@ final class DeeplinkHandlerTestCase: BaseTestCase {
             StytchSDKError.missingPKCE
         )
 
-        try Current.keychainClient.set(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
-        try Current.keychainClient.set(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
+        try Current.keychainClient.setStringValue(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
+        try Current.keychainClient.setStringValue(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
 
         Current.timer = { _, _, _ in .init() }
 

--- a/Tests/StytchCoreTests/KeychainClient+Mock.swift
+++ b/Tests/StytchCoreTests/KeychainClient+Mock.swift
@@ -37,7 +37,7 @@ extension KeychainClient {
     }
 
     func resultsExistForItem(_ item: Item) -> Bool {
-        (try? get(item).map { !$0.isEmpty }) ?? false
+        (try? getStringValue(item).map { !$0.isEmpty }) ?? false
     }
 }
 

--- a/Tests/StytchCoreTests/KeychainClientTestCase.swift
+++ b/Tests/StytchCoreTests/KeychainClientTestCase.swift
@@ -9,16 +9,16 @@ final class KeychainClientTestCase: BaseTestCase {
         XCTAssertFalse(Current.keychainClient.resultsExistForItem(item))
         XCTAssertFalse(Current.keychainClient.resultsExistForItem(otherItem))
 
-        try Current.keychainClient.set("test test", for: item)
+        try Current.keychainClient.setStringValue("test test", for: item)
 
         XCTAssertTrue(Current.keychainClient.resultsExistForItem(item))
         XCTAssertFalse(Current.keychainClient.resultsExistForItem(otherItem))
 
-        XCTAssertEqual(try Current.keychainClient.get(item), "test test")
+        XCTAssertEqual(try Current.keychainClient.getStringValue(item), "test test")
 
-        try Current.keychainClient.set("test again", for: item)
+        try Current.keychainClient.setStringValue("test again", for: item)
 
-        XCTAssertEqual(try Current.keychainClient.get(item), "test again")
+        XCTAssertEqual(try Current.keychainClient.getStringValue(item), "test again")
 
         try Current.keychainClient.removeItem(item)
 
@@ -76,12 +76,12 @@ final class KeychainClientTestCase: BaseTestCase {
 
     func testQueryResults() throws {
         let data = try Current.cryptoClient.dataWithRandomBytesOfCount(32)
-        try Current.keychainClient.set(
+        try Current.keychainClient.setPrivateKeyRegistration(
             key: data,
             registration: .init(userId: "user_123", userLabel: "user@example.com", registrationId: "registration_123"),
             accessPolicy: .deviceOwnerAuthenticationWithBiometrics
         )
-        let results = try Current.keychainClient.get(.privateKeyRegistration)
+        let results = try Current.keychainClient.getQueryResults(.privateKeyRegistration)
         XCTAssertNil(results.first?.account)
         XCTAssertEqual(results.first?.label, "user@example.com")
     }
@@ -89,28 +89,28 @@ final class KeychainClientTestCase: BaseTestCase {
     func testKeychainReset() throws {
         let installIdKey = "stytch_install_id_defaults_key"
         Current.defaults.set(Current.uuid().uuidString, forKey: installIdKey)
-        try Current.keychainClient.set("token", for: .sessionToken)
-        try Current.keychainClient.set("token_jwt", for: .sessionJwt)
+        try Current.keychainClient.setStringValue("token", for: .sessionToken)
+        try Current.keychainClient.setStringValue("token_jwt", for: .sessionJwt)
         StytchClient.configure(configuration: .init(publicToken: "some public token"))
-        XCTAssertEqual(try Current.keychainClient.get(.sessionToken), "token")
-        XCTAssertEqual(try Current.keychainClient.get(.sessionJwt), "token_jwt")
+        XCTAssertEqual(try Current.keychainClient.getStringValue(.sessionToken), "token")
+        XCTAssertEqual(try Current.keychainClient.getStringValue(.sessionJwt), "token_jwt")
         Current.defaults.removeObject(forKey: installIdKey)
         StytchClient.configure(configuration: .init(publicToken: "another public token"))
-        XCTAssertNil(try Current.keychainClient.get(.sessionToken))
-        XCTAssertNil(try Current.keychainClient.get(.sessionJwt))
+        XCTAssertNil(try Current.keychainClient.getStringValue(.sessionToken))
+        XCTAssertNil(try Current.keychainClient.getStringValue(.sessionJwt))
     }
 
     func testKeychainDoesNotResetWhenConfigureIsCalledAgainWithSamePublicToken() throws {
         let installIdKey = "stytch_install_id_defaults_key"
         Current.defaults.set(Current.uuid().uuidString, forKey: installIdKey)
-        try Current.keychainClient.set("token", for: .sessionToken)
-        try Current.keychainClient.set("token_jwt", for: .sessionJwt)
+        try Current.keychainClient.setStringValue("token", for: .sessionToken)
+        try Current.keychainClient.setStringValue("token_jwt", for: .sessionJwt)
         StytchClient.configure(configuration: .init(publicToken: "some public token"))
-        XCTAssertEqual(try Current.keychainClient.get(.sessionToken), "token")
-        XCTAssertEqual(try Current.keychainClient.get(.sessionJwt), "token_jwt")
+        XCTAssertEqual(try Current.keychainClient.getStringValue(.sessionToken), "token")
+        XCTAssertEqual(try Current.keychainClient.getStringValue(.sessionJwt), "token_jwt")
         Current.defaults.removeObject(forKey: installIdKey)
         StytchClient.configure(configuration: .init(publicToken: "some public token"))
-        XCTAssertNotNil(try Current.keychainClient.get(.sessionToken))
-        XCTAssertNotNil(try Current.keychainClient.get(.sessionJwt))
+        XCTAssertNotNil(try Current.keychainClient.getStringValue(.sessionToken))
+        XCTAssertNotNil(try Current.keychainClient.getStringValue(.sessionJwt))
     }
 }

--- a/Tests/StytchCoreTests/MagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/MagicLinksTestCase.swift
@@ -18,13 +18,13 @@ final class MagicLinksTestCase: BaseTestCase {
             locale: .en
         )
 
-        XCTAssertTrue(try Current.keychainClient.get(.codeVerifierPKCE).isEmpty)
+        XCTAssertTrue(try Current.keychainClient.getQueryResults(.codeVerifierPKCE).isEmpty)
 
         let response = try await StytchClient.magicLinks.email.loginOrCreate(parameters: parameters)
         XCTAssertEqual(response.statusCode, 200)
         XCTAssertEqual(response.requestId, "1234")
 
-        XCTAssertEqual(try Current.keychainClient.get(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
+        XCTAssertEqual(try Current.keychainClient.getStringValue(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
@@ -55,13 +55,13 @@ final class MagicLinksTestCase: BaseTestCase {
         )
 
         XCTAssertFalse(Current.sessionManager.hasValidSessionToken)
-        XCTAssertTrue(try Current.keychainClient.get(.codeVerifierPKCE).isEmpty)
+        XCTAssertTrue(try Current.keychainClient.getQueryResults(.codeVerifierPKCE).isEmpty)
 
         let response = try await StytchClient.magicLinks.email.send(parameters: parameters)
         XCTAssertEqual(response.statusCode, 200)
         XCTAssertEqual(response.requestId, "1234")
 
-        XCTAssertEqual(try Current.keychainClient.get(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
+        XCTAssertEqual(try Current.keychainClient.getStringValue(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
@@ -87,16 +87,16 @@ final class MagicLinksTestCase: BaseTestCase {
             locale: .en
         )
 
-        try Current.keychainClient.set("123", for: .sessionToken)
+        try Current.keychainClient.setStringValue("123", for: .sessionToken)
 
         XCTAssertTrue(Current.sessionManager.hasValidSessionToken)
-        XCTAssertTrue(try Current.keychainClient.get(.codeVerifierPKCE).isEmpty)
+        XCTAssertTrue(try Current.keychainClient.getQueryResults(.codeVerifierPKCE).isEmpty)
 
         let response = try await StytchClient.magicLinks.email.send(parameters: parameters)
         XCTAssertEqual(response.statusCode, 200)
         XCTAssertEqual(response.requestId, "1234")
 
-        XCTAssertEqual(try Current.keychainClient.get(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
+        XCTAssertEqual(try Current.keychainClient.getStringValue(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
@@ -124,10 +124,10 @@ final class MagicLinksTestCase: BaseTestCase {
             StytchSDKError.missingPKCE
         )
 
-        try Current.keychainClient.set(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
-        try Current.keychainClient.set(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
+        try Current.keychainClient.setStringValue(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
+        try Current.keychainClient.setStringValue(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
 
-        XCTAssertNotNil(try Current.keychainClient.get(.codeVerifierPKCE))
+        XCTAssertNotNil(try Current.keychainClient.getStringValue(.codeVerifierPKCE))
 
         Current.timer = { _, _, _ in .init() }
 

--- a/Tests/StytchCoreTests/OTPTestCase.swift
+++ b/Tests/StytchCoreTests/OTPTestCase.swift
@@ -109,7 +109,7 @@ final class OTPTestCase: BaseTestCase {
             response
         }
 
-        try Current.keychainClient.set("123", for: .sessionToken)
+        try Current.keychainClient.setStringValue("123", for: .sessionToken)
 
         XCTAssertTrue(Current.sessionManager.hasValidSessionToken)
 


### PR DESCRIPTION
[[iOS] Refactor Keychain Client](https://linear.app/stytch/issue/SDK-2492/[ios]-refactor-keychain-client) **1/2**

There are no functional changes in this PR.

## Changes:

1. In this first pr refactoring elements of the `KeychainClient` I focused on mostly renaming some things and moving code around for the second round of refactoring and readability.
2. In the `KeychainClient` there were many overlapping definitions of things like `get` and `set` which made confusing in the code which one was getting called when so I split them into more explicit naming:
3. `get` -> `getQueryResults`
4. `get` -> `getStringValue`
5. `set` -> `setStringValue`
6. `set` -> `setPrivateKeyRegistration`
7. `getQueryResult` -> `getFirstQueryResult`
8. In `KeychainClient+Live.swift` I changed some things from completion blocks into functions and added proper parameter labels for the next pr that will get rid of these completion blocks in favor of a protocol based implementation.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
