### PR TITLE
SDK-2742 Move some things from the Keychain into UserDefaults

### DIFF
--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClient.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClient.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+protocol EncryptedUserDefaultsClient: AnyObject {
+    func getItem(item: EncryptedUserDefaultsItem) throws -> EncryptedUserDefaultsItemResult?
+    func itemExists(item: EncryptedUserDefaultsItem) -> Bool
+    func setValueForItem(value: String?, item: EncryptedUserDefaultsItem) throws
+    func removeItem(item: EncryptedUserDefaultsItem) throws
+}
+
+extension EncryptedUserDefaultsClient {
+    func getObject<T: Decodable>(_: T.Type, for item: EncryptedUserDefaultsItem) throws -> T? {
+        guard let result = try getItem(item: item) else {
+            return nil
+        }
+        let data = try Current.jsonDecoder.decode(T.self, from: result.data)
+        return data
+    }
+
+    func getStringValue(_ item: EncryptedUserDefaultsItem) throws -> String? {
+        try getItem(item: item)?.stringValue
+    }
+
+    func setObjectValue<T: Encodable>(_ data: T, for item: EncryptedUserDefaultsItem) throws {
+        let data = try Current.jsonEncoder.encode(data.self)
+        try setValueForItem(value: String(data: data, encoding: .utf8), item: item)
+    }
+
+    func setStringValue(_ value: String, for item: EncryptedUserDefaultsItem) throws {
+        try setValueForItem(value: value, item: item)
+    }
+}
+
+struct EncryptedUserDefaultsItemResult {
+    let data: Data
+
+    var stringValue: String? {
+        String(data: data, encoding: .utf8)
+    }
+}

--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClient.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClient.swift
@@ -37,3 +37,7 @@ struct EncryptedUserDefaultsItemResult {
         String(data: data, encoding: .utf8)
     }
 }
+
+enum EncryptedUserDefaultsError: Error {
+    case encryptionKeyNotSet
+}

