### PR TITLE
SDK-2744 Add explicit canImport checks around DFP

### DIFF
--- a/Sources/StytchCore/CaptchaClient.swift
+++ b/Sources/StytchCore/CaptchaClient.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if canImport(RecaptchaEnterprise)
 import Foundation
 import RecaptchaEnterprise
 

--- a/Sources/StytchCore/DFPClient.swift
+++ b/Sources/StytchCore/DFPClient.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if canImport(StytchDFP)
 import Foundation
 import StytchDFP
 

--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -113,7 +113,7 @@ struct Environment {
         set { _passkeysClent = newValue }
     }
     #endif
-    #if os(iOS)
+    #if canImport(StytchDFP)
     var dfpClient: DFPProvider = DFPClient()
     var captcha: CaptchaProvider = CaptchaClient()
     #endif

--- a/Sources/StytchCore/Networking/NetworkRequestHandler.swift
+++ b/Sources/StytchCore/Networking/NetworkRequestHandler.swift
@@ -7,7 +7,7 @@ internal protocol NetworkRequestHandler {
 
     init(urlSession: URLSession)
 
-    #if os(iOS)
+    #if canImport(StytchDFP) && canImport(RecaptchaEnterprise)
     var captchaProvider: CaptchaProvider { get }
     var dfpProvider: DFPProvider { get }
 
@@ -20,7 +20,7 @@ internal protocol NetworkRequestHandler {
 }
 
 extension NetworkRequestHandler {
-    #if os(iOS)
+    #if canImport(StytchDFP) && canImport(RecaptchaEnterprise)
     func handleDFPDisabled(request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         // DISABLED = if captcha client is configured, add a captcha token, else do nothing
         if captchaProvider.isConfigured() == false {
@@ -76,7 +76,7 @@ extension NetworkRequestHandler {
 internal struct NetworkRequestHandlerImplementation: NetworkRequestHandler {
     let urlSession: URLSession
 
-    #if os(iOS)
+    #if canImport(StytchDFP) && canImport(RecaptchaEnterprise)
     var captchaProvider: CaptchaProvider {
         Current.captcha
     }

--- a/Sources/StytchCore/Networking/NetworkingClient.swift
+++ b/Sources/StytchCore/Networking/NetworkingClient.swift
@@ -72,7 +72,7 @@ final class NetworkingClientImplementation: NetworkingClient {
     }
 
     func handleRequest(request: URLRequest, useDFPPA: Bool) async throws -> (Data, HTTPURLResponse) {
-        #if os(iOS)
+        #if canImport(StytchDFP)
         if useDFPPA == true {
             if dfpEnabled == true {
                 switch dfpAuthMode {

--- a/Sources/StytchCore/PasskeysClient/PasskeysClient+Live.swift
+++ b/Sources/StytchCore/PasskeysClient/PasskeysClient+Live.swift
@@ -40,17 +40,16 @@ extension PasskeysClient {
 
             let credential: ASAuthorizationCredential = try await withCheckedThrowingContinuation { continuation in
                 delegate.continuation = continuation
+                #if os(iOS) && !targetEnvironment(macCatalyst)
                 switch requestBehavior {
-                #if os(iOS)
                 case .autoFill:
                     controller.performAutoFillAssistedRequests()
                 case let .default(preferLocalCredentials):
                     controller.performRequests(options: preferLocalCredentials ? .preferImmediatelyAvailableCredentials : [])
-                #else
-                case .default:
-                    controller.performRequests()
-                #endif
                 }
+                #else
+                controller.performRequests()
+                #endif
             }
 
             guard let credential = credential as? ASAuthorizationPublicKeyCredentialAssertion else {

--- a/Sources/StytchCore/StartupClient.swift
+++ b/Sources/StytchCore/StartupClient.swift
@@ -65,7 +65,7 @@ struct StartupClient {
             print("This application is using a Stytch client for B2B projects, but the public token is for a Stytch Consumer project. Use a Consumer Stytch client instead, or verify that the public token is correct.")
         }
 
-        #if os(iOS)
+        #if canImport(StytchDFP)
         Current.networkingClient.configureDFP(
             dfpEnabled: bootstrapData.dfpProtectedAuthEnabled,
             dfpAuthMode: bootstrapData.dfpProtectedAuthMode

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+DFP.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+DFP.swift
@@ -6,13 +6,13 @@ public extension StytchB2BClient {
 
 public extension StytchB2BClient {
     struct DFP {
-        #if os(iOS)
+        #if canImport(StytchDFP)
         @Dependency(\.dfpClient) private var dfpClient
         #endif
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Returns a DFP Telemetry ID
         public func getTelemetryID() async throws -> String {
-            #if os(iOS)
+            #if canImport(StytchDFP)
             let telemetryId = await dfpClient.getTelemetryId()
             return telemetryId
             #else

--- a/Sources/StytchCore/StytchClient/DFP/StytchClient+DFP.swift
+++ b/Sources/StytchCore/StytchClient/DFP/StytchClient+DFP.swift
@@ -6,13 +6,13 @@ public extension StytchClient {
 
 public extension StytchClient {
     struct DFP {
-        #if os(iOS)
+        #if canImport(StytchDFP)
         @Dependency(\.dfpClient) private var dfpClient
         #endif
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Returns a DFP Telemetry ID
         public func getTelemetryID() async throws -> String {
-            #if os(iOS)
+            #if canImport(StytchDFP)
             let telemetryId = await dfpClient.getTelemetryId()
             return telemetryId
             #else

--- a/Sources/StytchCore/StytchClientType.swift
+++ b/Sources/StytchCore/StytchClientType.swift
@@ -59,7 +59,7 @@ extension StytchClientType {
         runKeychainMigrations()
         sessionManager.clearEmptyTokens()
 
-        #if os(iOS)
+        #if canImport(StytchDFP)
         if let publicToken = configuration?.publicToken {
             Current.dfpClient.configure(publicToken: publicToken, dfppaDomain: configuration?.dfppaDomain)
         }

--- a/Stytch/Stytch.xcodeproj/project.pbxproj
+++ b/Stytch/Stytch.xcodeproj/project.pbxproj
@@ -991,6 +991,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.stytch.StytchUIDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				"SWIFT_OBJC_BRIDGING_HEADER[arch=*]" = "";
@@ -1032,6 +1034,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.stytch.StytchUIDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				"SWIFT_OBJC_BRIDGING_HEADER[arch=*]" = "";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
Linear Ticket: [SDK-2744](https://linear.app/stytch/issue/SDK-2744)

When building macCatalyst apps, the os is still considered iOS, but the binary framework is not available for macOS, so it fails to link correctly.

## Changes:

1.  Instead of relying on `os()` macros, use explicit checks for being able to import the desired modules
2. Fixes an additional issue with the passkeys implementation on macCatalyst, where `performAutoFillAssistedRequests` is explicitly disallowed for that platform

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
