### PR TITLE
SDK-2689 Enable custom domains as endpoint options for API

### DIFF
--- a/Sources/StytchCore/LocalStorage.swift
+++ b/Sources/StytchCore/LocalStorage.swift
@@ -29,9 +29,9 @@ extension LocalStorage {
         if let cnameDomain = bootstrapData?.cnameDomain {
             domain = cnameDomain
         } else if publicToken.hasPrefix("public-token-test") {
-            domain = "test.stytch.com"
+            domain = configuration?.testDomain ?? "test.stytch.com"
         } else {
-            domain = "api.stytch.com"
+            domain = configuration?.liveDomain ?? "api.stytch.com"
         }
         return domain
     }

--- a/Sources/StytchCore/SharedModels/StytchClientConfiguration.swift
+++ b/Sources/StytchCore/SharedModels/StytchClientConfiguration.swift
@@ -23,6 +23,8 @@ public struct StytchClientConfiguration: Equatable, Codable {
        - publicToken: Available via the Stytch dashboard in the `API keys` section
        - hostUrl: Generally this is your backend's base url, where your apple-app-site-association file is hosted. This is an https url which will be used as the domain for setting session-token cookies to be sent to your servers on subsequent requests. If not passed here, no cookies will be set on your behalf.
        - dfppaDomain: The domain that should be used for DFPPA
+       - testDomain: The custom domain to use for Stytch API calls for test projects
+       - liveDomain: The custom domain to use for Stytch API calls for live projects
      */
     public init(publicToken: String, hostUrl: URL? = nil, dfppaDomain: String? = nil, testDomain: String = "test.stytch.com", liveDomain: String = "api.stytch.com") {
         self.publicToken = publicToken

--- a/Sources/StytchCore/SharedModels/StytchClientConfiguration.swift
+++ b/Sources/StytchCore/SharedModels/StytchClientConfiguration.swift
@@ -7,11 +7,15 @@ public struct StytchClientConfiguration: Equatable, Codable {
         case publicToken = "StytchPublicToken"
         case hostUrl = "StytchHostURL"
         case dfppaDomain = "StytchDfppaDomain"
+        case testDomain = "StytchTestDomain"
+        case liveDomain = "StytchLiveDomain"
     }
 
     public let publicToken: String
     public let hostUrl: URL?
     public let dfppaDomain: String?
+    public let testDomain: String
+    public let liveDomain: String
 
     /**
      Creates the configuration object to configure the `StytchClient` and `StytchB2BClient`, you must set the `publicToken`.
@@ -20,10 +24,12 @@ public struct StytchClientConfiguration: Equatable, Codable {
        - hostUrl: Generally this is your backend's base url, where your apple-app-site-association file is hosted. This is an https url which will be used as the domain for setting session-token cookies to be sent to your servers on subsequent requests. If not passed here, no cookies will be set on your behalf.
        - dfppaDomain: The domain that should be used for DFPPA
      */
-    public init(publicToken: String, hostUrl: URL? = nil, dfppaDomain: String? = nil) {
+    public init(publicToken: String, hostUrl: URL? = nil, dfppaDomain: String? = nil, testDomain: String = "test.stytch.com", liveDomain: String = "api.stytch.com") {
         self.publicToken = publicToken
         self.hostUrl = hostUrl
         self.dfppaDomain = dfppaDomain
+        self.testDomain = testDomain
+        self.liveDomain = liveDomain
     }
 
     public var baseUrl: URL {
@@ -32,9 +38,9 @@ public struct StytchClientConfiguration: Equatable, Codable {
         urlComponents.path = "/sdk/v1/"
 
         if publicToken.hasPrefix("public-token-test") {
-            urlComponents.host = "test.stytch.com"
+            urlComponents.host = testDomain
         } else {
-            urlComponents.host = "api.stytch.com"
+            urlComponents.host = liveDomain
         }
 
         guard let url = urlComponents.url else {
@@ -49,6 +55,8 @@ public extension StytchClientConfiguration {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         publicToken = try container.decode(key: .publicToken)
         dfppaDomain = try container.decode(key: .dfppaDomain)
+        testDomain = try container.decode(key: .testDomain)
+        liveDomain = try container.decode(key: .liveDomain)
         do {
             hostUrl = try container.decode(key: .hostUrl)
         } catch {


### PR DESCRIPTION
Linear Ticket: [SDK-2689](https://linear.app/stytch/issue/SDK-2689)

## Changes:

1. Adds support for custom domains

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
