### PR TITLE
Add Biometrics To The Consumer Prebuilt UI

### DIFF
--- a/Sources/StytchCore/StytchClient/Biometrics/LAContextEvaluating.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/LAContextEvaluating.swift
@@ -8,6 +8,8 @@ import LocalAuthentication
 /// By conforming `LAContext` to this protocol and providing a mock implementation,
 /// we can inject a controllable context into our biometric flow for reliable testing.
 protocol LAContextEvaluating {
+    var biometryType: LABiometryType { get }
+
     func canEvaluatePolicy(_ policy: LAPolicy, error: NSErrorPointer) -> Bool
     func evaluatePolicy(_ policy: LAPolicy, localizedReason: String) async throws -> Bool
 }

--- a/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
@@ -7,6 +7,21 @@ public extension StytchClient.Biometrics {
         case systemUnavailable(LAError.Code?)
         case availableNoRegistration
         case availableRegistered
+
+        public var isSystemUnavailable: Bool {
+            if case .systemUnavailable = self { return true }
+            return false
+        }
+
+        public var isAvailableNoRegistration: Bool {
+            if case .availableNoRegistration = self { return true }
+            return false
+        }
+
+        public var isAvailableRegistered: Bool {
+            if case .availableRegistered = self { return true }
+            return false
+        }
     }
 }
 
@@ -57,6 +72,12 @@ public extension StytchClient {
             case (true, true):
                 return .availableRegistered
             }
+        }
+
+        /// Returns the type of biometric authentication available on the device. touchID or faceID
+        public var biometryType: LABiometryType {
+            _ = localAuthenticationContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
+            return localAuthenticationContext.biometryType
         }
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)

--- a/Sources/StytchUI/Components/ImageAsset.swift
+++ b/Sources/StytchUI/Components/ImageAsset.swift
@@ -6,6 +6,8 @@ enum ImageAsset {
     case b2bOauthIcon(StytchB2BClient.OAuth.ThirdParty.Provider)
     case sso(String)
     case poweredByStytch
+    case biometricsFaceID
+    case biometricsTouchID
 
     var image: UIImage? {
         let imageName: String
@@ -18,6 +20,10 @@ enum ImageAsset {
             imageName = provider.lowercased()
         case .poweredByStytch:
             imageName = "poweredbystytch"
+        case .biometricsFaceID:
+            return UIImage(systemName: "faceid")
+        case .biometricsTouchID:
+            return UIImage(systemName: "touchid")
         }
         return .init(named: imageName, in: .module, compatibleWith: nil)
     }

--- a/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
+++ b/Sources/StytchUI/StytchB2BUIClient/ViewControllers/B2BAuthRootViewController.swift
@@ -78,7 +78,7 @@ extension B2BAuthRootViewController {
 
             let loadingView = UIView()
             // swiftlint:disable:next object_literal
-            loadingView.backgroundColor = UIColor(white: 1.0, alpha: 0.2)
+            loadingView.backgroundColor = UIColor(white: 1.0, alpha: 0.5)
             loadingView.translatesAutoresizingMaskIntoConstraints = false
 
             let activityIndicator = UIActivityIndicatorView(style: .large)
@@ -94,7 +94,7 @@ extension B2BAuthRootViewController {
                 loadingView.topAnchor.constraint(equalTo: view.topAnchor),
                 loadingView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
                 activityIndicator.centerXAnchor.constraint(equalTo: loadingView.centerXAnchor),
-                activityIndicator.centerYAnchor.constraint(equalTo: loadingView.centerYAnchor),
+                activityIndicator.centerYAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor),
             ])
 
             self.loadingView = loadingView

