### PR TITLE
Run bootstrap and sessions.authenticate in parallel on start

### DIFF
--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -13,8 +13,20 @@ import UIKit
  */
 public struct StytchB2BClient: StytchClientType {
     static var instance: StytchB2BClient = .init()
-    static let router: NetworkingRouter<BaseRoute> = .init { instance.configuration }
-    public static var isInitialized: AnyPublisher<Bool, Never> { StartupClient.isInitialized }
+
+    static let router: NetworkingRouter<BaseRoute> = .init {
+        instance.configuration
+    }
+
+    /**
+     Signals that the SDK is fully initialized and ready for use.
+     This is sent after two parallel tasks complete:
+     1. Attempting to call sessions.authenticate (if there's a session token cached on the device).
+     2. Bootstrapping configuration, including DFP and captcha setup.
+     */
+    public static var isInitialized: AnyPublisher<Bool, Never> {
+        StartupClient.isInitialized
+    }
 
     public static var lastAuthMethodUsed: B2BAuthMethod {
         Current.sessionManager.b2bLastAuthMethodUsed

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -14,10 +14,27 @@ import UIKit
  */
 public struct StytchClient: StytchClientType {
     static var instance: StytchClient = .init()
-    static var router: NetworkingRouter<BaseRoute> = .init { instance.configuration }
-    public static var isInitialized: AnyPublisher<Bool, Never> { StartupClient.isInitialized }
+
+    static var router: NetworkingRouter<BaseRoute> = .init {
+        instance.configuration
+    }
+
+    /**
+     Signals that the SDK is fully initialized and ready for use.
+     This is sent after two parallel tasks complete:
+     1. Attempting to call sessions.authenticate (if there's a session token cached on the device).
+     2. Bootstrapping configuration, including DFP and captcha setup.
+     */
+    public static var isInitialized: AnyPublisher<Bool, Never> {
+        StartupClient.isInitialized
+    }
+
     // swiftlint:disable:next identifier_name
-    public static var _uiRouter: NetworkingRouter<UIRoute> { router.scopedRouter { $0.ui } }
+    public static var _uiRouter: NetworkingRouter<UIRoute> {
+        router.scopedRouter {
+            $0.ui
+        }
+    }
 
     public static var lastAuthMethodUsed: ConsumerAuthMethod {
         Current.sessionManager.consumerLastAuthMethodUsed


### PR DESCRIPTION
[[iOS] Look into performance improvements for configure call](https://linear.app/stytch/issue/SDK-2603/[ios]-look-into-performance-improvements-for-configure-call)
[[iOS] Add details to the documentation for "isInitialized"](https://linear.app/stytch/issue/SDK-2600/[ios]-add-details-to-the-documentation-for-isinitialized)

## Changes:

1. The `sessions.authenticate` call and the `bootstrap` call do not need to happen in sequence as they were happening now.
2. `sessions.authenticate` does not require dfppa or captcha so we can safely kick off `sessions.authenticate` in parallel. 
3. This bring down the time for the `isInitializedPublisher` by about 150ms.

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A
