### PR TITLE
[INFRA-2910] update CI token to org Github token

### DIFF
--- a/.github/workflows/cut_version.yml
+++ b/.github/workflows/cut_version.yml
@@ -21,7 +21,7 @@ jobs:
 
     - uses: actions/checkout@v3
       with:
-        token: ${{ secrets.CI_TOKEN }}
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
     - name: Ensure unique tag
       run: if [[ $(git tag -l $(Scripts/version show-current)) ]]; then exit 1; fi
@@ -31,14 +31,17 @@ jobs:
         git tag $(Scripts/version show-current)
         git push --tags
 
-    - name: Git Config
+    - name: Configure git to allow push to private repo
+      env:
+        TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       run: |
-        git config --local user.name "CI"
-        git config --local user.email "ci@stytch.com"
+        git config --global url."https://ci-stytch:${TOKEN}@github.com/stytchauth".insteadOf "https://github.com/stytchauth"
+        git config --global user.email "ci-stytch@stytch.com"
+        git config --global user.name "ci-stytch"
 
     - name: Bump version
       env:
-        GH_TOKEN: ${{ secrets.CI_TOKEN }}
+        GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       run: |
         Scripts/version increment ${{ github.event.inputs.release_type }}
         branch_name="version-increment/$(Scripts/version show-current)"
@@ -51,5 +54,5 @@ jobs:
 
     - name: Approve version PR
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       run: gh pr review --approve


### PR DESCRIPTION
Linear Ticket: [INFRA-2910](https://linear.app/stytch/issue/INFRA-2910)

## Changes:

1. I've added access to the org's `PERSONAL_ACCESS_TOKEN` secret to this repo
2. I've updated the workflow that uses the CI token to use this org-wide secret instead for the ci-stytch user