### PR TITLE
Create error publisher for prebuilt UI

### DIFF
--- a/Sources/StytchUI/Shared/ErrorPublisher.swift
+++ b/Sources/StytchUI/Shared/ErrorPublisher.swift
@@ -1,0 +1,14 @@
+import Combine
+import Foundation
+
+struct ErrorPublisher {
+    private static let errorPublisher = PassthroughSubject<Error, Never>()
+
+    static var publisher: AnyPublisher<Error, Never> {
+        errorPublisher.eraseToAnyPublisher()
+    }
+
+    static func publishError(_ error: Error) {
+        errorPublisher.send(error)
+    }
+}

--- a/Sources/StytchUI/Shared/EventsClient+UI.swift
+++ b/Sources/StytchUI/Shared/EventsClient+UI.swift
@@ -1,0 +1,9 @@
+import StytchCore
+
+extension EventsClient {
+    static func sendAuthenticationSuccessEvent() {
+        Task {
+            try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_success"))
+        }
+    }
+}

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController/BaseViewController+B2B-Helpers.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController/BaseViewController+B2B-Helpers.swift
@@ -18,11 +18,13 @@ extension BaseViewController {
 
     func showEmailNotEligibleForJitProvioningErrorIfPossible(_ error: any Error) {
         if let error = error as? StytchSDKError, error == .emailNotEligibleForJitProvioning {
+            ErrorPublisher.publishError(error)
             presentAlert(
                 title: NSLocalizedString("stytch.vcErrorTitle", value: "Error", comment: ""),
                 message: "\(MemberManager.emailAddress ?? "This email") does not have access to \(OrganizationManager.name ?? "this organization"). If you think this is a mistake, contact your admin."
             )
         } else {
+            ErrorPublisher.publishError(error)
             presentErrorAlert(error: error)
         }
     }

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController/BaseViewController+Discovery.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/BaseViewController/BaseViewController+Discovery.swift
@@ -39,6 +39,7 @@ extension BaseViewController {
                 StytchB2BUIClient.stopLoading()
             } catch {
                 StytchB2BUIClient.stopLoading()
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
             }
         }
