### PR TITLE
Make jwt optional in SessionTokens

### DIFF
--- a/Sources/StytchCore/SessionManager.swift
+++ b/Sources/StytchCore/SessionManager.swift
@@ -75,7 +75,7 @@ class SessionManager {
 
         if let tokens = tokens {
             updatePersistentStorage(tokens: tokens)
-            tokens.jwt.updateCookie(cookieClient: cookieClient, expiresAt: sessionType.expiresAt, hostUrl: hostUrl)
+            tokens.jwt?.updateCookie(cookieClient: cookieClient, expiresAt: sessionType.expiresAt, hostUrl: hostUrl)
             tokens.opaque.updateCookie(cookieClient: cookieClient, expiresAt: sessionType.expiresAt, hostUrl: hostUrl)
         }
 

--- a/Sources/StytchCore/SharedModels/SessionToken.swift
+++ b/Sources/StytchCore/SharedModels/SessionToken.swift
@@ -72,15 +72,15 @@ public struct SessionToken: Equatable, Sendable {
 
 /// A public interface to require the caller to explicitly pass one of each type of non nil token in order to update a session.
 public struct SessionTokens: Sendable {
-    internal let jwt: SessionToken
+    internal let jwt: SessionToken?
     internal let opaque: SessionToken
 
     /// A nullable initializer that requires the caller to pass at least one non-nil instance of each token type.
     /// - Parameters:
     ///   - jwt: An instance of `SessionToken` with a `type` of `.jwt`
     ///   - opaque: An instance of `SessionToken` with a `type` of `.opaque`
-    public init?(jwt: SessionToken, opaque: SessionToken) {
-        if jwt.kind != .jwt, jwt.value.isEmpty == true {
+    public init?(jwt: SessionToken?, opaque: SessionToken) {
+        if let jwt = jwt, jwt.kind != .jwt, jwt.value.isEmpty == true {
             return nil
         }
 


### PR DESCRIPTION
[[iOS] updateSession - jwt_token should be optional](https://linear.app/stytch/issue/SDK-2507/[ios]-updatesession-jwt-token-should-be-optional)

the JWT is somewhat of a superfluous part of the iOS SDK. It is returned from authentication responses and we cache and expose it via the SDK but it is never used internally. This PR makes some changes around the `SessionTokens` object  that holds both tokens and the object that is used to "update" as session. Which is when you may have received tokens from outside the SDK for some reason and want to inject them into the SDK.

## Changes:

1. In the `SessionTokens` object make the `jwt` optional.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
