### PR TITLE
SDK-2792 UserDefaults guardrails and waiting for protected data

### DIFF
--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClientImplementation.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClientImplementation.swift
@@ -1,63 +1,92 @@
 import CryptoKit
 import Foundation
 
-class EncryptedUserDefaultsClientImplementation: EncryptedUserDefaultsClient {
-    private let keychainClient: KeychainClient
+final class EncryptedUserDefaultsClientImplementation: EncryptedUserDefaultsClient {
+    static let shared = EncryptedUserDefaultsClientImplementation()
+    @Dependency(\.keychainClient) private var keychainClient
+    private let queue: DispatchQueue
+    private let queueKey = DispatchSpecificKey<Void>()
+
+    private var isOnQueue: Bool {
+        DispatchQueue.getSpecific(key: queueKey) != nil
+    }
 
     internal let defaults: UserDefaults = .init(suiteName: "StytchEncryptedUserDefaults") ?? .standard
 
-    init(keychainClient: KeychainClient) {
-        self.keychainClient = keychainClient
+    private init() {
+        queue = DispatchQueue(label: "StytchEncryptedUserDefaultsClientQueue")
+        queue.setSpecific(key: queueKey, value: ())
+    }
+
+    private func safelyEnqueue<T>(_ block: () throws -> T) throws -> T {
+        if isOnQueue {
+            return try block()
+        } else {
+            return try queue.sync { try block() }
+        }
     }
 
     func getItem(item: EncryptedUserDefaultsItem) throws -> EncryptedUserDefaultsItemResult? {
-        let userDefaultsData = defaults.data(forKey: item.name)
-        guard let decrypted = decryptData(encryptedData: userDefaultsData) else {
-            return nil
+        try safelyEnqueue {
+            let userDefaultsData = defaults.data(forKey: item.name)
+            guard let decrypted = decryptData(encryptedData: userDefaultsData) else {
+                return nil
+            }
+            guard let data = decrypted.data(using: .utf8) else {
+                return nil
+            }
+            return .init(data: data)
         }
-        guard let data = decrypted.data(using: .utf8) else {
-            return nil
-        }
-        return .init(data: data)
     }
 
     func itemExists(item: EncryptedUserDefaultsItem) -> Bool {
-        let encryptedData = defaults.data(forKey: item.name)
-        return encryptedData != nil
+        let result = try? safelyEnqueue {
+            let encryptedData = defaults.data(forKey: item.name)
+            return encryptedData != nil
+        }
+        return result ?? false
     }
 
     func setValueForItem(value: String?, item: EncryptedUserDefaultsItem) throws {
-        guard let valueString = value else {
-            return removeItem(item: item)
+        try safelyEnqueue {
+            guard let valueString = value else {
+                return removeItem(item: item)
+            }
+            let encryptedText = try encryptString(plainText: valueString)
+            defaults.set(encryptedText, forKey: item.name)
+            let encryptedDate = try encryptString(plainText: Date().asJson(encoder: Current.jsonEncoder))
+            defaults.set(encryptedDate, forKey: EncryptedUserDefaultsItem.lastValidatedAtDate(item.name).name)
         }
-        let encryptedText = try encryptString(plainText: valueString)
-        defaults.set(encryptedText, forKey: item.name)
-        let encryptedDate = try encryptString(plainText: Date().asJson(encoder: Current.jsonEncoder))
-        defaults.set(encryptedDate, forKey: EncryptedUserDefaultsItem.lastValidatedAtDate(item.name).name)
     }
 
     func removeItem(item: EncryptedUserDefaultsItem) {
-        defaults.removeObject(forKey: item.name)
-        defaults.removeObject(forKey: EncryptedUserDefaultsItem.lastValidatedAtDate(item.name).name)
+        try? safelyEnqueue {
+            defaults.removeObject(forKey: item.name)
+            defaults.removeObject(forKey: EncryptedUserDefaultsItem.lastValidatedAtDate(item.name).name)
+        }
     }
 
     private func encryptString(plainText: String) throws -> Data? {
-        guard let encryptionKey = keychainClient.encryptionKey else { return nil }
-        let sealedBox = try AES.GCM.seal(
-            Data(plainText.utf8),
-            using: encryptionKey
-        )
-        return sealedBox.combined
+        try safelyEnqueue {
+            guard let encryptionKey = keychainClient.encryptionKey else { return nil }
+            let sealedBox = try AES.GCM.seal(
+                Data(plainText.utf8),
+                using: encryptionKey
+            )
+            return sealedBox.combined
+        }
     }
 
     private func decryptData(encryptedData: Data?) -> String? {
-        guard let encryptionKey = keychainClient.encryptionKey, let encryptedData else { return nil }
-        do {
-            let sealedBox = try AES.GCM.SealedBox(combined: encryptedData)
-            let decryptedData = try AES.GCM.open(sealedBox, using: encryptionKey)
-            return String(data: decryptedData, encoding: .utf8)
-        } catch {
-            return nil
+        try? safelyEnqueue {
+            guard let encryptionKey = keychainClient.encryptionKey, let encryptedData else { return nil }
+            do {
+                let sealedBox = try AES.GCM.SealedBox(combined: encryptedData)
+                let decryptedData = try AES.GCM.open(sealedBox, using: encryptionKey)
+                return String(data: decryptedData, encoding: .utf8)
+            } catch {
+                return nil
+            }
         }
     }
 }

--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -71,7 +71,7 @@ struct Environment {
 
     var keychainClient: KeychainClient = KeychainClientImplementation.shared
 
-    var userDefaultsClient: EncryptedUserDefaultsClient = EncryptedUserDefaultsClientImplementation(keychainClient: KeychainClientImplementation.shared)
+    var userDefaultsClient: EncryptedUserDefaultsClient = EncryptedUserDefaultsClientImplementation.shared
 
     var networkMonitor: NetworkMonitor = .init()
 

--- a/Sources/StytchCore/KeychainClient/KeychainClient.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient.swift
@@ -8,6 +8,7 @@ protocol KeychainClient: AnyObject {
     func valueExistsForItem(item: KeychainItem) -> Bool
     func setValueForItem(value: KeychainItem.Value, item: KeychainItem) throws
     func removeItem(item: KeychainItem) throws
+    func onProtectedDataDidBecomeAvailable()
 }
 
 extension KeychainClient {

--- a/Sources/StytchCore/KeychainClient/KeychainClientImplementation.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClientImplementation.swift
@@ -19,7 +19,12 @@ final class KeychainClientImplementation: KeychainClient {
     private init() {
         queue = DispatchQueue(label: "StytchKeychainClientQueue")
         queue.setSpecific(key: queueKey, value: ())
-        encryptionKey = try? getEncryptionKey()
+    }
+
+    func onProtectedDataDidBecomeAvailable() {
+        try? safelyEnqueue {
+            encryptionKey = try? getEncryptionKey()
+        }
     }
 
     func safelyEnqueue<T>(_ block: () throws -> T) throws -> T {

--- a/Sources/StytchCore/StytchClientType.swift
+++ b/Sources/StytchCore/StytchClientType.swift
@@ -82,16 +82,18 @@ extension StytchClientType {
                 }
             }
         }
-        #endif
-
-        Task {
-            do {
-                try await StartupClient.start(clientType: Self.clientType)
-                try? await EventsClient.logEvent(parameters: .init(eventName: "client_initialization_success"))
-            } catch {
-                try? await EventsClient.logEvent(parameters: .init(eventName: "client_initialization_failure"))
+        if UIApplication.shared.isProtectedDataAvailable {
+            keychainClient.onProtectedDataDidBecomeAvailable()
+            defaultStartupFlow()
+        } else {
+            NotificationCenter.default.addObserver(forName: UIApplication.protectedDataDidBecomeAvailableNotification, object: nil, queue: nil) { _ in
+                keychainClient.onProtectedDataDidBecomeAvailable()
+                defaultStartupFlow()
             }
         }
+        #else
+        defaultStartupFlow()
+        #endif
     }
 
     // swiftlint:disable:next identifier_name large_tuple
@@ -136,6 +138,17 @@ extension StytchClientType {
                 defaults.set(true, forKey: migrationName)
             } catch {
                 print(error)
+            }
+        }
+    }
+
+    private func defaultStartupFlow() {
+        Task {
+            do {
+                try await StartupClient.start(clientType: Self.clientType)
+                try? await EventsClient.logEvent(parameters: .init(eventName: "client_initialization_success"))
+            } catch {
+                try? await EventsClient.logEvent(parameters: .init(eventName: "client_initialization_failure"))
             }
         }
     }

--- a/Tests/StytchCoreTests/KeychainClient+Mock.swift
+++ b/Tests/StytchCoreTests/KeychainClient+Mock.swift
@@ -6,6 +6,8 @@ import Foundation
 public var keychainDateCreatedOffsetInMinutes = 0
 
 class KeychainClientMock: KeychainClient {
+    func onProtectedDataDidBecomeAvailable() {}
+
     var encryptionKey: SymmetricKey? {
         do {
             return SymmetricKey(data: try Current.cryptoClient.dataWithRandomBytesOfCount(256))


### PR DESCRIPTION
Linear Ticket: [SDK-2792](https://linear.app/stytch/issue/SDK-2792)

## Changes:

1. Add a DispatchQueue to EncryptedUserDefaults the same way we did to the KeychainClient
2. Don't trigger the startup flow (or attempt to retrieve the encryption key) until we are sure that protectedData is available

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
