### PR TITLE
Remove checks for memberPasswordId

### DIFF
--- a/Sources/StytchUI/Inputs/EmailInput.swift
+++ b/Sources/StytchUI/Inputs/EmailInput.swift
@@ -26,15 +26,21 @@ final class EmailInput: TextInputView<EmailTextField> {
     }
 
     func updateText(_ text: String) {
-        textInput.text = text
+        Task { @MainActor in
+            textInput.text = text
+        }
     }
 
     func setReturnKeyType(returnKeyType: UIReturnKeyType) {
-        textInput.returnKeyType = returnKeyType
+        Task { @MainActor in
+            textInput.returnKeyType = returnKeyType
+        }
     }
 
     func assignFirstResponder() {
-        textInput.becomeFirstResponder()
+        Task { @MainActor in
+            textInput.becomeFirstResponder()
+        }
     }
 }
 

--- a/Sources/StytchUI/Inputs/PhoneNumberInput.swift
+++ b/Sources/StytchUI/Inputs/PhoneNumberInput.swift
@@ -36,11 +36,15 @@ final class PhoneNumberInput: TextInputView<PhoneNumberInputContainer> {
     }
 
     func setReturnKeyType(returnKeyType: UIReturnKeyType) {
-        textInput.textField.returnKeyType = returnKeyType
+        Task { @MainActor in
+            textInput.textField.returnKeyType = returnKeyType
+        }
     }
 
     func assignFirstResponder() {
-        textInput.textField.becomeFirstResponder()
+        Task { @MainActor in
+            textInput.textField.becomeFirstResponder()
+        }
     }
 }
 

--- a/Sources/StytchUI/Inputs/SecureTextInput.swift
+++ b/Sources/StytchUI/Inputs/SecureTextInput.swift
@@ -74,31 +74,41 @@ final class SecureTextInput: TextInputView<SecureTextField> {
     }
 
     func setZXCVBNFeedback(suggestions: [String]?, warning: String?, score: Int) {
-        feedback.isHidden = false
-        zxcvbnIndicatorView.isHidden = false
-        ludsIndicatorView.isHidden = true
-        zxcvbnIndicator.setFeedback(suggestions: suggestions, warning: warning, score: score)
-        didSetFeedback()
+        Task { @MainActor in
+            feedback.isHidden = false
+            zxcvbnIndicatorView.isHidden = false
+            ludsIndicatorView.isHidden = true
+            zxcvbnIndicator.setFeedback(suggestions: suggestions, warning: warning, score: score)
+            didSetFeedback()
+        }
     }
 
     func setLUDSFeedback(ludsRequirement: LudsRequirement, breached: Bool = false, passwordConfig: PasswordConfig? = nil) {
-        feedback.isHidden = false
-        zxcvbnIndicatorView.isHidden = true
-        ludsIndicatorView.isHidden = false
-        ludsIndicator.setFeedback(feedback: ludsRequirement, breached: breached, passwordConfig: passwordConfig)
-        didSetFeedback()
+        Task { @MainActor in
+            feedback.isHidden = false
+            zxcvbnIndicatorView.isHidden = true
+            ludsIndicatorView.isHidden = false
+            ludsIndicator.setFeedback(feedback: ludsRequirement, breached: breached, passwordConfig: passwordConfig)
+            didSetFeedback()
+        }
     }
 
     func updateText(_ text: String) {
-        textInput.text = text
+        Task { @MainActor in
+            textInput.text = text
+        }
     }
 
     func setReturnKeyType(returnKeyType: UIReturnKeyType) {
-        textInput.returnKeyType = returnKeyType
+        Task { @MainActor in
+            textInput.returnKeyType = returnKeyType
+        }
     }
 
     func assignFirstResponder() {
-        textInput.becomeFirstResponder()
+        Task { @MainActor in
+            textInput.becomeFirstResponder()
+        }
     }
 }
 

--- a/Sources/StytchUI/StytchB2BUIClient/Shared/B2BPasswordsViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/Shared/B2BPasswordsViewModel.swift
@@ -63,8 +63,7 @@ final class B2BPasswordsViewModel {
 
         Task {
             do {
-                let member = try? await AuthenticationOperations.searchMember(emailAddress: emailAddress)
-                if let memberPasswordId = member?.memberPasswordId, memberPasswordId.isEmpty == false {
+                if let member = try? await AuthenticationOperations.searchMember(emailAddress: emailAddress) {
                     let parameters = StytchB2BClient.Passwords.AuthenticateParameters(
                         organizationId: Organization.ID(rawValue: organizationId),
                         emailAddress: emailAddress,

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailConfirmationViewController/EmailConfirmationViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/EmailConfirmationViewController/EmailConfirmationViewModel.swift
@@ -14,8 +14,7 @@ final class EmailConfirmationViewModel {
         if state.configuration.computedAuthFlowType == .discovery {
             try await AuthenticationOperations.discoveryResetPasswordByEmailStart(configuration: state.configuration, emailAddress: emailAddress)
         } else {
-            let member = try await AuthenticationOperations.searchMember(emailAddress: emailAddress)
-            if let memberPasswordId = member?.memberPasswordId, memberPasswordId.isEmpty == false {
+            if let member = try await AuthenticationOperations.searchMember(emailAddress: emailAddress) {
                 try await AuthenticationOperations.organizationResetPasswordByEmailStart(configuration: state.configuration, emailAddress: emailAddress)
             } else {
                 try await AuthenticationOperations.sendEmailMagicLinkIfPossible(configuration: state.configuration, emailAddress: emailAddress)

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordForgotViewController/PasswordForgotViewModel.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/PasswordForgotViewController/PasswordForgotViewModel.swift
@@ -29,8 +29,7 @@ final class PasswordForgotViewModel {
     func organizationResetPasswordByEmail(_ emailAddress: String) {
         Task {
             do {
-                let member = try await AuthenticationOperations.searchMember(emailAddress: emailAddress)
-                if let memberPasswordId = member?.memberPasswordId, memberPasswordId.isEmpty == false {
+                if let member = try await AuthenticationOperations.searchMember(emailAddress: emailAddress) {
                     try await AuthenticationOperations.organizationResetPasswordByEmailStart(configuration: state.configuration, emailAddress: emailAddress)
                     delegate?.didSendResetByEmailStart()
                 } else {

--- a/Stytch/DemoApps/StytchB2BUIDemo/ContentView.swift
+++ b/Stytch/DemoApps/StytchB2BUIDemo/ContentView.swift
@@ -48,7 +48,7 @@ struct ContentView: View {
 
 class ContentViewModel: ObservableObject {
     // To hard-code the publicToken or orgSlug instead of inputting it through the UI, set it here.
-    @Published var publicToken: String = ""
+    @Published var publicToken: String = "public-token-test-..."
     @Published var orgSlug: String = ""
 
     @Published var isShowingB2BUI: Bool = false

--- a/Stytch/DemoApps/StytchB2BUIDemo/Info.plist
+++ b/Stytch/DemoApps/StytchB2BUIDemo/Info.plist
@@ -9,7 +9,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>stytchui-your-public-token</string>
+				<string>stytchui-public-token-test-...</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
[[iOS] Fix erroneous JIT provisioning error in B2B UI SDK](https://linear.app/stytch/issue/SDK-2589/[ios]-fix-erroneous-jit-provisioning-error-in-b2b-ui-sdk)

## Changes:

1. Modify logic to no longer check for memberPasswordId if the search member call returns a member. The existence of a member is enough to attempt password authenticate or send a password reset email.
2. Also found some UI operations in the text fields that we not happening on the main thread.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