@@ -53,6 +54,7 @@ extension BaseViewController {
                 )
                 startMFAFlowIfNeeded(configuration: configuration)
             } catch {
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
             }
         }

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/StateManagement/B2BAuthenticationManager.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/StateManagement/B2BAuthenticationManager.swift
@@ -65,6 +65,7 @@ enum B2BAuthenticationManager {
         // So if the totp response is not nil we want to wait to dismiss the ui until the user has saved the recovery codes
         if memberSession != nil {
             if totpResponse == nil || (totpResponse != nil && didSaveRecoveryCodes == true) {
+                EventsClient.sendAuthenticationSuccessEvent()
                 dismissUIPublisher.send()
             }
         }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BEmailViewController/B2BEmailViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BEmailViewController/B2BEmailViewController.swift
@@ -105,6 +105,7 @@ final class B2BEmailViewController: BaseViewController<B2BEmailState, B2BEmailVi
     func sendEmailMagicLink() {
         viewModel.sendEmailMagicLink(emailAddress: emailInput.text ?? "") { [weak self] error in
             if let error {
+                ErrorPublisher.publishError(error)
                 self?.presentErrorAlert(error: error)
             } else {
                 self?.delegate?.emailMagicLinkSent()
@@ -115,6 +116,7 @@ final class B2BEmailViewController: BaseViewController<B2BEmailState, B2BEmailVi
     func sendEmailOTP() {
         viewModel.sendEmailOTP(emailAddress: emailInput.text ?? "") { [weak self] error in
             if let error {
+                ErrorPublisher.publishError(error)
                 self?.presentErrorAlert(error: error)
             } else {
                 self?.delegate?.emailOTPSent()

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BOAuthViewController/B2BOAuthViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BOAuthViewController/B2BOAuthViewController.swift
@@ -50,7 +50,9 @@ final class B2BOAuthViewController: BaseViewController<B2BOAuthState, B2BOAuthVi
             } catch {
                 if let error = error as? ASWebAuthenticationSessionError, error.code == .canceledLogin {
                     // do nothing
+                    ErrorPublisher.publishError(error)
                 } else {
+                    ErrorPublisher.publishError(error)
                     self?.presentErrorAlert(error: error)
                     try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
                 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BSSOViewController/B2BSSOViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthHomeViewController/B2BSSOViewController/B2BSSOViewController.swift
@@ -62,6 +62,7 @@ final class B2BSSOViewController: BaseViewController<SSOState, SSOViewModel> {
                 StytchB2BUIClient.stopLoading()
             } catch {
                 try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
                 StytchB2BUIClient.stopLoading()
             }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
@@ -6,16 +6,13 @@ import UIKit
 final class B2BAuthRootViewController: UIViewController {
     private let configuration: StytchB2BUIClient.Configuration
 
-    private var onB2BAuthCallback: AuthCallback?
-
     private var homeController: B2BAuthHomeViewController?
 
     private var loadingView: UIView?
     private var activityIndicator: UIActivityIndicatorView?
 
-    init(configuration: StytchB2BUIClient.Configuration, onB2BAuthCallback: AuthCallback? = nil) {
+    init(configuration: StytchB2BUIClient.Configuration) {
         self.configuration = configuration
-        self.onB2BAuthCallback = onB2BAuthCallback
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailConfirmationViewController/EmailConfirmationViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailConfirmationViewController/EmailConfirmationViewController.swift
@@ -65,6 +65,7 @@ final class EmailConfirmationViewController: BaseViewController<EmailConfirmatio
                 presentAlert(title: "Email Sent!")
             } catch {
                 StytchB2BUIClient.stopLoading()
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
             }
         }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailMethodSelectionViewController/EmailMethodSelectionViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailMethodSelectionViewController/EmailMethodSelectionViewController.swift
@@ -39,6 +39,7 @@ final class EmailMethodSelectionViewController: BaseViewController<EmailMethodSe
     func sendEmailMagicLink() {
         viewModel.sendEmailMagicLink(emailAddress: MemberManager.emailAddress ?? "") { [weak self] error in
             if let error {
+                ErrorPublisher.publishError(error)
                 self?.presentErrorAlert(error: error)
             } else {
                 self?.emailMagicLinkSent()
@@ -49,6 +50,7 @@ final class EmailMethodSelectionViewController: BaseViewController<EmailMethodSe
     func sendEmailOTP() {
         viewModel.sendEmailOTP(emailAddress: MemberManager.emailAddress ?? "") { [weak self] error in
             if let error {
+                ErrorPublisher.publishError(error)
                 self?.presentErrorAlert(error: error)
             } else {
                 self?.emailOTPSent()

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailOTPEntryViewController/EmailOTPEntryViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailOTPEntryViewController/EmailOTPEntryViewController.swift
@@ -81,6 +81,7 @@ extension EmailOTPEntryViewController: OTPEntryViewControllerProtocol {
                 StytchB2BUIClient.stopLoading()
             } catch {
                 StytchB2BUIClient.stopLoading()
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
             }
         }
@@ -116,6 +117,7 @@ extension EmailOTPEntryViewController: OTPCodeEntryViewDelegate {
                 StytchB2BUIClient.stopLoading()
             } catch {
                 otpView.clear()
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
                 StytchB2BUIClient.stopLoading()
             }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/ErrorViewController/ErrorViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/ErrorViewController/ErrorViewController.swift
@@ -13,6 +13,7 @@ final class ErrorViewController: BaseViewController<ErrorState, ErrorViewModel> 
 
     init(state: ErrorState) {
         super.init(viewModel: ErrorViewModel(state: state))
+        ErrorPublisher.publishError(viewModel.state.type)
     }
 
     override func configureView() {

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordResetViewController/PasswordResetViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordResetViewController/PasswordResetViewController.swift
@@ -78,6 +78,7 @@ final class PasswordResetViewController: BaseViewController<PasswordResetState, 
                 }
             } catch {
                 StytchB2BUIClient.stopLoading()
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
             }
         }
@@ -132,6 +133,7 @@ final class PasswordResetViewController: BaseViewController<PasswordResetState, 
                     }
                 }
             } catch {
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
             }
         }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeEntryViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/RecoveryCodeEntryViewController/RecoveryCodeEntryViewController.swift
@@ -62,6 +62,7 @@ final class RecoveryCodeEntryViewController: BaseViewController<RecoveryCodeEntr
                 try await viewModel.recover(recoveryCode: recoveryCode)
                 StytchB2BUIClient.stopLoading()
             } catch {
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
                 StytchB2BUIClient.stopLoading()
             }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEnrollmentViewController/SMSOTPEnrollmentViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEnrollmentViewController/SMSOTPEnrollmentViewController.swift
@@ -97,6 +97,7 @@ final class SMSOTPEnrollmentViewController: BaseViewController<SMSOTPEnrollmentS
                     navigationController?.pushViewController(SMSOTPEntryViewController(state: .init(configuration: viewModel.state.configuration, didSendCode: true)), animated: true)
                 } catch {
                     StytchB2BUIClient.stopLoading()
+                    ErrorPublisher.publishError(error)
                     presentErrorAlert(error: error)
                 }
             }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEntryViewController/SMSOTPEntryViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SMSOTPEntryViewController/SMSOTPEntryViewController.swift
@@ -91,6 +91,7 @@ extension SMSOTPEntryViewController: OTPEntryViewControllerProtocol {
                 StytchB2BUIClient.stopLoading()
             } catch {
                 StytchB2BUIClient.stopLoading()
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
             }
         }
@@ -120,6 +121,7 @@ extension SMSOTPEntryViewController: OTPCodeEntryViewDelegate {
                 StytchB2BUIClient.stopLoading()
             } catch {
                 otpView.clear()
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
                 StytchB2BUIClient.stopLoading()
             }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SSODiscovery/SSODiscoveryEmailViewController/SSODiscoveryEmailViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SSODiscovery/SSODiscoveryEmailViewController/SSODiscoveryEmailViewController.swift
@@ -88,6 +88,7 @@ extension SSODiscoveryEmailViewController: SSODiscoveryEmailViewModelDelegate {
     }
 
     func ssoDiscoveryDidError(error: Error) {
+        ErrorPublisher.publishError(error)
         presentErrorAlert(error: error)
     }
 }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SSODiscovery/SSODiscoveryFallbackViewController/SSODiscoveryFallbackViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SSODiscovery/SSODiscoveryFallbackViewController/SSODiscoveryFallbackViewController.swift
@@ -53,6 +53,7 @@ final class SSODiscoveryFallbackViewController: BaseViewController<SSODiscoveryF
                 }
             } catch {
                 StytchB2BUIClient.stopLoading()
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
             }
         }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SSODiscovery/SSODiscoveryMenuViewController/SSODiscoveryMenuViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/SSODiscovery/SSODiscoveryMenuViewController/SSODiscoveryMenuViewController.swift
