### PR TITLE
Show faceid prompt on register

### DIFF
--- a/Resources/Sourcery/Templates/AsyncVariants.stencil
+++ b/Resources/Sourcery/Templates/AsyncVariants.stencil
@@ -5,8 +5,9 @@
 import Combine
 import Foundation
 
-{% set excludeWatchOS %}#if !os(watchOS){% endset %}
-{% if type.annotations.ExcludeWatchOS %}{{ excludeWatchOS }}{% elif method.annotations.ExcludeWatchOS %}{{ excludeWatchOS }}{% endif %}
+{% if type.annotations.ExcludeWatchOS or method.annotations.ExcludeWatchOS or type.annotations.ExcludeTVOS or method.annotations.ExcludeTVOS or type.annotations.ExcludeWatchAndTVOS or method.annotations.ExcludeWatchAndTVOS %}
+#if {% if type.annotations.ExcludeWatchOS or method.annotations.ExcludeWatchOS or type.annotations.ExcludeWatchAndTVOS or method.annotations.ExcludeWatchAndTVOS %}!os(watchOS){% endif %}{% if (type.annotations.ExcludeWatchOS or method.annotations.ExcludeWatchOS or type.annotations.ExcludeWatchAndTVOS or method.annotations.ExcludeWatchAndTVOS) and (type.annotations.ExcludeTVOS or method.annotations.ExcludeTVOS or type.annotations.ExcludeWatchAndTVOS or method.annotations.ExcludeWatchAndTVOS) %} && {% endif %}{% if type.annotations.ExcludeTVOS or method.annotations.ExcludeTVOS or type.annotations.ExcludeWatchAndTVOS or method.annotations.ExcludeWatchAndTVOS %}!os(tvOS){% endif %}
+{% endif %}
 {% for attribute in type.attributes.available %}{{ attribute }}{% endfor %}
 public extension {{ type.name }} {
 {% set methodKeywords %}{% if method.isClass %}class {% elif method.isStatic %}static {% endif %}func{% endset %}
@@ -47,8 +48,9 @@ public extension {{ type.name }} {
         .eraseToAnyPublisher()
     }
 }
-{% set excludeWatchOS %}#endif{% endset %}
-{% if type.annotations.ExcludeWatchOS %}{{ excludeWatchOS }}{% elif method.annotations.ExcludeWatchOS %}{{ excludeWatchOS }}{% endif %}
+{% if type.annotations.ExcludeWatchOS or method.annotations.ExcludeWatchOS or type.annotations.ExcludeTVOS or method.annotations.ExcludeTVOS or type.annotations.ExcludeWatchAndTVOS or method.annotations.ExcludeWatchAndTVOS %}
+#endif
+{% endif %}
 
 // sourcery:end
 {% endfor %}

--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -5,6 +5,10 @@ import AppKit
 import UIKit
 #endif
 
+#if !os(tvOS) && !os(watchOS)
+import LocalAuthentication
+#endif
+
 // swiftlint:disable identifier_name
 #if DEBUG
 var Current: Environment = .init()