--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClientImplementation.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClientImplementation.swift
@@ -7,12 +7,9 @@ class EncryptedUserDefaultsClientImplementation: EncryptedUserDefaultsClient {
 
     internal let defaults: UserDefaults = .init(suiteName: "StytchEncryptedUserDefaults") ?? .standard
 
-    init(keychainClient: KeychainClient) throws {
+    init(keychainClient: KeychainClient) {
         self.keychainClient = keychainClient
         encryptionKey = try? keychainClient.getEncryptionKey()
-        if encryptionKey == nil {
-            throw EncryptedUserDefaultsError.encryptionKeyNotSet
-        }
     }
 
     func getItem(item: EncryptedUserDefaultsItem) throws -> EncryptedUserDefaultsItemResult? {

--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClientImplementation.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClientImplementation.swift
@@ -14,12 +14,6 @@ class EncryptedUserDefaultsClientImplementation: EncryptedUserDefaultsClient {
 
     func getItem(item: EncryptedUserDefaultsItem) throws -> EncryptedUserDefaultsItemResult? {
         let userDefaultsData = defaults.data(forKey: item.name)
-        if item.kind == .unencrypted {
-            guard let userDefaultsData else {
-                return nil
-            }
-            return .init(data: userDefaultsData)
-        }
         guard let decrypted = decryptData(encryptedData: userDefaultsData) else {
             return nil
         }

--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClientImplementation.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClientImplementation.swift
@@ -1,0 +1,71 @@
+import Foundation
+import CryptoKit
+
+class EncryptedUserDefaultsClientImplementation: EncryptedUserDefaultsClient {
+    private let keychainClient: KeychainClient
+    private let encryptionKey: SymmetricKey?
+
+    internal let defaults: UserDefaults = .init(suiteName: "StytchEncryptedUserDefaults") ?? .standard
+
+    init(keychainClient: KeychainClient) {
+        self.keychainClient = keychainClient
+        self.encryptionKey = try? keychainClient.getEncryptionKey()
+    }
+
+    func getItem(item: EncryptedUserDefaultsItem) throws -> EncryptedUserDefaultsItemResult? {
+        let userDefaultsData = defaults.data(forKey: item.name)
+        if item.kind == .unencrypted {
+            guard let userDefaultsData else {
+                return nil
+            }
+            return .init(data: userDefaultsData)
+        }
+        guard let decrypted = decryptData(encryptedData: userDefaultsData) else {
+            return nil
+        }
+        guard let data = decrypted.data(using: .utf8) else {
+            return nil
+        }
+        return .init(data: data)
+    }
+
+    func itemExists(item: EncryptedUserDefaultsItem) -> Bool {
+        let encryptedData = defaults.data(forKey: item.name)
+        return encryptedData != nil
+    }
+
+    func setValueForItem(value: String?, item: EncryptedUserDefaultsItem) throws {
+        guard let value else {
+            return removeItem(item: item)
+        }
+        let encryptedText = try encryptString(plainText: value)
+        defaults.set(encryptedText, forKey: item.name)
+        let encryptedDate = try encryptString(plainText: Date().asJson(encoder: Current.jsonEncoder))
+        defaults.set(encryptedDate, forKey: EncryptedUserDefaultsItem.lastValidatedAtDate(item.name).name)
+    }
+
+    func removeItem(item: EncryptedUserDefaultsItem) {
+        defaults.removeObject(forKey: item.name)
+        defaults.removeObject(forKey: EncryptedUserDefaultsItem.lastValidatedAtDate(item.name).name)
+    }
+
+    private func encryptString(plainText: String) throws -> Data? {
+        guard let encryptionKey else { return nil }
+        let sealedBox = try AES.GCM.seal(
+            Data(plainText.utf8),
+            using: encryptionKey
+        )
+        return sealedBox.combined
+    }
+
+    private func decryptData(encryptedData: Data?) -> String? {
+        guard let encryptionKey, let encryptedData else { return nil }
+        do {
+            let sealedBox = try AES.GCM.SealedBox(combined: encryptedData)
+            let decryptedData = try AES.GCM.open(sealedBox, using: encryptionKey)
+            return String(data: decryptedData, encoding: .utf8)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsItem.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsItem.swift
@@ -32,6 +32,6 @@ extension EncryptedUserDefaultsItem {
     static let consumerLastAuthMethodUsed: Self = .init(name: "consumer_last_auth_method_used")
 
     static func lastValidatedAtDate(_ prefix: String) -> Self {
-        return .init(name: "\(prefix)_last_validated_at_date")
+        .init(name: "\(prefix)_last_validated_at_date")
     }
 }

--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsItem.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsItem.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+struct EncryptedUserDefaultsItem {
+    var kind: Kind = .encrypted
+    var name: String
+}
+
+extension EncryptedUserDefaultsItem {
+    enum Kind {
+        case encrypted
+        case unencrypted
+    }
+}
+
+extension EncryptedUserDefaultsItem {
+    static let biometricKeyRegistration: Self = .init(name: "stytch_biometric_key_registration")
+
+    static let sessionToken: Self = .init(name: SessionToken.Kind.opaque.name)
+    static let sessionJwt: Self = .init(name: SessionToken.Kind.jwt.name)
+    static let intermediateSessionToken: Self = .init(name: "stytch_intermediate_session_token")
+
+    static let codeVerifierPKCE: Self = .init(name: "stytch_code_verifier_pkce")
+    static let codeChallengePKCE: Self = .init(name: "stytch_code_challenge_pkce")
+
+    static let session: Self = .init(name: "stytch_session_object")
+    static let memberSession: Self = .init(name: "stytch_member_session_object")
+    static let user: Self = .init(name: "stytch_user_object")
+    static let member: Self = .init(name: "stytch_member_object")
+    static let organization: Self = .init(name: "stytch_organization_object")
+
+    static let b2bLastAuthMethodUsed: Self = .init(name: "b2b_last_auth_method_used")
+    static let consumerLastAuthMethodUsed: Self = .init(name: "consumer_last_auth_method_used")
+
+    static func lastValidatedAtDate(_ prefix: String) -> Self {
+        return .init(name: "\(prefix)_last_validated_at_date")
+    }
+}

--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsItem.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsItem.swift
@@ -8,7 +8,6 @@ struct EncryptedUserDefaultsItem {
 extension EncryptedUserDefaultsItem {
     enum Kind {
         case encrypted
-        case unencrypted
     }
 }
 

--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -71,6 +71,8 @@ struct Environment {
 
     var keychainClient: KeychainClient = KeychainClientImplementation()
 
+    let userDefaultsClient: EncryptedUserDefaultsClient = EncryptedUserDefaultsClientImplementation(keychainClient: KeychainClientImplementation())
+
     var networkMonitor: NetworkMonitor = .init()
 
     // consumer
@@ -122,7 +124,7 @@ struct Environment {
 
     var pkcePairManager: PKCEPairManager {
         PKCEPairManagerImpl(
-            keychainClient: keychainClient,
+            userDefaultsClient: userDefaultsClient,
             cryptoClient: cryptoClient
         )
     }

--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -71,7 +71,7 @@ struct Environment {
 
     var keychainClient: KeychainClient = KeychainClientImplementation()
 
-    let userDefaultsClient: EncryptedUserDefaultsClient = EncryptedUserDefaultsClientImplementation(keychainClient: KeychainClientImplementation())
+    var userDefaultsClient: EncryptedUserDefaultsClient = EncryptedUserDefaultsClientImplementation(keychainClient: KeychainClientImplementation())
 
     var networkMonitor: NetworkMonitor = .init()
 

--- a/Sources/StytchCore/KeychainClient/KeychainClient.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CryptoKit
+import Foundation
 
 protocol KeychainClient: AnyObject {
     func getQueryResults(item: KeychainItem) throws -> [KeychainQueryResult]

--- a/Sources/StytchCore/KeychainClient/KeychainClient.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient.swift
@@ -1,43 +1,17 @@
 import Foundation
+import CryptoKit
 
 protocol KeychainClient: AnyObject {
     func getQueryResults(item: KeychainItem) throws -> [KeychainQueryResult]
     func valueExistsForItem(item: KeychainItem) -> Bool
     func setValueForItem(value: KeychainItem.Value, item: KeychainItem) throws
     func removeItem(item: KeychainItem) throws
+    func getEncryptionKey() throws -> SymmetricKey
 }
 
 extension KeychainClient {
     func getFirstQueryResult(_ item: KeychainItem) throws -> KeychainQueryResult? {
         try getQueryResults(item: item).first
-    }
-
-    func getStringValue(_ item: KeychainItem) throws -> String? {
-        try getQueryResults(item: item)
-            .first
-            .flatMap(\.stringValue)
-    }
-
-    func getObject<T: Decodable>(_: T.Type, for item: KeychainItem) throws -> T? {
-        guard let result = try getFirstQueryResult(item) else {
-            return nil
-        }
-        return try Current.jsonDecoder.decode(T.self, from: result.data)
-    }
-
-    func setStringValue(_ value: String, for item: KeychainItem) throws {
-        try setValueForItem(
-            value: .init(data: .init(value.utf8), account: nil, label: nil, generic: nil, accessPolicy: nil),
-            item: item
-        )
-    }
-
-    func setObject(_ object: any Codable, for item: KeychainItem) throws {
-        let encodedData = try Current.jsonEncoder.encode(object)
-        try setValueForItem(
-            value: .init(data: encodedData, account: nil, label: nil, generic: nil, accessPolicy: nil),
-            item: item
-        )
     }
 
     func setPrivateKeyRegistration(

--- a/Sources/StytchCore/KeychainClient/KeychainClientImplementation.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClientImplementation.swift
@@ -1,12 +1,26 @@
 import Foundation
 import Security
+import CryptoKit
 #if !os(tvOS)
 import LocalAuthentication
 #endif
 
-// swiftlint:disable function_body_length
+public let AES_ACCOUNT = "EncryptedUserDefaultsKey"
 
 class KeychainClientImplementation: KeychainClient {
+    func getEncryptionKey() throws -> SymmetricKey {
+        let result = try getFirstQueryResult(KeychainItem.encryptionKey)
+        guard let result else {
+            // Key doesn't exist so create it
+            let data = SymmetricKey(size: .bits256).withUnsafeBytes {
+                return Data(Array($0))
+            }
+            try setValueForItem(value: .init(data: data, account: AES_ACCOUNT, label: nil, generic: nil, accessPolicy: nil), item: .encryptionKey)
+            return SymmetricKey(data: data)
+        }
+        return SymmetricKey(data: result.data)
+    }
+
     func getQueryResults(item: KeychainItem) throws -> [KeychainQueryResult] {
         var result: CFTypeRef?
 
@@ -49,6 +63,10 @@ class KeychainClientImplementation: KeychainClient {
                     break
                 }
             }
+        } else if item.kind == .encryptionKey {
+            var newQuery = query
+            newQuery[kSecAttrAccount] = AES_ACCOUNT
+            status = SecItemCopyMatching(newQuery as CFDictionary, &result)
         } else {
             status = SecItemCopyMatching(query as CFDictionary, &result)
         }
@@ -137,7 +155,7 @@ class KeychainClientImplementation: KeychainClient {
         }
 
         var parameters: [CFString: AnyObject] = [kSecAttrSynchronizable: kSecAttrSynchronizableAny]
-        if item.kind == .token {
+        if item.kind == .encryptionKey {
             parameters[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlock
             try tryRemovingItem(item.baseQuery.merging(parameters))
         } else {

--- a/Sources/StytchCore/KeychainClient/KeychainClientImplementation.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClientImplementation.swift
@@ -1,11 +1,11 @@
+import CryptoKit
 import Foundation
 import Security
-import CryptoKit
 #if !os(tvOS)
 import LocalAuthentication
 #endif
 
-public let AES_ACCOUNT = "EncryptedUserDefaultsKey"
+public let ENCRYPTEDUSERDEFAULTSKEYNAME = "EncryptedUserDefaultsKey"
 
 class KeychainClientImplementation: KeychainClient {
     func getEncryptionKey() throws -> SymmetricKey {
@@ -13,14 +13,15 @@ class KeychainClientImplementation: KeychainClient {
         guard let result else {
             // Key doesn't exist so create it
             let data = SymmetricKey(size: .bits256).withUnsafeBytes {
-                return Data(Array($0))
+                Data(Array($0))
             }
-            try setValueForItem(value: .init(data: data, account: AES_ACCOUNT, label: nil, generic: nil, accessPolicy: nil), item: .encryptionKey)
+            try setValueForItem(value: .init(data: data, account: ENCRYPTEDUSERDEFAULTSKEYNAME, label: nil, generic: nil, accessPolicy: nil), item: .encryptionKey)
             return SymmetricKey(data: data)
         }
         return SymmetricKey(data: result.data)
     }
 
+    // swiftlint:disable:next function_body_length
     func getQueryResults(item: KeychainItem) throws -> [KeychainQueryResult] {
         var result: CFTypeRef?
 
@@ -65,7 +66,7 @@ class KeychainClientImplementation: KeychainClient {
             }
         } else if item.kind == .encryptionKey {
             var newQuery = query
-            newQuery[kSecAttrAccount] = AES_ACCOUNT
+            newQuery[kSecAttrAccount] = ENCRYPTEDUSERDEFAULTSKEYNAME
             status = SecItemCopyMatching(newQuery as CFDictionary, &result)
         } else {
             status = SecItemCopyMatching(query as CFDictionary, &result)

--- a/Sources/StytchCore/KeychainClient/KeychainItem.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainItem.swift
@@ -42,9 +42,6 @@ struct KeychainItem {
         if let accessControl = try? value.accessPolicy?.accessControl {
             querySegment[kSecAttrAccessControl] = accessControl
         }
-        if kind == .token {
-            querySegment[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlock
-        }
         return querySegment
     }
 }
@@ -52,8 +49,8 @@ struct KeychainItem {
 extension KeychainItem {
     enum Kind {
         case privateKey
-        case token
-        case object
+        case encryptionKey
+        case deprecated
     }
 }
 
@@ -110,42 +107,28 @@ extension KeychainItem {
 extension KeychainItem {
     // The private key registration is central to biometric authentication, and this item should be protected by biometrics unless explicitly specified otherwise by the caller.
     static let privateKeyRegistration: Self = .init(kind: .privateKey, name: "stytch_private_key_registration")
-    // This was introduced in version 0.54.0 to store the biometric registration ID in a keychain item that is not protected by biometrics.
-    static let biometricKeyRegistration: Self = .init(kind: .object, name: "stytch_biometric_key_registration")
+    static let encryptionKey: Self = .init(kind: .encryptionKey, name: "stytch_encryption_key")
 
-    static let sessionToken: Self = .init(kind: .token, name: SessionToken.Kind.opaque.name)
-    static let sessionJwt: Self = .init(kind: .token, name: SessionToken.Kind.jwt.name)
-    static let intermediateSessionToken: Self = .init(kind: .token, name: "stytch_intermediate_session_token")
-
-    static let codeVerifierPKCE: Self = .init(kind: .token, name: "stytch_code_verifier_pkce")
-    static let codeChallengePKCE: Self = .init(kind: .token, name: "stytch_code_challenge_pkce")
-
-    static let session: Self = .init(kind: .object, name: "stytch_session_object")
-    static let memberSession: Self = .init(kind: .object, name: "stytch_member_session_object")
-    static let user: Self = .init(kind: .object, name: "stytch_user_object")
-    static let member: Self = .init(kind: .object, name: "stytch_member_object")
-    static let organization: Self = .init(kind: .object, name: "stytch_organization_object")
-
-    static let b2bLastAuthMethodUsed: Self = .init(kind: .object, name: "b2b_last_auth_method_used")
-    static let consumerLastAuthMethodUsed: Self = .init(kind: .object, name: "consumer_last_auth_method_used")
+    // The following key types are deprecated, but exist for backwards compatibility with migrations
+    static let biometricKeyRegistration: Self = .init(kind: .deprecated, name: "stytch_biometric_key_registration")
+    static let sessionToken: Self = .init(kind: .deprecated, name: SessionToken.Kind.opaque.name)
+    static let sessionJwt: Self = .init(kind: .deprecated, name: SessionToken.Kind.jwt.name)
+    static let intermediateSessionToken: Self = .init(kind: .deprecated, name: "stytch_intermediate_session_token")
+    static let codeVerifierPKCE: Self = .init(kind: .deprecated, name: "stytch_code_verifier_pkce")
+    static let codeChallengePKCE: Self = .init(kind: .deprecated, name: "stytch_code_challenge_pkce")
+    static let session: Self = .init(kind: .deprecated, name: "stytch_session_object")
+    static let memberSession: Self = .init(kind: .deprecated, name: "stytch_member_session_object")
+    static let user: Self = .init(kind: .deprecated, name: "stytch_user_object")
+    static let member: Self = .init(kind: .deprecated, name: "stytch_member_object")
+    static let organization: Self = .init(kind: .deprecated, name: "stytch_organization_object")
+    static let b2bLastAuthMethodUsed: Self = .init(kind: .deprecated, name: "b2b_last_auth_method_used")
+    static let consumerLastAuthMethodUsed: Self = .init(kind: .deprecated, name: "consumer_last_auth_method_used")
 
     // TODO: - set up linting or codegen to ensure any new `KeychainItem` added (this file or elsewhere) is added to this array
     static var allItems: [Self] {
         [
             .privateKeyRegistration,
-            .biometricKeyRegistration,
-            .sessionToken,
-            .sessionJwt,
-            .intermediateSessionToken,
-            .codeVerifierPKCE,
-            .codeChallengePKCE,
-            .session,
-            .memberSession,
-            .user,
-            .member,
-            .organization,
-            .b2bLastAuthMethodUsed,
-            .consumerLastAuthMethodUsed,
+            .encryptionKey,
         ]
     }
 }

--- a/Sources/StytchCore/KeychainClient/KeychainMigrations/KeychainMigration.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainMigrations/KeychainMigration.swift
@@ -11,6 +11,7 @@ extension KeychainClient {
             KeychainMigration1.self,
             KeychainMigration2.self,
             KeychainMigration3.self,
+            KeychainMigration4.self,
         ]
     }
 }

--- a/Sources/StytchCore/KeychainClient/KeychainMigrations/KeychainMigration4.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainMigrations/KeychainMigration4.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Security
+
+struct KeychainMigration4: KeychainMigration {
+    static let keychainClient = Current.keychainClient
+    static let userDefaultsClient = Current.userDefaultsClient
+
+    static func run() throws {
+        try [
+            (KeychainItem.biometricKeyRegistration, EncryptedUserDefaultsItem.biometricKeyRegistration),
+            (KeychainItem.sessionToken, EncryptedUserDefaultsItem.sessionToken),
+            (KeychainItem.sessionJwt, EncryptedUserDefaultsItem.sessionJwt),
+            (KeychainItem.intermediateSessionToken, EncryptedUserDefaultsItem.intermediateSessionToken),
+            (KeychainItem.codeVerifierPKCE, EncryptedUserDefaultsItem.codeVerifierPKCE),
+            (KeychainItem.codeChallengePKCE, EncryptedUserDefaultsItem.codeChallengePKCE),
+            (KeychainItem.session, EncryptedUserDefaultsItem.session),
+            (KeychainItem.memberSession, EncryptedUserDefaultsItem.memberSession),
+            (KeychainItem.user, EncryptedUserDefaultsItem.user),
+            (KeychainItem.member, EncryptedUserDefaultsItem.member),
+            (KeychainItem.organization, EncryptedUserDefaultsItem.organization),
+            (KeychainItem.b2bLastAuthMethodUsed, EncryptedUserDefaultsItem.b2bLastAuthMethodUsed),
+            (KeychainItem.consumerLastAuthMethodUsed, EncryptedUserDefaultsItem.consumerLastAuthMethodUsed),
+        ]
+        .forEach { (keyChainKey, userDefaultsKey) in
+            // fetch data from keychain
+            let results = try keychainClient.getQueryResults(item: keyChainKey)
+            guard let keychainData = results.first, let keychainDataString = keychainData.stringValue else { return }
+            // save to userdefaults
+            try userDefaultsClient.setStringValue(keychainDataString, for: userDefaultsKey)
+        }
+    }
+}

--- a/Sources/StytchCore/KeychainClient/KeychainMigrations/KeychainMigration4.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainMigrations/KeychainMigration4.swift
@@ -21,7 +21,7 @@ struct KeychainMigration4: KeychainMigration {
             (KeychainItem.b2bLastAuthMethodUsed, EncryptedUserDefaultsItem.b2bLastAuthMethodUsed),
             (KeychainItem.consumerLastAuthMethodUsed, EncryptedUserDefaultsItem.consumerLastAuthMethodUsed),
         ]
-        .forEach { (keyChainKey, userDefaultsKey) in
+        .forEach { keyChainKey, userDefaultsKey in
             // fetch data from keychain
             let results = try keychainClient.getQueryResults(item: keyChainKey)
             guard let keychainData = results.first, let keychainDataString = keychainData.stringValue else { return }

--- a/Sources/StytchCore/ObjectStorage.swift
+++ b/Sources/StytchCore/ObjectStorage.swift
@@ -21,22 +21,23 @@ public enum StytchObjectInfo<T: Equatable>: Equatable {
 protocol ObjectStorageWrapper {
     associatedtype ObjectType: Equatable
     var lastValidatedAtDate: Date? { get }
-    var keychainItem: KeychainItem { get }
+    var item: EncryptedUserDefaultsItem { get }
     func setObject(object: ObjectType?)
     func getObject() throws -> ObjectType?
 }
 
 extension ObjectStorageWrapper {
-    var keychainClient: KeychainClient {
-        Current.keychainClient
+    var userDefaultsClient: EncryptedUserDefaultsClient {
+        Current.userDefaultsClient
     }
 
-    var queryResult: KeychainQueryResult? {
-        try? keychainClient.getFirstQueryResult(keychainItem)
+    var queryResult: EncryptedUserDefaultsItemResult? {
+        try? userDefaultsClient.getItem(item: item)
     }
 
     var lastValidatedAtDate: Date? {
-        queryResult?.modifiedAt
+        let last = try? userDefaultsClient.getObject(Date.self, for: EncryptedUserDefaultsItem.lastValidatedAtDate(item.name))
+        return last
     }
 }
 
@@ -84,14 +85,14 @@ class ObjectStorage<WrapperType: ObjectStorageWrapper> {
 
 class SessionStorageWrapper: ObjectStorageWrapper {
     @Dependency(\.sessionManager) var sessionManager
-    let keychainItem = KeychainItem.session
+    let item = EncryptedUserDefaultsItem.session
 
     func setObject(object: Session?) {
-        try? keychainClient.setObject(object, for: keychainItem)
+        try? userDefaultsClient.setObjectValue(object, for: item)
     }
 
     func getObject() throws -> Session? {
-        var sessionToReturn: Session? = try keychainClient.getObject(Session.self, for: keychainItem)
+        var sessionToReturn: Session? = try userDefaultsClient.getObject(Session.self, for: item)
         if let session = sessionToReturn, session.expiresAt.isInThePast {
             sessionToReturn = nil
             sessionManager.resetSession()
@@ -102,14 +103,14 @@ class SessionStorageWrapper: ObjectStorageWrapper {
 
 class MemberSessionStorageWrapper: ObjectStorageWrapper {
     @Dependency(\.sessionManager) var sessionManager
-    let keychainItem = KeychainItem.memberSession
+    let item = EncryptedUserDefaultsItem.memberSession
 
     func setObject(object: MemberSession?) {
-        try? keychainClient.setObject(object, for: keychainItem)
+        try? userDefaultsClient.setObjectValue(object, for: item)
     }
 
     func getObject() throws -> MemberSession? {
-        var sessionToReturn: MemberSession? = try keychainClient.getObject(MemberSession.self, for: keychainItem)
+        var sessionToReturn: MemberSession? = try userDefaultsClient.getObject(MemberSession.self, for: item)
         if let session = sessionToReturn, session.expiresAt.isInThePast {
             sessionToReturn = nil
             sessionManager.resetSession()
@@ -119,38 +120,38 @@ class MemberSessionStorageWrapper: ObjectStorageWrapper {
 }
 
 class UserStorageWrapper: ObjectStorageWrapper {
-    let keychainItem = KeychainItem.user
+    let item = EncryptedUserDefaultsItem.user
 
     func setObject(object: User?) {
-        try? keychainClient.setObject(object, for: keychainItem)
+        try? userDefaultsClient.setObjectValue(object, for: item)
     }
 
     func getObject() throws -> User? {
-        try keychainClient.getObject(User.self, for: keychainItem)
+        try userDefaultsClient.getObject(User.self, for: item)
     }
 }
 
 class MemberStorageWrapper: ObjectStorageWrapper {
-    let keychainItem = KeychainItem.member
+    let item = EncryptedUserDefaultsItem.member
 
     func setObject(object: Member?) {
-        try? keychainClient.setObject(object, for: keychainItem)
+        try? userDefaultsClient.setObjectValue(object, for: item)
     }
 
     func getObject() throws -> Member? {
-        try keychainClient.getObject(Member.self, for: keychainItem)
+        try userDefaultsClient.getObject(Member.self, for: item)
     }
 }
 
 class OrganizationStorageWrapper: ObjectStorageWrapper {
-    let keychainItem = KeychainItem.organization
+    let item = EncryptedUserDefaultsItem.organization
 
     func setObject(object: Organization?) {
-        try? keychainClient.setObject(object, for: keychainItem)
+        try? userDefaultsClient.setObjectValue(object, for: item)
     }
 
     func getObject() throws -> Organization? {
-        try keychainClient.getObject(Organization.self, for: keychainItem)
+        try userDefaultsClient.getObject(Organization.self, for: item)
     }
 }
 

--- a/Sources/StytchCore/PKCE/PKCEPairManager.swift
+++ b/Sources/StytchCore/PKCE/PKCEPairManager.swift
@@ -26,25 +26,25 @@ protocol PKCEPairManager {
 }
 
 internal class PKCEPairManagerImpl: PKCEPairManager {
-    let keychainClient: KeychainClient
+    let userDefaultsClient: EncryptedUserDefaultsClient
     let cryptoClient: CryptoClient
 
-    init(keychainClient: KeychainClient, cryptoClient: CryptoClient) {
-        self.keychainClient = keychainClient
+    init(userDefaultsClient: EncryptedUserDefaultsClient, cryptoClient: CryptoClient) {
+        self.userDefaultsClient = userDefaultsClient
         self.cryptoClient = cryptoClient
     }
 
     func generateAndReturnPKCECodePair() throws -> PKCECodePair {
         let codeVerifier = try cryptoClient.dataWithRandomBytesOfCount(32).toHexString()
         let codeChallenge = cryptoClient.sha256(codeVerifier).base64UrlEncoded()
-        try keychainClient.setStringValue(codeVerifier, for: .codeVerifierPKCE)
-        try keychainClient.setStringValue(codeChallenge, for: .codeChallengePKCE)
+        try userDefaultsClient.setStringValue(codeVerifier, for: .codeVerifierPKCE)
+        try userDefaultsClient.setStringValue(codeChallenge, for: .codeChallengePKCE)
         return PKCECodePair(codeChallenge: codeChallenge, codeVerifier: codeVerifier)
     }
 
     func getPKCECodePair() -> PKCECodePair? {
-        let codeChallenge = try? keychainClient.getStringValue(.codeChallengePKCE)
-        let codeVerifier = try? keychainClient.getStringValue(.codeVerifierPKCE)
+        let codeChallenge = try? userDefaultsClient.getStringValue(.codeChallengePKCE)
+        let codeVerifier = try? userDefaultsClient.getStringValue(.codeVerifierPKCE)
         if let codeChallenge = codeChallenge, let codeVerifier = codeVerifier {
             return PKCECodePair(codeChallenge: codeChallenge, codeVerifier: codeVerifier)
         } else {
@@ -53,7 +53,7 @@ internal class PKCEPairManagerImpl: PKCEPairManager {
     }
 
     func clearPKCECodePair() throws {
-        try keychainClient.removeItem(item: .codeChallengePKCE)
-        try keychainClient.removeItem(item: .codeVerifierPKCE)
+        try userDefaultsClient.removeItem(item: .codeChallengePKCE)
+        try userDefaultsClient.removeItem(item: .codeVerifierPKCE)
     }
 }

--- a/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
@@ -57,7 +57,7 @@ public extension StytchClient {
         }
 
         public var biometricRegistrationId: String? {
-            return try? userDefaultsClient.getStringValue(.biometricKeyRegistration)
+            try? userDefaultsClient.getStringValue(.biometricKeyRegistration)
         }
 
         /// Indicates if biometrics are available

--- a/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
@@ -43,6 +43,8 @@ public extension StytchClient {
 
         @Dependency(\.keychainClient) private var keychainClient
 
+        @Dependency(\.userDefaultsClient) private var userDefaultsClient
+
         @Dependency(\.sessionManager) private var sessionManager
 
         @Dependency(\.jsonDecoder) private var jsonDecoder
@@ -152,7 +154,7 @@ public extension StytchClient {
             )
 
             // Set the .biometricKeyRegistration
-            try keychainClient.setStringValue(registration.registrationId.rawValue, for: .biometricKeyRegistration)
+            try userDefaultsClient.setStringValue(registration.registrationId.rawValue, for: .biometricKeyRegistration)
 
             return finishResponse
         }
@@ -233,9 +235,9 @@ public extension StytchClient {
          without prompting the user unnecessarily for biometric authentication.
          */
         func copyBiometricRegistrationIDToKeychainIfNeeded(_ privateKeyRegistrationQueryResult: KeychainQueryResult) throws {
-            let biometricKeyRegistrationQueryResult = try? keychainClient.getQueryResults(item: .biometricKeyRegistration).first
+            let biometricKeyRegistrationQueryResult = try? userDefaultsClient.getItem(item: .biometricKeyRegistration)
             if biometricKeyRegistrationQueryResult == nil, let privateKeyRegistration = try privateKeyRegistrationQueryResult.generic.map({ try jsonDecoder.decode(BiometricPrivateKeyRegistration.self, from: $0) }) {
-                try keychainClient.setStringValue(privateKeyRegistration.registrationId.rawValue, for: .biometricKeyRegistration)
+                try userDefaultsClient.setStringValue(privateKeyRegistration.registrationId.rawValue, for: .biometricKeyRegistration)
             }
         }
     }

--- a/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
@@ -57,10 +57,7 @@ public extension StytchClient {
         }
 
         public var biometricRegistrationId: String? {
-            guard let biometricKeyRegistrationQueryResult = try? keychainClient.getQueryResults(item: .biometricKeyRegistration).first else {
-                return nil
-            }
-            return biometricKeyRegistrationQueryResult.stringValue
+            return try? userDefaultsClient.getStringValue(.biometricKeyRegistration)
         }
 
         /// Indicates if biometrics are available

--- a/Stytch/DemoApps/StytchUIDemo/Info.plist
+++ b/Stytch/DemoApps/StytchUIDemo/Info.plist
@@ -15,7 +15,5 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSFaceIDUsageDescription</key>
-	<string>For Authentication</string>
 </dict>
 </plist>

--- a/Stytch/Stytch.xcodeproj/project.pbxproj
+++ b/Stytch/Stytch.xcodeproj/project.pbxproj
@@ -974,6 +974,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DemoApps/StytchUIDemo/Info.plist;
+				INFOPLIST_KEY_NSFaceIDUsageDescription = "For Authentication";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -1014,6 +1015,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DemoApps/StytchUIDemo/Info.plist;
+				INFOPLIST_KEY_NSFaceIDUsageDescription = "For Authentication";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
@@ -17,13 +17,13 @@ final class B2BMagicLinksTestCase: BaseTestCase {
             signupTemplateId: "mate"
         )
 
-        XCTAssertTrue(try Current.keychainClient.getQueryResults(item: .codeVerifierPKCE).isEmpty)
+        XCTAssertTrue(try Current.userDefaultsClient.getItem(item: .codeVerifierPKCE) == nil)
 
         let response = try await StytchB2BClient.magicLinks.email.loginOrSignup(parameters: parameters)
         XCTAssertEqual(response.statusCode, 200)
         XCTAssertEqual(response.requestId, "1234")
 
-        XCTAssertEqual(try Current.keychainClient.getStringValue(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
+        XCTAssertEqual(try Current.userDefaultsClient.getStringValue(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
@@ -105,10 +105,10 @@ final class B2BMagicLinksTestCase: BaseTestCase {
             locale: .en
         )
 
-        try Current.keychainClient.setStringValue(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
-        try Current.keychainClient.setStringValue(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
+        try Current.userDefaultsClient.setStringValue(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
+        try Current.userDefaultsClient.setStringValue(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
 
-        XCTAssertNotNil(try Current.keychainClient.getStringValue(.codeVerifierPKCE))
+        XCTAssertNotNil(try Current.userDefaultsClient.getStringValue(.codeVerifierPKCE))
 
         Current.timer = { _, _, _ in .init() }
 
@@ -162,10 +162,10 @@ final class B2BMagicLinksTestCase: BaseTestCase {
             StytchSDKError.missingPKCE
         )
 
-        try Current.keychainClient.setStringValue(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
-        try Current.keychainClient.setStringValue(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
+        try Current.userDefaultsClient.setStringValue(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
+        try Current.userDefaultsClient.setStringValue(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
 
-        XCTAssertNotNil(try Current.keychainClient.getStringValue(.codeVerifierPKCE))
+        XCTAssertNotNil(try Current.userDefaultsClient.getStringValue(.codeVerifierPKCE))
 
         Current.timer = { _, _, _ in .init() }
 

--- a/Tests/StytchCoreTests/BaseTestCase.swift
+++ b/Tests/StytchCoreTests/BaseTestCase.swift
@@ -16,6 +16,7 @@ class BaseTestCase: XCTestCase {
         Current.sessionsPollingClient = .failing
         Current.cookieClient = .mock()
         Current.keychainClient = KeychainClientMock()
+        Current.userDefaultsClient = EncryptedUserDefaultsClientMock()
         Current.cryptoClient = .live
         Current.localStorage = .init()
         Current.timer = { _, _, _ in

--- a/Tests/StytchCoreTests/BiometricsTestCase.swift
+++ b/Tests/StytchCoreTests/BiometricsTestCase.swift
@@ -12,7 +12,7 @@ final class BiometricsTestCase: BaseTestCase {
         let userId: User.ID = "user_123"
         let email = "example@stytch.com"
 
-        try Current.keychainClient.setStringValue(sessionToken, for: .sessionToken)
+        try Current.userDefaultsClient.setStringValue(sessionToken, for: .sessionToken)
 
         let registerStartResponse = try StytchClient.Biometrics.RegisterStartResponse(
             biometricRegistrationId: regId,
@@ -62,7 +62,7 @@ final class BiometricsTestCase: BaseTestCase {
         )
 
         // Set the .biometricKeyRegistration
-        try Current.keychainClient.setStringValue(regId.rawValue, for: .biometricKeyRegistration)
+        try Current.userDefaultsClient.setStringValue(regId.rawValue, for: .biometricKeyRegistration)
 
         XCTAssertTrue(StytchClient.biometrics.registrationAvailable)
 
@@ -109,7 +109,7 @@ final class BiometricsTestCase: BaseTestCase {
         )
 
         // Set the .biometricKeyRegistration
-        try Current.keychainClient.setStringValue(regId.rawValue, for: .biometricKeyRegistration)
+        try Current.userDefaultsClient.setStringValue(regId.rawValue, for: .biometricKeyRegistration)
 
         XCTAssertTrue(StytchClient.biometrics.registrationAvailable)
 
@@ -126,7 +126,7 @@ final class BiometricsTestCase: BaseTestCase {
     }
 
     func testRegisterThrowsErrorWhenPrivateKeyExists() async throws {
-        try Current.keychainClient.setStringValue("session_token_123", for: .sessionToken)
+        try Current.userDefaultsClient.setStringValue("session_token_123", for: .sessionToken)
 
         // Set the .privateKeyRegistration
         try Current.keychainClient.setPrivateKeyRegistration(

--- a/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
+++ b/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
@@ -29,7 +29,7 @@ final class CryptoWalletsTestCase: BaseTestCase {
             StytchClient.CryptoWallets.AuthenticateStartResponse(requestId: "mock-request-id", statusCode: 200, wrapped: .init(challenge: "mock-challenge"))
         }
 
-        try Current.keychainClient.setStringValue("123", for: .sessionToken)
+        try Current.userDefaultsClient.setStringValue("123", for: .sessionToken)
 
         XCTAssertTrue(Current.sessionManager.hasValidSessionToken)
 

--- a/Tests/StytchCoreTests/DeeplinkHandlerTestCase.swift
+++ b/Tests/StytchCoreTests/DeeplinkHandlerTestCase.swift
@@ -21,8 +21,8 @@ final class DeeplinkHandlerTestCase: BaseTestCase {
             StytchSDKError.missingPKCE
         )
 
-        try Current.keychainClient.setStringValue(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
-        try Current.keychainClient.setStringValue(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
+        try Current.userDefaultsClient.setStringValue(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
+        try Current.userDefaultsClient.setStringValue(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
 
         Current.timer = { _, _, _ in .init() }
 

--- a/Tests/StytchCoreTests/EncryptedUserDefaultsClientMock.swift
+++ b/Tests/StytchCoreTests/EncryptedUserDefaultsClientMock.swift
@@ -1,0 +1,41 @@
+import CryptoKit
+import Foundation
+@testable import StytchCore
+
+// used for testing the expiration of the IST
+public var userDefaultsLastModifiedOffset = 0
+
+class EncryptedUserDefaultsClientMock: EncryptedUserDefaultsClient {
+    let lock: NSLock = .init()
+    var userDefaultItems: [String: EncryptedUserDefaultsItemResult] = [:]
+
+    func getItem(item: EncryptedUserDefaultsItem) throws -> EncryptedUserDefaultsItemResult? {
+        lock.withLock { userDefaultItems[item.name] }
+    }
+
+    func itemExists(item: EncryptedUserDefaultsItem) -> Bool {
+        lock.withLock { userDefaultItems[item.name] != nil }
+    }
+
+    func setValueForItem(value: String?, item: EncryptedUserDefaultsItem) throws {
+        lock.withLock {
+            let result: EncryptedUserDefaultsItemResult = .init(data: (value ?? "").data(using: .utf8)!)
+            userDefaultItems[item.name] = result
+            let lastValidatedAtDate = Date().minutesAgo(minutes: userDefaultsLastModifiedOffset)
+            userDefaultItems["\(item.name)_last_validated_at_date"] = try? .init(data: lastValidatedAtDate.asJson(encoder: Current.jsonEncoder).data(using: .utf8)!)
+        }
+    }
+
+    func removeItem(item: EncryptedUserDefaultsItem) throws {
+        lock.withLock {
+            userDefaultItems[item.name] = nil
+            userDefaultItems["\(item.name)_last_validated_at_date"] = nil
+        }
+    }
+}
+
+extension EncryptedUserDefaultsClient {
+    func resultsExistForItem(_ item: EncryptedUserDefaultsItem) -> Bool {
+        (try? getStringValue(item).map { !$0.isEmpty }) ?? false
+    }
+}

--- a/Tests/StytchCoreTests/KeychainClient+Mock.swift
+++ b/Tests/StytchCoreTests/KeychainClient+Mock.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 @testable import StytchCore
 
@@ -5,6 +6,10 @@ import Foundation
 public var keychainDateCreatedOffsetInMinutes = 0
 
 class KeychainClientMock: KeychainClient {
+    func getEncryptionKey() throws -> SymmetricKey {
+        SymmetricKey(data: try Current.cryptoClient.dataWithRandomBytesOfCount(256))
+    }
+
     let lock: NSLock = .init()
     var keychainItems: [String: [KeychainQueryResult]] = [:]
 
@@ -38,12 +43,6 @@ class KeychainClientMock: KeychainClient {
 
     func removeItem(item: KeychainItem) throws {
         lock.withLock { keychainItems[item.name] = nil }
-    }
-}
-
-extension KeychainClient {
-    func resultsExistForItem(_ item: KeychainItem) -> Bool {
-        (try? getStringValue(item).map { !$0.isEmpty }) ?? false
     }
 }
 

--- a/Tests/StytchCoreTests/MagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/MagicLinksTestCase.swift
@@ -18,13 +18,13 @@ final class MagicLinksTestCase: BaseTestCase {
             locale: .en
         )
 
-        XCTAssertTrue(try Current.keychainClient.getQueryResults(item: .codeVerifierPKCE).isEmpty)
+        XCTAssertTrue(try Current.userDefaultsClient.getItem(item: .codeVerifierPKCE) == nil)
 
         let response = try await StytchClient.magicLinks.email.loginOrCreate(parameters: parameters)
         XCTAssertEqual(response.statusCode, 200)
         XCTAssertEqual(response.requestId, "1234")
 
-        XCTAssertEqual(try Current.keychainClient.getStringValue(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
+        XCTAssertEqual(try Current.userDefaultsClient.getStringValue(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
@@ -61,7 +61,7 @@ final class MagicLinksTestCase: BaseTestCase {
         XCTAssertEqual(response.statusCode, 200)
         XCTAssertEqual(response.requestId, "1234")
 
-        XCTAssertEqual(try Current.keychainClient.getStringValue(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
+        XCTAssertEqual(try Current.userDefaultsClient.getStringValue(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
@@ -87,7 +87,7 @@ final class MagicLinksTestCase: BaseTestCase {
             locale: .en
         )
 
-        try Current.keychainClient.setStringValue("123", for: .sessionToken)
+        try Current.userDefaultsClient.setStringValue("123", for: .sessionToken)
 
         XCTAssertTrue(Current.sessionManager.hasValidSessionToken)
         XCTAssertTrue(try Current.keychainClient.getQueryResults(item: .codeVerifierPKCE).isEmpty)
@@ -96,7 +96,7 @@ final class MagicLinksTestCase: BaseTestCase {
         XCTAssertEqual(response.statusCode, 200)
         XCTAssertEqual(response.requestId, "1234")
 
-        XCTAssertEqual(try Current.keychainClient.getStringValue(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
+        XCTAssertEqual(try Current.userDefaultsClient.getStringValue(.codeVerifierPKCE), "e0683c9c02bf554ab9c731a1767bc940d71321a40fdbeac62824e7b6495a8741")
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],
@@ -124,10 +124,10 @@ final class MagicLinksTestCase: BaseTestCase {
             StytchSDKError.missingPKCE
         )
 
-        try Current.keychainClient.setStringValue(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
-        try Current.keychainClient.setStringValue(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
+        try Current.userDefaultsClient.setStringValue(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
+        try Current.userDefaultsClient.setStringValue(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
 
-        XCTAssertNotNil(try Current.keychainClient.getStringValue(.codeVerifierPKCE))
+        XCTAssertNotNil(try Current.userDefaultsClient.getStringValue(.codeVerifierPKCE))
 
         Current.timer = { _, _, _ in .init() }
 

--- a/Tests/StytchCoreTests/OTPTestCase.swift
+++ b/Tests/StytchCoreTests/OTPTestCase.swift
@@ -109,7 +109,7 @@ final class OTPTestCase: BaseTestCase {
             response
         }
 
-        try Current.keychainClient.setStringValue("123", for: .sessionToken)
+        try Current.userDefaultsClient.setStringValue("123", for: .sessionToken)
 
         XCTAssertTrue(Current.sessionManager.hasValidSessionToken)
 

--- a/Tests/StytchCoreTests/SessionStorageTestCase.swift
+++ b/Tests/StytchCoreTests/SessionStorageTestCase.swift
@@ -5,7 +5,7 @@ import XCTest
 final class SessionStorageTestCase: BaseTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
-        keychainDateCreatedOffsetInMinutes = 0
+        userDefaultsLastModifiedOffset = 0
     }
 
     func testNotification() throws {
@@ -27,13 +27,13 @@ final class SessionStorageTestCase: BaseTestCase {
     }
 
     func testIntermediateSessionTokenExpiresAfter11Minutes() {
-        let keychainItem: KeychainItem = .intermediateSessionToken
+        let istItem: EncryptedUserDefaultsItem = .intermediateSessionToken
 
         // clear the IST
-        try? Current.keychainClient.removeItem(item: keychainItem)
+        try? Current.userDefaultsClient.removeItem(item: istItem)
 
         // set the date created offset to 11 minutes so that the IST will be expired and return nil
-        keychainDateCreatedOffsetInMinutes = 11
+        userDefaultsLastModifiedOffset = 11
 
         // call updateSession with only the IST which will assign it to the keychain item for the IST
         Current.sessionManager.updateSession(intermediateSessionToken: "1234567890")
@@ -49,7 +49,7 @@ final class SessionStorageTestCase: BaseTestCase {
         try? Current.keychainClient.removeItem(item: keychainItem)
 
         // set the date created offset to only 5 minutes so that the IST is still valid
-        keychainDateCreatedOffsetInMinutes = 5
+        userDefaultsLastModifiedOffset = 5
 
         // call updateSession with only the IST which will assign it to the keychain item for the IST
         Current.sessionManager.updateSession(intermediateSessionToken: "1234567890")

--- a/tutorials/Sessions.md
+++ b/tutorials/Sessions.md
@@ -2,7 +2,7 @@
 Stytch user sessions are identified by a `Session` or `MemberSession` object, a session token and a JWT (JSON Web Token) that are authenticated on, and returned from, our authentication endpoints. The Stytch iOS SDK automatically persists these tokens and appends them to network requests as required, to make interacting with Stytch's authentication flows as simple as possible, and provides both Automatic and Manual session management helpers.
 
 ## Session Data Persistence
-The Stytch iOS SDK persists to the keychain a few sets of encrypted values using AES256-GCM which are accessible across launches and help with session management:
+The Stytch iOS SDK persists to UserDefaults a few sets of encrypted values using AES256-GCM which are accessible across launches and help with session management:
 1. The session token and JWT.
 2. For the consumer client: `Session` and `User`.
 3. For the B2B client: `MemberSession`, `Member` and `Organization`.
@@ -10,7 +10,7 @@ The Stytch iOS SDK persists to the keychain a few sets of encrypted values using
 The `Session` / `MemberSession` object is the definitive source of truth for if the user is logged in or not as it contains an expiration date property for when the session expires.
 
 ## Automatic Session Management
-When the Stytch iOS SDK is initialized, it decrypts the persisted session tokens and `Session` / `MemberSession` object, if any, and attempts to make a Sessions Authenticate call to ensure the session is still active/valid. On every authentication response, the SDK updates the in-memory and device-persisted session data with the latest data returned from the endpoint. In addition, once the SDK receives a valid session, it begins an automatic "heartbeat" job that checks for continued session validity in the background, roughly every three minutes. This heartbeat does not extend an existing session, it merely checks it's validity and updates the local data as appropriate. You as the developer can either observe changes in the session via the combine publisher shown below or directly though the `StytchClient.sessions.session` which both access the Session object stored in the keychain.
+When the Stytch iOS SDK is initialized, it decrypts the persisted session tokens and `Session` / `MemberSession` object, if any, and attempts to make a Sessions Authenticate call to ensure the session is still active/valid. On every authentication response, the SDK updates the in-memory and device-persisted session data with the latest data returned from the endpoint. In addition, once the SDK receives a valid session, it begins an automatic "heartbeat" job that checks for continued session validity in the background, roughly every three minutes. This heartbeat does not extend an existing session, it merely checks it's validity and updates the local data as appropriate. You as the developer can either observe changes in the session via the combine publisher shown below or directly though the `StytchClient.sessions.session` which both access the Session object stored (encrypted) in UserDefaults.
 
 It is then good practice when using the Stytch iOS SDK to access any data that may have been updated via the heartbeat call through their cached values. Otherwise if you hold onto a reference of a response that contains authentication information in it, like token or user, you risk the those values returned in the response becoming stale. Values updated via the heartbeat are: `Session`, `User`, `MemberSession`, `Member` `Organization`, `sessionToken` and  `sessionJwt`. 
 


### PR DESCRIPTION
Linear Ticket: [SDK-2742](https://linear.app/stytch/issue/SDK-2742)

Because there have been reported issues with accessing data in the Keychain, particularly when returning or launching from a background state, we have decided to move the bulk of the data we were _previously_ storing in the Keychain into UserDefaults. All data is encrypted before persisting to UserDefaults, with a key stored in the Keychain, so even if a malicious actor gained access to a device and could exfiltrate the UserDefaults file, it would remain encrypted. This follows the same pattern used in the Android and ReactNative SDKs.

Biometric registration data, being tied to FaceID/TouchID, remains in the keychain.

## Changes:

1. Updates all of the getters and setters for session/user/member/organization/PKCE data to use UserDefaults instead of the Keychain
2. Updates all of the above to implement the appropriate encryption/decryption with a Keychain-backed AES-256 key
3. Updates/adds tests as appropriate

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