@@ -47,6 +47,7 @@ final class SSODiscoveryMenuViewController: BaseViewController<SSODiscoveryMenuS
                 startMFAFlowIfNeeded(configuration: viewModel.state.configuration)
             } catch {
                 StytchB2BUIClient.stopLoading()
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
             }
         }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPEnrollmentViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEnrollmentManualViewController/TOTPEnrollmentViewController.swift
@@ -74,6 +74,7 @@ final class TOTPEnrollmentViewController: BaseViewController<TOTPEnrollmentState
             } catch {
                 Task { @MainActor in
                     self?.continueButton.setTitle(NSLocalizedString("stytch.pwContinueTryAgainTitle", value: "Try Again", comment: ""), for: .normal)
+                    ErrorPublisher.publishError(error)
                     self?.presentErrorAlert(error: error)
                     self?.error = error
                     StytchB2BUIClient.stopLoading()

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEntryViewController/TOTPEntryViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/TOTPEntryViewController/TOTPEntryViewController.swift
@@ -88,6 +88,7 @@ extension TOTPEntryViewController: OTPCodeEntryViewDelegate {
                 continueWithTOTP()
             } catch {
                 otpView.clear()
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
                 StytchB2BUIClient.stopLoading()
             }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/ActionableInfoViewController/ActionableInfoViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/ActionableInfoViewController/ActionableInfoViewController.swift
@@ -95,6 +95,7 @@ final class ActionableInfoViewController: BaseViewController<ActionableInfoState
                         self.launchForgotPassword(email: email)
                     }
                 } catch {
+                    ErrorPublisher.publishError(error)
                     presentErrorAlert(error: error)
                 }
             }
@@ -106,6 +107,7 @@ final class ActionableInfoViewController: BaseViewController<ActionableInfoState
                         self.launchCheckYourEmail(email: email)
                     }
                 } catch {
+                    ErrorPublisher.publishError(error)
                     presentErrorAlert(error: error)
                 }
             }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/AuthHomeViewController/AuthHomeViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/AuthHomeViewController/AuthHomeViewController.swift
