### PR TITLE
Refactor NetworkRequestHandler

### DIFF
--- a/Sources/StytchCore/Networking/NetworkRequestHandler.swift
+++ b/Sources/StytchCore/Networking/NetworkRequestHandler.swift
@@ -1,69 +1,100 @@
 import Foundation
 
+// swiftlint:disable type_contents_order
+
 internal protocol NetworkRequestHandler {
+    var urlSession: URLSession { get }
+
+    init(urlSession: URLSession)
+
     #if os(iOS)
-    func handleDFPDisabled(session: URLSession, request: URLRequest, captcha: CaptchaProvider, requestHandler: (URLSession, URLRequest) async throws -> (Data, HTTPURLResponse)) async throws -> (Data, HTTPURLResponse)
+    var captchaProvider: CaptchaProvider { get }
+    var dfpProvider: DFPProvider { get }
 
-    // swiftlint:disable:next function_parameter_count
-    func handleDFPObservationMode(session: URLSession, request: URLRequest, publicToken: String, dfppaDomain: String, captcha: CaptchaProvider, dfp: DFPProvider, requestHandler: (URLSession, URLRequest) async throws -> (Data, HTTPURLResponse)) async throws -> (Data, HTTPURLResponse)
-
-    // swiftlint:disable:next function_parameter_count
-    func handleDFPDecisioningMode(session: URLSession, request: URLRequest, publicToken: String, dfppaDomain: String, captcha: CaptchaProvider, dfp: DFPProvider, requestHandler: (URLSession, URLRequest) async throws -> (Data, HTTPURLResponse)) async throws -> (Data, HTTPURLResponse)
+    func handleDFPDisabled(request: URLRequest) async throws -> (Data, HTTPURLResponse)
+    func handleDFPObservationMode(request: URLRequest, publicToken: String, dfppaDomain: String) async throws -> (Data, HTTPURLResponse)
+    func handleDFPDecisioningMode(request: URLRequest, publicToken: String, dfppaDomain: String) async throws -> (Data, HTTPURLResponse)
     #endif
+
+    func defaultRequestHandler(_ request: URLRequest) async throws -> (Data, HTTPURLResponse)
 }
 
