### PR TITLE
Add @preconcurrency to RecaptchaEnterprise

### DIFF
--- a/Sources/StytchCore/CaptchaClient.swift
+++ b/Sources/StytchCore/CaptchaClient.swift
@@ -1,6 +1,6 @@
 #if canImport(RecaptchaEnterprise)
 import Foundation
-import RecaptchaEnterprise
+@preconcurrency import RecaptchaEnterprise
 
 internal protocol CaptchaProvider {
     func setCaptchaClient(siteKey: String) async


### PR DESCRIPTION
Linear Ticket: [LINEAR_NUMBER](https://linear.app/stytch/issue/YOUR_TICKET)

## Changes:

1. Add @preconcurrency to RecaptchaEnterprise

This Enables Xcode 26 to be used[until Google fixes](https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk/issues/146) this and releases a swift 6 version of the client. 

I tested with Xcode 26, but not Xcode 16

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A