@@ -39,6 +39,7 @@ final class AuthHomeViewController: BaseViewController<AuthHomeState, AuthHomeVi
         do {
             try viewModel.checkValidConfig()
         } catch {
+            ErrorPublisher.publishError(error)
             presentErrorAlert(error: error)
             return
         }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/AuthInputViewController/AuthInputViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/AuthInputViewController/AuthInputViewController.swift
@@ -281,6 +281,7 @@ final class AuthInputViewController: BaseViewController<AuthInputState, AuthInpu
                     }
                 }
             } catch {
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
             }
         }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/AuthRootViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/AuthRootViewController.swift
@@ -8,11 +8,8 @@ final class AuthRootViewController: UIViewController {
 
     private let activityIndicator: UIActivityIndicatorView = .init(style: .large)
 
-    private var onAuthCallback: AuthCallback?
-
-    init(config: StytchUIClient.Configuration, onAuthCallback: AuthCallback? = nil) {
+    init(config: StytchUIClient.Configuration) {
         self.config = config
-        self.onAuthCallback = onAuthCallback
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/OAuthViewController/OAuthViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/OAuthViewController/OAuthViewController.swift
@@ -33,6 +33,7 @@ final class OAuthViewController: BaseViewController<OAuthState, OAuthViewModel> 
                 try await viewModel.startOAuth(provider: provider)
             } catch {
                 try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
             }
         }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/OAuthViewController/OAuthViewModel.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/OAuthViewController/OAuthViewModel.swift
@@ -32,13 +32,11 @@ extension OAuthViewModel: OAuthViewModelProtocol {
         switch provider {
         case .apple:
             let response = try await appleOauthProvider.start(parameters: .init(sessionDuration: state.config.sessionDurationMinutes))
-            StytchUIClient.onAuthCallback?(response)
         case let .thirdParty(provider):
             let (token, _) = try await (thirdPartyClientForTesting ?? provider.client).start(
                 configuration: .init(loginRedirectUrl: state.config.redirectUrl, signupRedirectUrl: state.config.redirectUrl)
             )
             let response = try await oAuthProvider.authenticate(parameters: .init(token: token, sessionDuration: state.config.sessionDurationMinutes))
-            StytchUIClient.onAuthCallback?(response)
         }
     }
 }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/OTPCodeViewController/OTPCodeViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/OTPCodeViewController/OTPCodeViewController.swift
@@ -38,6 +38,7 @@ final class OTPCodeViewController: BaseViewController<OTPCodeState, OTPCodeViewM
                     self?.launchPassword(email: email)
                 }
             } catch {
+                ErrorPublisher.publishError(error)
                 self?.presentErrorAlert(error: error)
             }
         }
@@ -107,6 +108,7 @@ final class OTPCodeViewController: BaseViewController<OTPCodeState, OTPCodeViewM
             do {
                 try await viewModel.resendCode(input: viewModel.state.input)
             } catch {
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
             }
         }
@@ -131,6 +133,7 @@ extension OTPCodeViewController: OTPCodeEntryViewDelegate {
                 self.otpView.clear()
             } catch {
                 try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
+                ErrorPublisher.publishError(error)
                 self.presentErrorAlert(error: error)
                 self.otpView.clear()
             }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/OTPCodeViewController/OTPCodeViewModel.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/OTPCodeViewController/OTPCodeViewModel.swift
@@ -54,7 +54,6 @@ extension OTPCodeViewModel: OTPCodeViewModelProtocol {
 
     func enterCode(code: String, methodId: String) async throws {
         let response = try await otpClient.authenticate(parameters: .init(code: code, methodId: methodId))
-        StytchUIClient.onAuthCallback?(response)
     }
 }
 

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/PasswordViewController/PasswordViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/PasswordViewController/PasswordViewController.swift
@@ -1,6 +1,8 @@
 import StytchCore
 import UIKit
 
+// swiftlint:disable type_body_length
+
 final class PasswordViewController: BaseViewController<PasswordState, PasswordViewModel> {
     private let scrollView: UIScrollView = .init()
 
@@ -17,6 +19,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                     self?.launchCheckYourEmail(email: email)
                 }
             } catch {
+                ErrorPublisher.publishError(error)
                 self?.presentErrorAlert(error: error)
             }
         }