@@ -110,6 +114,10 @@ struct Environment {
     #if os(iOS)
     var dfpClient: DFPProvider = DFPClient()
     var captcha: CaptchaProvider = CaptchaClient()
+    #endif
+
+    #if !os(tvOS) && !os(watchOS)
+    var localAuthenticationContext: LAContextEvaluating = LAContext()
     #endif
 
     var pkcePairManager: PKCEPairManager {

--- a/Sources/StytchCore/Generated/StytchClient.Biometrics.authenticate+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.Biometrics.authenticate+AsyncVariants.generated.swift
@@ -3,6 +3,7 @@
 import Combine
 import Foundation
 
+#if !os(watchOS) && !os(tvOS)
 public extension StytchClient.Biometrics {
     /// If a valid biometric registration exists, this method confirms the current device owner via the device's built-in biometric reader and returns an updated session object by either starting a new session or adding a the biometric factor to an existing session.
     func authenticate(parameters: AuthenticateParameters, completion: @escaping Completion<AuthenticateResponse>) {
@@ -31,3 +32,4 @@ public extension StytchClient.Biometrics {
         .eraseToAnyPublisher()
     }
 }
+#endif

--- a/Sources/StytchCore/Generated/StytchClient.Biometrics.register+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.Biometrics.register+AsyncVariants.generated.swift
@@ -3,6 +3,7 @@
 import Combine
 import Foundation
 
+#if !os(watchOS) && !os(tvOS)
 public extension StytchClient.Biometrics {
     /// When a valid/active session exists, this method will add a biometric registration for the current user. The user will later be able to start a new session with biometrics or use biometrics as an additional authentication factor.
     /// 
@@ -35,3 +36,4 @@ public extension StytchClient.Biometrics {
         .eraseToAnyPublisher()
     }
 }
+#endif

--- a/Sources/StytchCore/Generated/StytchClient.Biometrics.removeRegistration+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.Biometrics.removeRegistration+AsyncVariants.generated.swift
@@ -3,6 +3,7 @@
 import Combine
 import Foundation
 
+#if !os(watchOS) && !os(tvOS)
 public extension StytchClient.Biometrics {
     /// Removes the current device's existing biometric registration from both the device itself and from the server.
     func removeRegistration(completion: @escaping Completion<Void>) {
@@ -31,3 +32,4 @@ public extension StytchClient.Biometrics {
         .eraseToAnyPublisher()
     }
 }
+#endif

--- a/Sources/StytchCore/SharedModels/Errors/StytchSDKError.swift
+++ b/Sources/StytchCore/SharedModels/Errors/StytchSDKError.swift
@@ -63,6 +63,18 @@ public extension StytchSDKError {
             errorType: "biometrics_already_enrolled"
         )
     )
+    static let biometricsUnavailable = StytchSDKError(
+        message: "Biometric authentication is unavailable on this device. Check device settings and try again.",
+        options: .init(
+            errorType: "biometrics_unavailable"
+        )
+    )
+    static let biometricAuthenticationFailed = StytchSDKError(
+        message: "Biometric authentication failed. Please try again.",
+        options: .init(
+            errorType: "biometric_authentication_failed"
+        )
+    )
     static let invalidAuthorizationCredential = StytchSDKError(
         message: "The authorization credential is invalid. Verify that OAuth is set up correctly in the developer console, and call the start flow method.",
         options: .init(

--- a/Sources/StytchCore/StytchClient/Biometrics/LAContextEvaluating.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/LAContextEvaluating.swift
@@ -1,0 +1,16 @@
+#if !os(tvOS) && !os(watchOS)
+import LocalAuthentication
+
+/// A protocol abstraction over `LAContext` to enable unit testing of biometric logic.
+///
+/// Direct usage of `LAContext` in tests is impractical because `canEvaluatePolicy`
+/// and `evaluatePolicy` depend on actual device hardware and biometric configuration.
+/// By conforming `LAContext` to this protocol and providing a mock implementation,
+/// we can inject a controllable context into our biometric flow for reliable testing.
+protocol LAContextEvaluating {
+    func canEvaluatePolicy(_ policy: LAPolicy, error: NSErrorPointer) -> Bool
+    func evaluatePolicy(_ policy: LAPolicy, localizedReason: String) async throws -> Bool
+}
+
+extension LAContext: LAContextEvaluating {}
+#endif

--- a/Stytch/DemoApps/StytchUIDemo/ContentView.swift
+++ b/Stytch/DemoApps/StytchUIDemo/ContentView.swift
@@ -9,11 +9,7 @@ struct ContentView: View {
     var body: some View {
         NavigationView {
             VStack(spacing: 20) {
-                Button("Log In With Stytch!") {
-                    viewModel.shouldShowB2CUI = true
-                }.font(.title).bold()
-
-                if viewModel.shouldShowB2CUI == false {
+                if viewModel.isAuthenticated == true {
                     Text("You have logged in with Stytch!")
                         .font(.largeTitle)
                         .bold()
@@ -21,6 +17,10 @@ struct ContentView: View {
 
                     Button("Log Out") {
                         logOut()
+                    }.font(.title).bold()
+                } else {
+                    Button("Log In With Stytch!") {
+                        viewModel.shouldShowB2CUI = true
                     }.font(.title).bold()
                 }
             }
@@ -48,6 +48,7 @@ struct ContentView: View {
 
 class ContentViewModel: ObservableObject {
     @Published var shouldShowB2CUI: Bool = false
+    @Published var isAuthenticated: Bool = false
     private var cancellables = Set<AnyCancellable>()
     var date = Date()
 
@@ -70,10 +71,11 @@ class ContentViewModel: ObservableObject {
                     print("Session Available: \(session.expiresAt) - lastValidatedAtDate: \(lastValidatedAtDate)\n")
                     print("StytchClient.sessions.sessionToken: \(StytchClient.sessions.sessionToken?.value ?? "no sessionToken")")
                     print("StytchClient.sessions.sessionJwt: \(StytchClient.sessions.sessionJwt?.value ?? "no sessionJwt")")
+                    self?.isAuthenticated = true
                     self?.shouldShowB2CUI = false
                 case .unavailable:
                     print("Session Unavailable\n")
-                    self?.shouldShowB2CUI = true
+                    self?.isAuthenticated = false
                 }
             }.store(in: &cancellables)
 

--- a/Tests/StytchCoreTests/BaseTestCase.swift
+++ b/Tests/StytchCoreTests/BaseTestCase.swift
@@ -46,6 +46,10 @@ class BaseTestCase: XCTestCase {
 
         Current.sessionManager.consumerLastAuthMethodUsed = StytchClient.ConsumerAuthMethod.unknown
         Current.sessionManager.b2bLastAuthMethodUsed = StytchB2BClient.B2BAuthMethod.unknown
+
+        #if !os(tvOS) && !os(watchOS)
+        Current.localAuthenticationContext = MockLocalAuthenticationContext()
+        #endif
     }
 }
 
@@ -173,3 +177,23 @@ extension XCTestCase {
         }
     }
 }
+
+#if !os(tvOS) && !os(watchOS)
+import LocalAuthentication
+class MockLocalAuthenticationContext: LAContextEvaluating {
+    var canEvaluate = true
+    var shouldSucceed = true
+    var thrownError: Error?
+
+    func canEvaluatePolicy(_: LAPolicy, error _: NSErrorPointer) -> Bool {
+        canEvaluate
+    }
+
+    func evaluatePolicy(_: LAPolicy, localizedReason _: String) async throws -> Bool {
+        if let error = thrownError {
+            throw error
+        }
+        return shouldSucceed
+    }
+}
+#endif


### PR DESCRIPTION
[[iOS] Biometrics - Show biometrics prompt on register.](https://linear.app/stytch/issue/SDK-2679/ios-biometrics-show-biometrics-prompt-on-register)

## Changes:

1. When the developer calls register we should show the biometrics prompt.
2. Added a protocol for testing called `LAContextEvaluating` that `LAContext` can conform to by default. Which made it possible to mock the methods within `LAContext`.
3. Added an instance of `LAContextEvaluating` to the `Environment` called `localAuthenticationContext` which in live is just an instance of `LAContext`.
4. Modified the Sorcery template to include an option to add a compiler directive to exclude bot `watchOS` and `tvOS`, before you could only exclude `watchOS`.
5. Remove redundant `AccessPolicy` from the `StytchClient.Biometrics.RegisterParameters` and instead just use an instance of `LAPolicy`.
6. Improved logic for the consumer UI sample app.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