-internal struct NetworkRequestHandlerImplementation: NetworkRequestHandler {
+extension NetworkRequestHandler {
     #if os(iOS)
-    func handleDFPDisabled(session: URLSession, request: URLRequest, captcha: CaptchaProvider, requestHandler: (URLSession, URLRequest) async throws -> (Data, HTTPURLResponse)) async throws -> (Data, HTTPURLResponse) {
+    func handleDFPDisabled(request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         // DISABLED = if captcha client is configured, add a captcha token, else do nothing
-        if captcha.isConfigured() == false {
-            return try await requestHandler(session, request)
+        if captchaProvider.isConfigured() == false {
+            return try await defaultRequestHandler(request)
         }
         var newRequest = request
         if request.httpMethod != "GET", request.httpMethod != "DELETE" {
             let oldBody = newRequest.httpBody ?? Data("{}".utf8)
             var newBody = try JSONSerialization.jsonObject(with: oldBody) as? [String: AnyObject] ?? [:]
-            newBody["captcha_token"] = await captcha.executeRecaptcha() as AnyObject
+            newBody["captcha_token"] = await captchaProvider.executeRecaptcha() as AnyObject
             newRequest.httpBody = try JSONSerialization.data(withJSONObject: newBody)
         }
-        return try await requestHandler(session, newRequest)
+        return try await defaultRequestHandler(newRequest)
     }
 
-    // swiftlint:disable:next function_parameter_count
-    func handleDFPObservationMode(session: URLSession, request: URLRequest, publicToken: String, dfppaDomain: String, captcha: CaptchaProvider, dfp: DFPProvider, requestHandler: (URLSession, URLRequest) async throws -> (Data, HTTPURLResponse)) async throws -> (Data, HTTPURLResponse) {
+    func handleDFPObservationMode(request: URLRequest, publicToken: String, dfppaDomain: String) async throws -> (Data, HTTPURLResponse) {
         // OBSERVATION = Always DFP; CAPTCHA if configured
         var newRequest = request
         let oldBody = newRequest.httpBody ?? Data("{}".utf8)
         var newBody = try JSONSerialization.jsonObject(with: oldBody) as? [String: AnyObject] ?? [:]
-        let telemetryId = await dfp.getTelemetryId(publicToken: publicToken, dfppaDomain: dfppaDomain) as AnyObject
+        let telemetryId = await dfpProvider.getTelemetryId(publicToken: publicToken, dfppaDomain: dfppaDomain) as AnyObject
         newBody["dfp_telemetry_id"] = telemetryId
-        if captcha.isConfigured() {
-            newBody["captcha_token"] = await captcha.executeRecaptcha() as AnyObject
+        if captchaProvider.isConfigured() {
+            newBody["captcha_token"] = await captchaProvider.executeRecaptcha() as AnyObject
         }
         newRequest.httpBody = try JSONSerialization.data(withJSONObject: newBody)
-        return try await requestHandler(session, newRequest)
+        return try await defaultRequestHandler(newRequest)
     }
 
-    // swiftlint:disable:next function_parameter_count
-    func handleDFPDecisioningMode(session: URLSession, request: URLRequest, publicToken: String, dfppaDomain: String, captcha: CaptchaProvider, dfp: DFPProvider, requestHandler: (URLSession, URLRequest) async throws -> (Data, HTTPURLResponse)) async throws -> (Data, HTTPURLResponse) {
+    func handleDFPDecisioningMode(request: URLRequest, publicToken: String, dfppaDomain: String) async throws -> (Data, HTTPURLResponse) {
         // DECISIONING = add DFP Id, proceed; if request 403s, add a captcha token
         var firstRequest = request
         let oldBody = firstRequest.httpBody ?? Data("{}".utf8)
         var firstRequestBody = try JSONSerialization.jsonObject(with: oldBody) as? [String: AnyObject] ?? [:]
-        let telemetryId1 = await dfp.getTelemetryId(publicToken: publicToken, dfppaDomain: dfppaDomain) as AnyObject
+        let telemetryId1 = await dfpProvider.getTelemetryId(publicToken: publicToken, dfppaDomain: dfppaDomain) as AnyObject
         firstRequestBody["dfp_telemetry_id"] = telemetryId1
         firstRequest.httpBody = try JSONSerialization.data(withJSONObject: firstRequestBody)
-        let (data, response) = try await requestHandler(session, firstRequest)
+        let (data, response) = try await defaultRequestHandler(firstRequest)
         if response.statusCode != 403 {
             return (data, response)
         }
         var secondRequest = request
         var secondRequestBody = try JSONSerialization.jsonObject(with: oldBody) as? [String: AnyObject] ?? [:]
-        let telemetryId2 = await dfp.getTelemetryId(publicToken: publicToken, dfppaDomain: dfppaDomain) as AnyObject
+        let telemetryId2 = await dfpProvider.getTelemetryId(publicToken: publicToken, dfppaDomain: dfppaDomain) as AnyObject
         secondRequestBody["dfp_telemetry_id"] = telemetryId2
-        secondRequestBody["captcha_token"] = await captcha.executeRecaptcha() as AnyObject
+        secondRequestBody["captcha_token"] = await captchaProvider.executeRecaptcha() as AnyObject
         secondRequest.httpBody = try JSONSerialization.data(withJSONObject: secondRequestBody)
-        return try await requestHandler(session, secondRequest)
+        return try await defaultRequestHandler(secondRequest)
     }
     #endif
+}
+
+internal struct NetworkRequestHandlerImplementation: NetworkRequestHandler {
+    let urlSession: URLSession
+
+    #if os(iOS)
+    var captchaProvider: CaptchaProvider {
+        Current.captcha
+    }
+
+    var dfpProvider: DFPProvider {
+        Current.dfpClient
+    }
+    #endif
+
+    init(urlSession: URLSession) {
+        self.urlSession = urlSession
+    }
+
+    func defaultRequestHandler(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let (data, response) = try await urlSession.data(for: request)
+        guard let response = response as? HTTPURLResponse else {
+            throw StytchAPISchemaError(message: "Request does not match expected schema.")
+        }
+        return (data, response)
+    }
 }


### PR DESCRIPTION
[[iOS] Refactor NetworkingClient](https://linear.app/stytch/issue/SDK-2500/[ios]-refactor-networkingclient)

Part of incremental progress in refactoring networking.

## Changes:

1. Consolidate request handling into `NetworkRequestHandler` including the `defaultRequestHandler`.
2. Move properties into protocol definition so that we are not passing everything into each function call.
3. Use the `NetworkRequestHandler` extension as the default / live implementation.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