--- a/Sources/StytchUI/StytchUIClient/StytchUIClient+Configuration.swift
+++ b/Sources/StytchUI/StytchUIClient/StytchUIClient+Configuration.swift
@@ -16,12 +16,9 @@ public extension StytchUIClient {
         public let passwordOptions: PasswordOptions?
         public let magicLinkOptions: MagicLinkOptions?
         public let otpOptions: OTPOptions?
+        public let biometricsOptions: BiometricsOptions
         public let theme: StytchTheme
         public let locale: StytchLocale
-
-        public var inputProductsEnabled: Bool {
-            products.contains(.passwords) || products.contains(.emailMagicLinks) || products.contains(.otp)
-        }
 
         public var redirectUrl: URL? {
             URL(string: "stytchui-\(stytchClientConfiguration.publicToken)://deeplink")
@@ -43,6 +40,18 @@ public extension StytchUIClient {
             products.contains(.passwords)
         }
 
+        public var supportsBiometrics: Bool {
+            products.contains(.biometrics)
+        }
+
+        public var supportsBiometricsAndOAuth: Bool {
+            supportsBiometrics && supportsOauth
+        }
+
+        public var supportsInputProducts: Bool {
+            products.contains(.passwords) || products.contains(.emailMagicLinks) || products.contains(.otp)
+        }
+
         /// - Parameters:
         ///   - stytchClientConfiguration: A flexible and extensible object used to configure the core `StychClient` requiring at least a public token, with optional additional settings.
         ///   - products: The products array allows you to specify the authentication methods that you would like to expose to your users.
@@ -53,6 +62,7 @@ public extension StytchUIClient {
         ///   - passwordOptions: The password options to use if you have a custom configuration.
         ///   - magicLinkOptions: The email magic link options to use if you have a custom configuration.
         ///   - otpOptions: The otp options to use if you have a custom configuration.
+        ///   - biometricsOptions: The biometrics options to use if you want to configure whether biometric registration should be shown during login. If not provided, biometric registration will be shown automatically.
         ///   - theme: A configureable way to control the appearance of the UI, has default values provided
         ///   - locale: The locale is used to determine which language to use in the email. Parameter is a https://www.w3.org/International/articles/language-tags/ IETF BCP 47 language tag, e.g. "en".
         ///     Currently supported languages are English ("en"), Spanish ("es"), and Brazilian Portuguese ("pt-br"); if no value is provided, the copy defaults to English.
@@ -65,6 +75,7 @@ public extension StytchUIClient {
             passwordOptions: PasswordOptions? = nil,
             magicLinkOptions: MagicLinkOptions? = nil,
             otpOptions: OTPOptions? = nil,
+            biometricsOptions: BiometricsOptions = BiometricsOptions(showBiometricRegistrationOnLogin: true),
             theme: StytchTheme = StytchTheme(),
             locale: StytchLocale = .en
         ) {
@@ -76,6 +87,7 @@ public extension StytchUIClient {
             self.passwordOptions = passwordOptions
             self.magicLinkOptions = magicLinkOptions
             self.otpOptions = otpOptions
+            self.biometricsOptions = biometricsOptions
             self.theme = theme
             self.locale = locale
         }
@@ -86,6 +98,7 @@ public extension StytchUIClient {
         case oauth
         case passwords
         case otp
+        case biometrics
     }
 
     enum OAuthProvider: Codable {
@@ -158,6 +171,18 @@ public extension StytchUIClient {
             self.expiration = expiration
             self.loginTemplateId = loginTemplateId
             self.signupTemplateId = signupTemplateId
+        }
+    }
+
+    /// A struct defining the configuration of the Biometrics product.
+    /// `showBiometricRegistrationOnLogin` determines whether the biometric registration screen is shown during login
+    /// when biometric registration is available but not yet completed. If set to `false`, you must call
+    /// `StytchClient.biometrics.register` from elsewhere in your app to handle registration.
+    struct BiometricsOptions: Codable {
+        let showBiometricRegistrationOnLogin: Bool
+
+        public init(showBiometricRegistrationOnLogin: Bool) {
+            self.showBiometricRegistrationOnLogin = showBiometricRegistrationOnLogin
         }
     }
 

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/AuthHomeViewController/AuthHomeViewModel.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/AuthHomeViewController/AuthHomeViewModel.swift
@@ -17,17 +17,32 @@ final class AuthHomeViewModel {
 extension AuthHomeViewModel {
     var productComponents: [StytchUIClient.ProductComponent] {
         var productComponents = [StytchUIClient.ProductComponent]()
+
         for component in state.config.products {
             switch component {
-            case .oauth:
-                productComponents.appendIfNotPresent(.oAuthButtons)
             case .emailMagicLinks, .passwords, .otp:
                 productComponents.appendIfNotPresent(.inputProducts)
+            case .oauth:
+                if state.config.supportsBiometricsAndOAuth {
+                    productComponents.appendIfNotPresent(.oAuthButtons)
+                    productComponents.appendIfNotPresent(.biometrics)
+                }
+            case .biometrics:
+                if state.config.supportsBiometricsAndOAuth {
+                    productComponents.appendIfNotPresent(.biometrics)
+                    productComponents.appendIfNotPresent(.oAuthButtons)
+                }
             }
         }
 
-        if productComponents.count == 2 {
-            productComponents.insert(.divider, at: 1)
+        if state.config.supportsInputProducts, state.config.supportsOauth || state.config.supportsBiometrics {
+            if let index = productComponents.firstIndex(of: .inputProducts) {
+                if index == 0 {
+                    productComponents.insert(.divider, at: 1)
+                } else {
+                    productComponents.insert(.divider, at: index)
+                }
+            }
         }
 
         return productComponents
@@ -59,6 +74,7 @@ extension StytchUIClient {
     enum ProductComponent: String, Equatable {
         case inputProducts
         case oAuthButtons
+        case biometrics
         case divider
     }
 }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/AuthInputViewController/AuthInputViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/AuthInputViewController/AuthInputViewController.swift
@@ -241,6 +241,7 @@ final class AuthInputViewController: BaseViewController<AuthInputState, AuthInpu
     }
 
     @objc private func didTapContinue() {
+        StytchUIClient.startLoading()
         Task {
             do {
                 switch activeInput {
@@ -258,6 +259,8 @@ final class AuthInputViewController: BaseViewController<AuthInputState, AuthInpu
                         } else {
                             try await launchPasswordOnly(email: email)
                         }
+
+                        StytchUIClient.stopLoading()
                     }
                 case .phone:
                     if let phone = phoneNumberInput.phoneNumberE164, let formattedPhone = phoneNumberInput.formattedPhoneNumber {
@@ -268,6 +271,8 @@ final class AuthInputViewController: BaseViewController<AuthInputState, AuthInpu
                         DispatchQueue.main.async {
                             self.launchOTP(input: phone, formattedInput: formattedPhone, otpMethod: .sms, result: result, expiry: expiry)
                         }
+
+                        StytchUIClient.stopLoading()
                     }
                 case .whatsapp:
                     if let phone = whatsAppInput.phoneNumberE164, let formattedPhone = whatsAppInput.formattedPhoneNumber {
@@ -278,9 +283,12 @@ final class AuthInputViewController: BaseViewController<AuthInputState, AuthInpu
                         DispatchQueue.main.async {
                             self.launchOTP(input: phone, formattedInput: formattedPhone, otpMethod: .whatsapp, result: result, expiry: expiry)
                         }
+
+                        StytchUIClient.stopLoading()
                     }
                 }
             } catch {
+                StytchUIClient.stopLoading()
                 ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
             }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/BiometricsRegistrationViewController/BiometricsRegistrationViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/BiometricsRegistrationViewController/BiometricsRegistrationViewController.swift
@@ -1,0 +1,110 @@
+import AuthenticationServices
+import StytchCore
+import UIKit
+
+protocol BiometricsRegistrationViewControllerDelegate: AnyObject {
+    func biometricsRegistrationViewControllerDidComplete()
+}
+
+final class BiometricsRegistrationViewController: BaseViewController<BiometricsRegistrationState, BiometricsRegistrationViewModel> {
+    weak var delegate: BiometricsRegistrationViewControllerDelegate?
+
+    init(state: BiometricsRegistrationState, delegate: BiometricsRegistrationViewControllerDelegate) {
+        super.init(viewModel: BiometricsRegistrationViewModel(state: state))
+        self.delegate = delegate
+    }
+
+    override func configureView() {
+        super.configureView()
+
+        attachStackView(within: view)
+
+        let titleLabel: UILabel = .makeTitleLabel(text: titleText)
+        let subtitleLabel: UILabel = .makeSubtitleLabel(text: subtitleText)
+
+        let enableFaceIDButton: Button = .primary(title: enableFaceIDButtonText) { [weak self] in
+            self?.enableFaceIDButtonTapped()
+        }
+
+        let skipForNowButton: Button = .tertiary(title: "Skip for now") { [weak self] in
+            self?.skipForNowButtonTapped()
+        }
+
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(subtitleLabel)
+        stackView.addArrangedSubview(enableFaceIDButton)
+        stackView.addArrangedSubview(skipForNowButton)
+        stackView.addArrangedSubview(SpacerView())
+
+        stackView.spacing = .spacingHuge
+        stackView.setCustomSpacing(8, after: enableFaceIDButton)
+
+        NSLayoutConstraint.activate(
+            stackView.arrangedSubviews.map { $0.widthAnchor.constraint(equalTo: stackView.widthAnchor) }
+        )
+
+        hideBackButton()
+    }
+
+    @objc func enableFaceIDButtonTapped() {
+        registerBiometrics()
+    }
+
+    @objc func skipForNowButtonTapped() {
+        delegate?.biometricsRegistrationViewControllerDidComplete()
+    }
+
+    func registerBiometrics() {
+        StytchUIClient.startLoading()
+        Task {
+            do {
+                let user = try await StytchClient.user.get()
+                let biometricsRegistrationIdentifier = user.biometricsRegistrationIdentifier
+                _ = try await StytchClient.biometrics.register(parameters: .init(identifier: biometricsRegistrationIdentifier))
+                delegate?.biometricsRegistrationViewControllerDidComplete()
+                StytchUIClient.stopLoading()
+            } catch {
+                print(error.errorInfo)
+                StytchUIClient.stopLoading()
+            }
+        }
+    }
+}
+
+extension BiometricsRegistrationViewController {
+    var titleText: String {
+        var titleText = "Enable Face ID login?"
+        if StytchClient.biometrics.biometryType == .touchID {
+            titleText = "Enable Touch ID login?"
+        }
+        return titleText
+    }
+
+    var subtitleText: String {
+        var subtitleText = "Use Face ID to log into your account. You will be prompted to allow this app to use Face ID."
+        if StytchClient.biometrics.biometryType == .touchID {
+            subtitleText = "Use Touch ID to log into your account. You will be prompted to allow this app to use Touch ID."
+        }
+        return subtitleText
+    }
+
+    var enableFaceIDButtonText: String {
+        var enableFaceIDButtonText = "Enable Face ID"
+        if StytchClient.biometrics.biometryType == .touchID {
+            enableFaceIDButtonText = "Enable Touch ID"
+        }
+        return enableFaceIDButtonText
+    }
+}
+
+private extension User {
+    var biometricsRegistrationIdentifier: String {
+        if let email = emails.first?.email {
+            return email
+        } else if let phone = phoneNumbers.first?.phoneNumber {
+            return phone
+        } else {
+            return id.rawValue
+        }
+    }
+}

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/BiometricsRegistrationViewController/BiometricsRegistrationViewModel.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/BiometricsRegistrationViewController/BiometricsRegistrationViewModel.swift
@@ -1,0 +1,15 @@
+import StytchCore
+
+final class BiometricsRegistrationViewModel {
+    let state: BiometricsRegistrationState
+
+    init(
+        state: BiometricsRegistrationState
+    ) {
+        self.state = state
+    }
+}
+
+struct BiometricsRegistrationState {
+    let config: StytchUIClient.Configuration
+}

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/OAuthViewController/OAuthViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/OAuthViewController/OAuthViewController.swift
@@ -28,10 +28,13 @@ final class OAuthViewController: BaseViewController<OAuthState, OAuthViewModel> 
 
     @objc private func didTapOAuthButton(sender: UIControl) {
         guard let (_, provider) = viewModel.state.config.oauthProviders.enumerated().first(where: { $0.offset == sender.tag }) else { return }
+        StytchB2BUIClient.startLoading()
         Task {
             do {
+                StytchB2BUIClient.stopLoading()
                 try await viewModel.startOAuth(provider: provider)
             } catch {
+                StytchB2BUIClient.stopLoading()
                 try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
                 ErrorPublisher.publishError(error)
                 presentErrorAlert(error: error)
@@ -52,9 +55,8 @@ private extension OAuthViewController {
 
     static func makeAppleButton() -> ASAuthorizationAppleIDButton {
         let button = ASAuthorizationAppleIDButton(type: .continue, style: .whiteOutline)
-        NSLayoutConstraint.activate([
-            button.heightAnchor.constraint(equalToConstant: .buttonHeight),
-        ])
+        button.removeConstraints(button.constraints)
+        button.heightAnchor.constraint(equalToConstant: .buttonHeight).isActive = true
         button.cornerRadius = .cornerRadius
         button.translatesAutoresizingMaskIntoConstraints = false
         button.tintColor = .primaryText

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/OAuthViewController/OAuthViewModel.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/OAuthViewController/OAuthViewModel.swift
@@ -31,12 +31,12 @@ extension OAuthViewModel: OAuthViewModelProtocol {
         guard state.config.supportsOauth else { return }
         switch provider {
         case .apple:
-            let response = try await appleOauthProvider.start(parameters: .init(sessionDurationMinutes: state.config.sessionDurationMinutes))
+            _ = try await appleOauthProvider.start(parameters: .init(sessionDurationMinutes: state.config.sessionDurationMinutes))
         case let .thirdParty(provider):
             let (token, _) = try await (thirdPartyClientForTesting ?? provider.client).start(
                 configuration: .init(loginRedirectUrl: state.config.redirectUrl, signupRedirectUrl: state.config.redirectUrl)
             )
-            let response = try await oAuthProvider.authenticate(parameters: .init(token: token, sessionDurationMinutes: state.config.sessionDurationMinutes))
+            _ = try await oAuthProvider.authenticate(parameters: .init(token: token, sessionDurationMinutes: state.config.sessionDurationMinutes))
         }
     }
 }

--- a/Sources/StytchUI/StytchUIClient/ViewControllers/OTPCodeViewController/OTPCodeViewController.swift
+++ b/Sources/StytchUI/StytchUIClient/ViewControllers/OTPCodeViewController/OTPCodeViewController.swift
@@ -123,19 +123,23 @@ final class OTPCodeViewController: BaseViewController<OTPCodeState, OTPCodeViewM
 
 extension OTPCodeViewController: OTPCodeEntryViewDelegate {
     func didEnterOTPCode(_ code: String) {
+        StytchUIClient.startLoading()
         Task {
             do {
                 try await self.viewModel.enterCode(code: code, methodId: self.viewModel.state.methodId)
+                StytchUIClient.stopLoading()
             } catch let error as StytchAPIError where error.errorType == .otpCodeNotFound {
                 DispatchQueue.main.async {
                     self.presentAlert(title: NSLocalizedString("stytch.otpError", value: "Invalid passcode, please try again.", comment: ""))
                 }
                 self.otpView.clear()
+                StytchUIClient.stopLoading()
             } catch {
                 try? await EventsClient.logEvent(parameters: .init(eventName: "ui_authentication_failure", error: error))
                 ErrorPublisher.publishError(error)
                 self.presentErrorAlert(error: error)
                 self.otpView.clear()
+                StytchUIClient.stopLoading()
             }
         }
     }

--- a/Stytch/DemoApps/StytchUIDemo/Info.plist
+++ b/Stytch/DemoApps/StytchUIDemo/Info.plist
@@ -15,5 +15,7 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSFaceIDUsageDescription</key>
+	<string>For Authentication</string>
 </dict>
 </plist>

--- a/Tests/StytchCoreTests/BaseTestCase.swift
+++ b/Tests/StytchCoreTests/BaseTestCase.swift
@@ -185,6 +185,10 @@ class MockLocalAuthenticationContext: LAContextEvaluating {
     var shouldSucceed = true
     var thrownError: Error?
 
+    var biometryType: LABiometryType {
+        .faceID
+    }
+
     func canEvaluatePolicy(_: LAPolicy, error _: NSErrorPointer) -> Bool {
         canEvaluate
     }


### PR DESCRIPTION
[SDK-2680: \[iOS\] Productionize hackweek project for biometrics in the consumer prebuilt UI.](https://linear.app/stytch/issue/SDK-2680/ios-productionize-hackweek-project-for-biometrics-in-the-consumer)

## Changes:

1. Add support to the consumer prebuilt UI for biometrics registration and authentication.
2. You can configure the it so that you do or do not register after authentication via the `BiometricsOptions`.
3. If you choose not to register via the prebuilt UI you will have to call register from elsewhere.
4. In either case if the user is somehow registered and you include in the product config `.biometrics` then a button will be added to the home screen to authenticate with biometrics.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
