### PR TITLE
Update dfp client for iOS 15

### DIFF
--- a/Sources/StytchCore/DFPClient/DFPClient.swift
+++ b/Sources/StytchCore/DFPClient/DFPClient.swift
@@ -62,7 +62,10 @@ private final class MessageHandler: NSObject, WKScriptMessageHandler {
 
 private extension UIApplication {
     var rootViewController: UIViewController? {
-        UIApplication.shared.windows.first { $0.isKeyWindow }?.rootViewController
+        (connectedScenes.first { $0.activationState == .foregroundActive } as? UIWindowScene)?
+            .windows
+            .first { $0.isKeyWindow }?
+            .rootViewController
     }
 }
 


### PR DESCRIPTION
## Changes:

1. There was a warning in the DFP client after making the minimum target for the sdk iOS 15 that I fixed here, tested and it works.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
