### PR TITLE
Fix NetworkingClient logic for dfppa

### DIFF
--- a/Sources/StytchCore/Networking/NetworkingClient+Live.swift
+++ b/Sources/StytchCore/Networking/NetworkingClient+Live.swift
@@ -10,20 +10,22 @@ extension NetworkingClient {
 
         return .init { request, dfpEnabled, dfpAuthMode, publicToken, dfppaDomain, useDFPPA in
             #if os(iOS)
-            if request.url?.path.contains("/events") == true {
-                return try await defaultRequestHandler(session: session, request: request)
-            }
-            if dfpEnabled == true, useDFPPA == true {
-                switch dfpAuthMode {
-                case .observation:
-                    return try await networkRequestHandler.handleDFPObservationMode(session: session, request: request, publicToken: publicToken, dfppaDomain: dfppaDomain, captcha: captcha, dfp: dfpClient, requestHandler: defaultRequestHandler)
-                case .decisioning:
-                    return try await networkRequestHandler.handleDFPDecisioningMode(session: session, request: request, publicToken: publicToken, dfppaDomain: dfppaDomain, captcha: captcha, dfp: dfpClient, requestHandler: defaultRequestHandler)
+            if useDFPPA == true {
+                if dfpEnabled == true {
+                    switch dfpAuthMode {
+                    case .observation:
+                        return try await networkRequestHandler.handleDFPObservationMode(session: session, request: request, publicToken: publicToken, dfppaDomain: dfppaDomain, captcha: captcha, dfp: dfpClient, requestHandler: defaultRequestHandler)
+                    case .decisioning:
+                        return try await networkRequestHandler.handleDFPDecisioningMode(session: session, request: request, publicToken: publicToken, dfppaDomain: dfppaDomain, captcha: captcha, dfp: dfpClient, requestHandler: defaultRequestHandler)
+                    }
+                } else {
+                    return try await networkRequestHandler.handleDFPDisabled(session: session, request: request, captcha: captcha, requestHandler: defaultRequestHandler)
                 }
             } else {
-                return try await networkRequestHandler.handleDFPDisabled(session: session, request: request, captcha: captcha, requestHandler: defaultRequestHandler)
+                return try await defaultRequestHandler(session: session, request: request)
             }
             #endif
+
             return try await defaultRequestHandler(session: session, request: request)
         }
     }

--- a/Tests/StytchCoreTests/NetworkingClient+LiveTestCase.swift
+++ b/Tests/StytchCoreTests/NetworkingClient+LiveTestCase.swift
@@ -30,7 +30,7 @@ final class NetworkingClientLiveTestCase: XCTestCase {
         let client = NetworkingClient.live(networkRequestHandler: handler)
         client.dfpEnabled = false
         client.dfpAuthMode = DFPProtectedAuthMode.observation
-        _ = try await client.performRequest(.get, url: XCTUnwrap(URL(string: "https://www.stytch.com")), useDFPPA: false)
+        _ = try await client.performRequest(.get, url: XCTUnwrap(URL(string: "https://www.stytch.com")), useDFPPA: true)
         #if !os(iOS)
         XCTAssert(handler.methodCalled == nil)
         #else


### PR DESCRIPTION
## Changes:

1. Modify the logic the in `NetworkingClient+Live` to only configure an endpoint for DFPPA disabled if the endpoint uses DFPPA but its disabled from the bootstrap call.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
