### PR TITLE
Only clear session for unrecoverable error types

### DIFF
--- a/Sources/StytchCore/Networking/NetworkingRouter.swift
+++ b/Sources/StytchCore/Networking/NetworkingRouter.swift
@@ -119,7 +119,6 @@ public extension NetworkingRouter {
         }
     }
 
-    // swiftlint:disable:next function_body_length
     private func performRequest<Response: Decodable>(
         _ method: NetworkingClient.Method,
         route: Route,
@@ -172,9 +171,6 @@ public extension NetworkingRouter {
                 )
             }
             return dataContainer.data
-        } catch let error as StytchAPIError where error.statusCode == 401 {
-            sessionManager.resetSession()
-            throw error
         } catch {
             throw error
         }

--- a/Sources/StytchCore/SessionManager.swift
+++ b/Sources/StytchCore/SessionManager.swift
@@ -119,6 +119,16 @@ class SessionManager {
         }
     }
 
+    func resetSessionForUnrecoverableError(_ error: Error, forceClear: Bool = false) {
+        if forceClear == true {
+            resetSession()
+        }
+
+        if let stytchAPIError = error.stytchAPIError, stytchAPIError.isUnrecoverableErrorType == true {
+            resetSession()
+        }
+    }
+
     @objc func cookiesDidUpdate(notification: Notification) {
         let storage = (notification.object as? HTTPCookieStorage) ?? .shared
 

--- a/Sources/StytchCore/SharedModels/Errors/StytchAPIError.swift
+++ b/Sources/StytchCore/SharedModels/Errors/StytchAPIError.swift
@@ -22,6 +22,13 @@ public class StytchAPIError: StytchError, Decodable {
     public var url: URL? { errorUrl }
     private let errorUrl: URL?
 
+    public var isUnrecoverableErrorType: Bool {
+        errorType == .unauthorizedCredentials ||
+            errorType == .userUnauthenticated ||
+            errorType == .invalidSecretAuthentication ||
+            errorType == .sessionNotFound
+    }
+
     init(
         statusCode: Int,
         requestId: String? = nil,

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Sessions.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Sessions.swift
@@ -36,7 +36,12 @@ public extension StytchB2BClient {
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Wraps Stytch's [authenticate](https://stytch.com/docs/api/session-auth) Session endpoint and validates that the session issued to the user is still valid, returning both an opaque sessionToken and sessionJwt for this session. The sessionJwt will have a fixed lifetime of five minutes regardless of the underlying session duration, though it will be refreshed automatically in the background after a successful authentication.
         public func authenticate(parameters: AuthenticateParameters) async throws -> B2BAuthenticateResponse {
-            try await router.post(to: .authenticate, parameters: parameters)
+            do {
+                return try await router.post(to: .authenticate, parameters: parameters)
+            } catch {
+                sessionManager.resetSessionForUnrecoverableError(error)
+                throw error
+            }
         }
 
         /// If your app has cookies disabled or simply receives updated session tokens from your backend via means other than
@@ -54,7 +59,7 @@ public extension StytchB2BClient {
                 sessionManager.resetSession()
                 return response
             } catch {
-                if parameters.forceClear { sessionManager.resetSession() }
+                sessionManager.resetSessionForUnrecoverableError(error, forceClear: parameters.forceClear)
                 throw error
             }
         }


### PR DESCRIPTION
[[iOS][Android] Investigate which network failures should clear session](https://linear.app/stytch/issue/SDK-2368/[ios][android]-investigate-which-network-failures-should-clear-session)

## Changes:

This behavior moves from clearing the session on all 401s from any endpoint, regardless of error type,
to only clearing the session if we get a 401 with an unrecoverable error type, and only during session authenticate or session revoke calls.

Additionally, for revoke, we don't always clear the session on failure. We only clear it if:
- The error is unrecoverable, or
- The developer passes a forceClear flag to explicitly clear the session even if revoke fails.

This gives developers control over how strictly they want to enforce backend revocation.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
