### PR TITLE
Remove incorrect session revocation on possible event 401s

### DIFF
--- a/Sources/StytchCore/Networking/NetworkingRouter.swift
+++ b/Sources/StytchCore/Networking/NetworkingRouter.swift
@@ -107,14 +107,7 @@ public extension NetworkingRouter {
             useDFPPA: useDFPPA
         )
 
-        do {
-            try response.verifyStatusCode(data: data, jsonDecoder: jsonDecoder)
-        } catch let error as StytchAPIError where error.statusCode == 401 {
-            sessionManager.resetSession()
-            throw error
-        } catch {
-            throw error
-        }
+        try response.verifyStatusCode(data: data, jsonDecoder: jsonDecoder)
     }
 
     // swiftlint:disable function_body_length


### PR DESCRIPTION
Linear Ticket: [SDK-2686](https://linear.app/stytch/issue/SDK-2686)

## Changes:

1. It was possible for a session to be revoked if an events call returned a 401. It's _unlikely_ this ever would happen, but just in case, we should protect against that.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