@@ -61,6 +64,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                     self?.launchForgotPassword(email: email)
                 }
             } catch {
+                ErrorPublisher.publishError(error)
                 self?.presentErrorAlert(error: error)
             }
         }
@@ -79,6 +83,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                     self?.launchCheckYourEmail(email: email)
                 }
             } catch {
+                ErrorPublisher.publishError(error)
                 self?.presentErrorAlert(error: error)
             }
         }
@@ -218,6 +223,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                     try await viewModel.setPassword(token: token, password: password)
                 } catch {
                     try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
+                    ErrorPublisher.publishError(error)
                     presentErrorAlert(error: error)
                 }
             }
@@ -227,6 +233,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                     try await viewModel.login(email: email, password: password)
                 } catch {
                     try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
+                    ErrorPublisher.publishError(error)
                     presentErrorAlert(error: error)
                 }
             }
@@ -236,6 +243,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                     try await viewModel.signup(email: email, password: password)
                 } catch {
                     try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
+                    ErrorPublisher.publishError(error)
                     presentErrorAlert(error: error)
                 }
             }
@@ -280,6 +288,7 @@ final class PasswordViewController: BaseViewController<PasswordState, PasswordVi
                     passwordInput.setFeedback(nil)
                 }
             } catch {
+                ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
             }
         }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/PasswordViewController/PasswordViewModel.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/PasswordViewController/PasswordViewModel.swift
@@ -33,17 +33,14 @@ extension PasswordViewModel: PasswordViewModelProtocol {
 
     func setPassword(token: String, password: String) async throws {
         let response = try await passwordClient.resetByEmail(parameters: .init(token: token, password: password, sessionDuration: state.config.sessionDurationMinutes))
-        StytchUIClient.onAuthCallback?(response)
     }
 
     func signup(email: String, password: String) async throws {
         let response = try await passwordClient.create(parameters: .init(email: email, password: password, sessionDuration: state.config.sessionDurationMinutes))
-        StytchUIClient.onAuthCallback?(response)
     }
 
     func login(email: String, password: String) async throws {
         let response = try await passwordClient.authenticate(parameters: .init(email: email, password: password, sessionDuration: state.config.sessionDurationMinutes))
-        StytchUIClient.onAuthCallback?(response)
     }
 
     func loginWithEmail(email: String) async throws {

--- a/Stytch/DemoApps/StytchB2BUIDemo/ContentView.swift
+++ b/Stytch/DemoApps/StytchB2BUIDemo/ContentView.swift
@@ -35,9 +35,7 @@ struct ContentView: View {
                 .font(.title).bold()
             }
         }
-        .b2bAuthenticationSheet(configuration: viewModel.stytchB2BUIConfig, isPresented: $viewModel.isShowingB2BUI, onB2BAuthCallback: {
-            print("member session: \(String(describing: StytchB2BClient.sessions.memberSession))")
-        })
+        .b2bAuthenticationSheet(configuration: viewModel.stytchB2BUIConfig, isPresented: $viewModel.isShowingB2BUI)
         .padding()
         .onAppear {
             viewModel.loadFromUserDefaults()
@@ -64,6 +62,14 @@ class ContentViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 self?.isShowingB2BUI = false
+            }
+            .store(in: &cancellables)
+
+        StytchB2BUIClient.errorPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { error in
+                print("Error from StytchB2BUIClient:")
+                print(error.errorInfo)
             }
             .store(in: &cancellables)
 

--- a/Stytch/DemoApps/StytchUIDemo/ContentView.swift
+++ b/Stytch/DemoApps/StytchUIDemo/ContentView.swift
@@ -24,9 +24,7 @@ struct ContentView: View {
                     }.font(.title).bold()
                 }
             }
