### PR TITLE
Make Captcha Opt In

### DIFF
--- a/CaptchaIntegrationGuide.md
+++ b/CaptchaIntegrationGuide.md
@@ -1,0 +1,144 @@
+# Stytch Captcha Integration Guide
+
+The Stytch iOS SDK now supports **optional** captcha integration through a separate `StytchCaptcha` package. This allows you to include Google's RecaptchaEnterprise only when needed, reducing your app's binary size when captcha functionality isn't required.
+
+## Overview
+
+The captcha functionality has been restructured into:
+
+- **`StytchCore`**: Contains the `CaptchaProvider` protocol and a `NoOpCaptchaProvider` (default)
+- **`StytchCaptcha`**: Contains the full `CaptchaClient` implementation with RecaptchaEnterprise
+
+## Installation
+
+### Option 1: Basic Usage (No Captcha)
+
+If you don't need captcha functionality, simply use StytchCore as before:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/stytchauth/stytch-ios", from: "1.0.0")
+],
+targets: [
+    .target(
+        name: "YourApp",
+        dependencies: [
+            .product(name: "StytchCore", package: "stytch-ios")
+        ]
+    )
+]
+```
+
+### Option 2: With Captcha Support
+
+If you need captcha functionality, add both packages:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/stytchauth/stytch-ios", from: "1.0.0")
+],
+targets: [
+    .target(
+        name: "YourApp",
+        dependencies: [
+            .product(name: "StytchCore", package: "stytch-ios"),
+            .product(name: "StytchCaptcha", package: "stytch-ios")
+        ]
+    )
+]
+```
+
+## Usage
+
+### Basic Setup (No Captcha)
+
+```swift
+import StytchCore
+
+// Configure Stytch as usual
+StytchClient.configure(configuration: .init(publicToken: "your-public-token"))
+
+// The SDK will use NoOpCaptchaProvider by default - no captcha functionality
+```
+
+### Setup with Captcha Support
+
+```swift
+import StytchCore
+import StytchCaptcha
+
+// Configure Stytch
+StytchClient.configure(configuration: .init(publicToken: "your-public-token"))
+
+// Configure captcha provider
+StytchClient.configureCaptcha(captchaProvider: CaptchaClient())
+```
+
+### For B2B Projects
+
+```swift
+import StytchCore
+import StytchCaptcha
+
+// Configure Stytch B2B
+StytchB2BClient.configure(configuration: .init(publicToken: "your-public-token"))
+
+// Configure captcha provider
+StytchB2BClient.configureCaptcha(captchaProvider: CaptchaClient())
+```
+
+## Custom Captcha Provider
+
+You can also implement your own captcha provider by conforming to the `CaptchaProvider` protocol:
+
+```swift
+import StytchCore
+
+class MyCustomCaptchaProvider: CaptchaProvider {
+    func setCaptchaClient(siteKey: String) async {
+        // Your custom captcha setup
+    }
+    
+    func executeRecaptcha() async -> String {
+        // Your custom captcha execution
+        return "your-captcha-token"
+    }
+    
+    func isConfigured() -> Bool {
+        // Return whether captcha is ready
+        return true
+    }
+}
+
+// Use your custom provider
+StytchClient.configureCaptcha(captchaProvider: MyCustomCaptchaProvider())
+```
+
+## Migration from Previous Versions
+
+If you were previously using Stytch with built-in captcha support:
+
+### Before
+```swift
+import StytchCore
+
+StytchClient.configure(configuration: .init(publicToken: "your-token"))
+// Captcha was automatically available
+```
+
+### After (with captcha)
+```swift
+import StytchCore
+import StytchCaptcha
+
+StytchClient.configure(configuration: .init(publicToken: "your-token"))
+StytchClient.configureCaptcha(captchaProvider: CaptchaClient())
+```
+
+### After (without captcha)
+```swift
+import StytchCore
+
+StytchClient.configure(configuration: .init(publicToken: "your-token"))
+// No additional setup needed - captcha is disabled by default
+```

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
     products: [
         .library(name: "StytchCore", targets: ["StytchCore"]),
         .library(name: "StytchUI", targets: ["StytchUI"]),
+        .library(name: "StytchCaptcha", targets: ["StytchCaptcha"]),
     ],
     dependencies: [
         .package(url: "https://github.com/marmelroy/PhoneNumberKit", .exact("3.8.0")),
@@ -34,12 +35,18 @@ let package = Package(
         .target(
             name: "StytchCore",
             dependencies: [
-                .product(name: "RecaptchaEnterprise", package: "recaptcha-enterprise-mobile-sdk", condition: .when(platforms: [.iOS])),
                 .product(name: "StytchDFP", package: "stytch-ios-dfp", condition: .when(platforms: [.iOS])),
                 .product(name: "SwiftyJSON", package: "SwiftyJSON"),
             ],
             resources: [
                 .process("PrivacyInfo.xcprivacy"),
+            ]
+        ),
+        .target(
+            name: "StytchCaptcha",
+            dependencies: [
+                .target(name: "StytchCore"),
+                .product(name: "RecaptchaEnterprise", package: "recaptcha-enterprise-mobile-sdk", condition: .when(platforms: [.iOS])),
             ]
         ),
         .testTarget(name: "StytchCoreTests", dependencies: ["StytchCore"]),

--- a/Sources/StytchCaptcha/CaptchaClient.swift
+++ b/Sources/StytchCaptcha/CaptchaClient.swift
@@ -1,0 +1,59 @@
+import Foundation
+import StytchCore
+
+#if canImport(RecaptchaEnterprise)
+import RecaptchaEnterprise
+
+/// Implementation of CaptchaProvider that uses Google's RecaptchaEnterprise
+public final class CaptchaClient: CaptchaProvider {
+    private var recaptchaClient: RecaptchaClient?
+    
+    public init() {}
+
+    public func isConfigured() -> Bool {
+        recaptchaClient != nil
+    }
+
+    public func executeRecaptcha() async -> String {
+        guard let recaptchaClient = recaptchaClient else {
+            return ""
+        }
+        do {
+            return try await recaptchaClient.execute(withAction: RecaptchaAction.login)
+        } catch let error as RecaptchaError {
+            print("RecaptchaClient execute error: \(String(describing: error.errorMessage)).")
+            return ""
+        } catch {
+            print("RecaptchaClient execute error: \(String(describing: error)).")
+            return ""
+        }
+    }
+
+    public func setCaptchaClient(siteKey: String) async {
+        do {
+            recaptchaClient = try await Recaptcha.fetchClient(withSiteKey: siteKey)
+        } catch let error as RecaptchaError {
+            print("RecaptchaClient creation error: \(String(describing: error.errorMessage)).")
+        } catch {
+            print("RecaptchaClient creation error: \(String(describing: error))")
+        }
+    }
+}
+#else
+/// Fallback implementation when RecaptchaEnterprise is not available
+public final class CaptchaClient: CaptchaProvider {
+    public init() {}
+    
+    public func setCaptchaClient(siteKey: String) async {
+        print("RecaptchaEnterprise not available on this platform")
+    }
+    
+    public func executeRecaptcha() async -> String {
+        return ""
+    }
+    
+    public func isConfigured() -> Bool {
+        return false
+    }
+}
+#endif 

--- a/Sources/StytchCore/CaptchaClient.swift
+++ b/Sources/StytchCore/CaptchaClient.swift
@@ -1,45 +1,29 @@
-#if canImport(RecaptchaEnterprise)
 import Foundation
-import RecaptchaEnterprise
 
-internal protocol CaptchaProvider {
+/// Protocol defining the interface for captcha providers
+public protocol CaptchaProvider: Sendable {
     func setCaptchaClient(siteKey: String) async
-
     func executeRecaptcha() async -> String
-
     func isConfigured() -> Bool
 }
 
-final class CaptchaClient: CaptchaProvider {
-    private var recaptchaClient: RecaptchaClient?
-
-    func isConfigured() -> Bool {
-        recaptchaClient != nil
+/// No-op implementation of CaptchaProvider for when captcha functionality is not needed
+public final class NoOpCaptchaProvider: CaptchaProvider {
+    public init() {}
+    
+    public func setCaptchaClient(siteKey: String) async {
+        // No-op implementation
     }
-
-    func executeRecaptcha() async -> String {
-        guard let recaptchaClient = recaptchaClient else {
-            return ""
-        }
-        do {
-            return try await recaptchaClient.execute(withAction: RecaptchaAction.login)
-        } catch let error as RecaptchaError {
-            print("RecaptchaClient execute error: \(String(describing: error.errorMessage)).")
-            return ""
-        } catch {
-            print("RecaptchaClient execute error: \(String(describing: error)).")
-            return ""
-        }
+    
+    public func executeRecaptcha() async -> String {
+        // Returns empty string when no captcha is configured
+        return ""
     }
-
-    func setCaptchaClient(siteKey: String) async {
-        do {
-            recaptchaClient = try await Recaptcha.fetchClient(withSiteKey: siteKey)
-        } catch let error as RecaptchaError {
-            print("RecaptchaClient creation error: \(String(describing: error.errorMessage)).")
-        } catch {
-            print("RecaptchaClient creation error: \(String(describing: error))")
-        }
+    
+    public func isConfigured() -> Bool {
+        // Always returns false for no-op implementation
+        return false
     }
 }
-#endif
+
+

--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -115,8 +115,9 @@ struct Environment {
     #endif
     #if canImport(StytchDFP)
     var dfpClient: DFPProvider = DFPClient()
-    var captcha: CaptchaProvider = CaptchaClient()
     #endif
+    
+    var captcha: CaptchaProvider = NoOpCaptchaProvider()
 
     #if !os(tvOS) && !os(watchOS)
     var localAuthenticationContext: LAContextEvaluating = LAContext()

--- a/Sources/StytchCore/Networking/NetworkRequestHandler.swift
+++ b/Sources/StytchCore/Networking/NetworkRequestHandler.swift
@@ -7,7 +7,7 @@ internal protocol NetworkRequestHandler {
 
     init(urlSession: URLSession)
 
-    #if canImport(StytchDFP) && canImport(RecaptchaEnterprise)
+    #if canImport(StytchDFP)
     var captchaProvider: CaptchaProvider { get }
     var dfpProvider: DFPProvider { get }
 
@@ -20,7 +20,7 @@ internal protocol NetworkRequestHandler {
 }
 
 extension NetworkRequestHandler {
-    #if canImport(StytchDFP) && canImport(RecaptchaEnterprise)
+    #if canImport(StytchDFP)
     func handleDFPDisabled(request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         // DISABLED = if captcha client is configured, add a captcha token, else do nothing
         if captchaProvider.isConfigured() == false {
@@ -76,15 +76,15 @@ extension NetworkRequestHandler {
 internal struct NetworkRequestHandlerImplementation: NetworkRequestHandler {
     let urlSession: URLSession
 
-    #if canImport(StytchDFP) && canImport(RecaptchaEnterprise)
-    var captchaProvider: CaptchaProvider {
-        Current.captcha
-    }
-
+    #if canImport(StytchDFP)
     var dfpProvider: DFPProvider {
         Current.dfpClient
     }
     #endif
+    
+    var captchaProvider: CaptchaProvider {
+        Current.captcha
+    }
 
     init(urlSession: URLSession) {
         self.urlSession = urlSession

--- a/Sources/StytchCore/StartupClient.swift
+++ b/Sources/StytchCore/StartupClient.swift
@@ -70,11 +70,11 @@ struct StartupClient {
             dfpEnabled: bootstrapData.dfpProtectedAuthEnabled,
             dfpAuthMode: bootstrapData.dfpProtectedAuthMode
         )
+        #endif
 
         if let siteKey = bootstrapData.captchaSettings.siteKey, !siteKey.isEmpty {
             await Current.captcha.setCaptchaClient(siteKey: siteKey)
         }
-        #endif
     }
 
     @discardableResult static func bootstrap() async throws -> BootstrapResponseData {

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient.swift
@@ -60,6 +60,24 @@ public struct StytchB2BClient: StytchClientType {
     public static func configure(configuration: StytchClientConfiguration) {
         instance.configure(newConfiguration: configuration)
     }
+    
+    /**
+     Configures the captcha provider for the `StytchB2BClient`
+     - Parameters:
+       - captchaProvider: An implementation of `CaptchaProvider` to use for captcha functionality. Use `CaptchaClient()` from `StytchCaptcha` package for full functionality, or provide your own implementation.
+       
+     # Example
+     ```swift
+     import StytchCore
+     import StytchCaptcha
+     
+     StytchB2BClient.configure(configuration: .init(publicToken: "your-token"))
+     StytchB2BClient.configureCaptcha(captchaProvider: CaptchaClient())
+     ```
+     */
+    public static func configureCaptcha(captchaProvider: CaptchaProvider) {
+        Current.captcha = captchaProvider
+    }
 
     // swiftlint:disable:next orphaned_doc_comment
     ///  A helper function for parsing out the Stytch token types and values from a given deeplink

--- a/Sources/StytchCore/StytchClient/StytchClient.swift
+++ b/Sources/StytchCore/StytchClient/StytchClient.swift
@@ -60,6 +60,24 @@ public struct StytchClient: StytchClientType {
     public static func configure(configuration: StytchClientConfiguration) {
         instance.configure(newConfiguration: configuration)
     }
+    
+    /**
+     Configures the captcha provider for the `StytchClient`
+     - Parameters:
+       - captchaProvider: An implementation of `CaptchaProvider` to use for captcha functionality. Use `CaptchaClient()` from `StytchCaptcha` package for full functionality, or provide your own implementation.
+       
+     # Example
+     ```swift
+     import StytchCore
+     import StytchCaptcha
+     
+     StytchClient.configure(configuration: .init(publicToken: "your-token"))
+     StytchClient.configureCaptcha(captchaProvider: CaptchaClient())
+     ```
+     */
+    public static func configureCaptcha(captchaProvider: CaptchaProvider) {
+        Current.captcha = captchaProvider
+    }
 
     // swiftlint:disable:next orphaned_doc_comment
     ///  A helper function for parsing out the Stytch token types and values from a given deeplink


### PR DESCRIPTION
I dont know if this is something y'all will even consider, but our project doesn't use Captcha, and Stytch force includes it, and sets it up. This leads to larger binary than necessary for our app, and includes code execution and memory were not interested in. 

This PR allows Captcha to be opt-in. However it is a breaking change requiring users who were using it to opt-in

I made the injection points not required, but if we wanted to make sure people used the new captcha protocol, we could make it required by changing the function signature here
`StytchClient.configure(configuration: .init(publicToken: "your-public-token"))`

## Benefits

1. Apps that don't need captcha won't include the RecaptchaEnterprise framework
3. Use the provided implementation or create your own
4. **Breaking change** Existing code continues to work (captcha is just disabled by default)

## Architecture Details

The new architecture uses dependency injection through the `CaptchaProvider` protocol:

- **Protocol**: `CaptchaProvider` defines the interface
- **Default Implementation**: `NoOpCaptchaProvider` (does nothing)
- **Full Implementation**: `CaptchaClient` (uses RecaptchaEnterprise)
- **Injection Point**: `StytchClient.configureCaptcha()` or `StytchB2BClient.configureCaptcha()`

