### PR TITLE
SDK-2744 Bump DFP dependency to signed version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(url: "https://github.com/marmelroy/PhoneNumberKit", .exact("3.8.0")),
         .package(url: "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk", .exact("18.7.0")),
         .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", from: "5.0.2"),
-        .package(url: "https://github.com/stytchauth/stytch-ios-dfp.git", from: "1.0.2"),
+        .package(url: "https://github.com/stytchauth/stytch-ios-dfp.git", from: "1.0.4"),
     ],
     targets: [
         .target(

--- a/Stytch/Stytch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stytch/Stytch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/stytchauth/stytch-ios-dfp.git",
         "state": {
           "branch": null,
-          "revision": "2c2147580d6ab6b85e89d3fe6e4038d78da6f9bd",
-          "version": "1.0.2"
+          "revision": "1d597b8613986b61509508f3bee800cd5d1778f4",
+          "version": "1.0.4"
         }
       },
       {


### PR DESCRIPTION
Linear Ticket: [SDK-2744](https://linear.app/stytch/issue/SDK-2744)

## Changes:

1. Previous versions of the native DFP XCFramework were not being signed. Update to the latest version that _is_ signed

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
