### PR TITLE
Assign the tokens before we fire the session event

### DIFF
--- a/Sources/StytchCore/SessionManager.swift
+++ b/Sources/StytchCore/SessionManager.swift
@@ -66,17 +66,17 @@ class SessionManager {
         // If there is a valid sessionType then we should clear the IST because we are fully authenticated
         self.intermediateSessionToken = nil
 
+        if let tokens = tokens {
+            updatePersistentStorage(tokens: tokens)
+            tokens.jwt?.updateCookie(cookieClient: cookieClient, expiresAt: sessionType.expiresAt, hostUrl: hostUrl)
+            tokens.opaque.updateCookie(cookieClient: cookieClient, expiresAt: sessionType.expiresAt, hostUrl: hostUrl)
+        }
+
         switch sessionType {
         case let .member(session):
             memberSessionStorage.update(session)
         case let .user(session):
             sessionStorage.update(session)
-        }
-
-        if let tokens = tokens {
-            updatePersistentStorage(tokens: tokens)
-            tokens.jwt?.updateCookie(cookieClient: cookieClient, expiresAt: sessionType.expiresAt, hostUrl: hostUrl)
-            tokens.opaque.updateCookie(cookieClient: cookieClient, expiresAt: sessionType.expiresAt, hostUrl: hostUrl)
         }
 
         switch sessionType {


### PR DESCRIPTION
This is a small but important PR where we now assign the tokens before we publish the session objects. We were assigning them after we published and the tokens were nil if you logged them in the publisher from the sample app.