-            .authenticationSheet(configuration: viewModel.configuration, isPresented: $viewModel.shouldShowB2CUI, onAuthCallback: { authenticateResponseType in
-                print("user: \(authenticateResponseType.user) - session: \(authenticateResponseType.session)")
-            })
+            .authenticationSheet(configuration: viewModel.configuration, isPresented: $viewModel.shouldShowB2CUI)
             .padding()
             .onOpenURL { url in
                 viewModel.shouldShowB2CUI = true
@@ -53,6 +51,7 @@ class ContentViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
 
     init() {
+        // you can also observere: `StytchClient.user.onUserChange` if need be
         StytchClient.sessions.onSessionChange
             .receive(on: DispatchQueue.main)
             .sink { [weak self] sessionInfo in
@@ -65,6 +64,14 @@ class ContentViewModel: ObservableObject {
                     self?.shouldShowB2CUI = true
                 }
             }.store(in: &cancellables)
+
+        StytchUIClient.errorPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { error in
+                print("Error from StytchUIClient:")
+                print(error.errorInfo)
+            }
+            .store(in: &cancellables)
 
         // To start the underlying client’s observables before displaying the UI, call configure separately.
         StytchUIClient.configure(configuration: configuration)

--- a/Tests/StytchUIUnitTests/StytchUIClientTests/AuthInputViewModelTests.swift
+++ b/Tests/StytchUIUnitTests/StytchUIClientTests/AuthInputViewModelTests.swift
@@ -25,7 +25,6 @@ final class AuthInputViewModelTests: BaseTestCase {
     override func setUp() async throws {
         try await super.setUp()
         calledMethod = nil
-        StytchUIClient.onAuthCallback = nil
     }
 
     func testCreatesCorrectResetByEmailStartParams() {

--- a/Tests/StytchUIUnitTests/StytchUIClientTests/OAuthViewModelTests.swift
+++ b/Tests/StytchUIUnitTests/StytchUIClientTests/OAuthViewModelTests.swift
@@ -12,7 +12,6 @@ final class OAuthViewModelTests: BaseTestCase {
     override func setUp() async throws {
         try await super.setUp()
         calledMethods = []
-        StytchUIClient.onAuthCallback = nil
     }
 
     func testSessionDurationMinutesReadsFromConfig() {
@@ -48,14 +47,9 @@ final class OAuthViewModelTests: BaseTestCase {
         )
         let appleSpy = AppleSpy(callback: calledMethodCallback)
         let viewModel = OAuthViewModel(state: state, appleOAuthProvider: appleSpy)
-        var didCallUICallback = false
-        StytchUIClient.onAuthCallback = { _ in
-            didCallUICallback = true
-        }
         try await viewModel.startOAuth(provider: .apple)
         XCTAssert(calledMethods.count == 1)
         XCTAssert(calledMethods.contains(.oauthAppleStart))
-        XCTAssert(didCallUICallback)
     }
 
     func testStartOAuthDoesNothingIfOAuthIsNotConfiguredAndProviderIsThirdParty() async throws {
@@ -70,13 +64,8 @@ final class OAuthViewModelTests: BaseTestCase {
         let oAuthSpy = OAuthSpy(callback: calledMethodCallback)
         let thirdPartySpy = ThirdPartyOAuthSpy(callback: calledMethodCallback)
         let viewModel = OAuthViewModel(state: state, appleOAuthProvider: appleSpy, oAuthProvider: oAuthSpy)
-        var didCallUICallback = false
-        StytchUIClient.onAuthCallback = { _ in
-            didCallUICallback = true
-        }
         try await viewModel.startOAuth(provider: .thirdParty(.amazon), thirdPartyClientForTesting: thirdPartySpy)
         XCTAssert(calledMethods.isEmpty)
-        XCTAssert(!didCallUICallback)
     }
 
     func testStartOAuthCallsThirdPartyStartAndAuthenticateFlowAndReportsToUIIfOAuthIsConfiguredAndProviderIsThirdParty() async throws {
@@ -91,14 +80,9 @@ final class OAuthViewModelTests: BaseTestCase {
         let oAuthSpy = OAuthSpy(callback: calledMethodCallback)
         let thirdPartySpy = ThirdPartyOAuthSpy(callback: calledMethodCallback)
         let viewModel = OAuthViewModel(state: state, appleOAuthProvider: appleSpy, oAuthProvider: oAuthSpy)
-        var didCallUICallback = false
-        StytchUIClient.onAuthCallback = { _ in
-            didCallUICallback = true
-        }
         try await viewModel.startOAuth(provider: .thirdParty(.amazon), thirdPartyClientForTesting: thirdPartySpy)
         XCTAssert(calledMethods.count == 2)
         XCTAssert(calledMethods.contains(.oauthThirdPartyStart))
         XCTAssert(calledMethods.contains(.oauthAuthenticate))
-        XCTAssert(didCallUICallback)
     }
 }

--- a/Tests/StytchUIUnitTests/StytchUIClientTests/OTPCodeViewModelTest.swift
+++ b/Tests/StytchUIUnitTests/StytchUIClientTests/OTPCodeViewModelTest.swift
@@ -12,7 +12,6 @@ final class OTPCodeViewModelTest: BaseTestCase {
     override func setUp() async throws {
         try await super.setUp()
         calledMethod = nil
-        StytchUIClient.onAuthCallback = nil
     }
 
     func testResendCodeCallsLoginOrCreateAndUpdatesState() async throws {
@@ -51,12 +50,7 @@ final class OTPCodeViewModelTest: BaseTestCase {
         )
         let spy = OTPSpy(callback: calledMethodCallback)
         let viewModel: OTPCodeViewModel = .init(state: state, otpClient: spy)
-        var didCallUICallback = false
-        StytchUIClient.onAuthCallback = { _ in
-            didCallUICallback = true
-        }
         _ = try await viewModel.enterCode(code: "123456", methodId: "")
         XCTAssert(calledMethod == .otpAuthenticate)
-        XCTAssert(didCallUICallback)
     }
 }

--- a/Tests/StytchUIUnitTests/StytchUIClientTests/PasswordViewModelTests.swift
+++ b/Tests/StytchUIUnitTests/StytchUIClientTests/PasswordViewModelTests.swift
@@ -12,7 +12,6 @@ final class PasswordViewModelTests: BaseTestCase {
     override func setUp() async throws {
         try await super.setUp()
         calledMethod = nil
-        StytchUIClient.onAuthCallback = nil
         StytchUIClient.pendingResetEmail = nil
     }
 
@@ -135,13 +134,8 @@ final class PasswordViewModelTests: BaseTestCase {
         )
         let spy: PasswordsProtocol = PasswordsSpy(callback: calledMethodCallback)
         let viewModel = PasswordViewModel(state: state, passwordClient: spy)
-        var didCallUICallback = false
-        StytchUIClient.onAuthCallback = { _ in
-            didCallUICallback = true
-        }
         _ = try await viewModel.setPassword(token: "", password: "")
         XCTAssert(calledMethod == .passwordsResetByEmail)
-        XCTAssert(didCallUICallback)
     }
 
     func testSignupCallsCreateAndReportsToOnAuthCallback() async throws {
@@ -156,13 +150,8 @@ final class PasswordViewModelTests: BaseTestCase {
         )
         let spy: PasswordsProtocol = PasswordsSpy(callback: calledMethodCallback)
         let viewModel = PasswordViewModel(state: state, passwordClient: spy)
-        var didCallUICallback = false
-        StytchUIClient.onAuthCallback = { _ in
-            didCallUICallback = true
-        }
         _ = try await viewModel.signup(email: "", password: "")
         XCTAssert(calledMethod == .passwordsCreate)
-        XCTAssert(didCallUICallback)
     }
 
     func testLoginCallsAuthenticateAndReportsToOnAuthCallback() async throws {
@@ -177,13 +166,8 @@ final class PasswordViewModelTests: BaseTestCase {
         )
         let spy: PasswordsProtocol = PasswordsSpy(callback: calledMethodCallback)
         let viewModel = PasswordViewModel(state: state, passwordClient: spy)
-        var didCallUICallback = false
-        StytchUIClient.onAuthCallback = { _ in
-            didCallUICallback = true
-        }
         _ = try await viewModel.login(email: "", password: "")
         XCTAssert(calledMethod == .passwordsAuthenticate)
-        XCTAssert(didCallUICallback)
     }
 
     func testLoginWithEmailExitsEarlyWhenEMLProductIsNotConfigured() async throws {


### PR DESCRIPTION
[[iOS] Consider ways to surface authentication events and errors better from the pre built ui](https://linear.app/stytch/issue/SDK-2498/[ios]-consider-ways-to-surface-authentication-events-and-errors-better)

## Changes:

1. Since this pr: https://github.com/stytchauth/stytch-ios/pull/312, all core objects have their own publisher. Therefore the UI does not need to publish authentication events separately. It was previously attempting to publish the direct response from api calls, but with B2B that was not as possible since there are multiple types of responses and anything that you would hope to pull out of the response is independently available via one of the publishers or though the session objects.
2. The only thing that was missing was the UI surfacing error events so I created a separate publisher for error events.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
