### PR TITLE
Guard against session storms and expose reasons for unavailable cases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # @stytchauth/mobile-sdks will be requested for
 # review when someone opens a pull request.
-*       @stytchauth/mobile-sdks
+*       @stytchauth/mobile-sdks @stytchauth/frontend

--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClient.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClient.swift
@@ -12,12 +12,19 @@ extension EncryptedUserDefaultsClient {
         guard let result = try getItem(item: item) else {
             return nil
         }
-        let data = try Current.jsonDecoder.decode(T.self, from: result.data)
-        return data
+        do {
+            return try Current.jsonDecoder.decode(T.self, from: result.data)
+        } catch {
+            throw EncryptedUserDefaultsError.dataCouldNotBeMarshalled
+        }
     }
 
     func getStringValue(_ item: EncryptedUserDefaultsItem) throws -> String? {
-        try getItem(item: item)?.stringValue
+        do {
+            return try getItem(item: item)?.stringValue
+        } catch {
+            return nil
+        }
     }
 
     func setObjectValue<T: Encodable>(_ data: T, for item: EncryptedUserDefaultsItem) throws {
@@ -38,6 +45,13 @@ struct EncryptedUserDefaultsItemResult {
     }
 }
 
-enum EncryptedUserDefaultsError: Error {
-    case encryptionKeyNotSet
+public enum EncryptedUserDefaultsError: Error {
+    case encryptionKeyNotAvailable
+    case noDataFound
+    case dataCouldNotBeDecrypted
+    case decryptedDataWasNil
+    case decryptedDataCouldNotBeStringified
+    case dataCouldNotBeMarshalled
+    case metadataIsMissing
+    case dataIsExpired
 }

--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClient.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClient.swift
@@ -15,6 +15,13 @@ extension EncryptedUserDefaultsClient {
         do {
             return try Current.jsonDecoder.decode(T.self, from: result.data)
         } catch {
+            Task {
+                var details: [String: String] = [
+                    "type" : item.name,
+                    "json" : result.stringValue ?? "No String Value"
+                ]
+                try? await EventsClient.logEvent(parameters: .init(eventName: "json_decoding_error", details: details))
+            }
             throw EncryptedUserDefaultsError.dataCouldNotBeMarshalled
         }
     }

--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClient.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClient.swift
@@ -10,7 +10,7 @@ protocol EncryptedUserDefaultsClient: AnyObject {
 extension EncryptedUserDefaultsClient {
     func getObject<T: Decodable>(_: T.Type, for item: EncryptedUserDefaultsItem) throws -> T? {
         guard let result = try getItem(item: item), result.stringValue != "null" else {
-            return nil
+            throw EncryptedUserDefaultsError.noDataFound
         }
         do {
             return try Current.jsonDecoder.decode(T.self, from: result.data)

--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClient.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClient.swift
@@ -9,16 +9,16 @@ protocol EncryptedUserDefaultsClient: AnyObject {
 
 extension EncryptedUserDefaultsClient {
     func getObject<T: Decodable>(_: T.Type, for item: EncryptedUserDefaultsItem) throws -> T? {
-        guard let result = try getItem(item: item) else {
+        guard let result = try getItem(item: item), result.stringValue != "null" else {
             return nil
         }
         do {
             return try Current.jsonDecoder.decode(T.self, from: result.data)
         } catch {
             Task {
-                var details: [String: String] = [
-                    "type" : item.name,
-                    "json" : result.stringValue ?? "No String Value"
+                let details: [String: String] = [
+                    "type": item.name,
+                    "json": result.stringValue ?? "No String Value",
                 ]
                 try? await EventsClient.logEvent(parameters: .init(eventName: "json_decoding_error", details: details))
             }

--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsItem.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsItem.swift
@@ -1,8 +1,12 @@
 import Foundation
 
-struct EncryptedUserDefaultsItem {
+struct EncryptedUserDefaultsItem: Equatable {
     var kind: Kind = .encrypted
     var name: String
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.name == rhs.name
+    }
 }
 
 extension EncryptedUserDefaultsItem {

--- a/Sources/StytchCore/Networking/NetworkingRouter.swift
+++ b/Sources/StytchCore/Networking/NetworkingRouter.swift
@@ -92,6 +92,28 @@ public extension NetworkingRouter {
 }
 
 public extension NetworkingRouter {
+    private func isSessionStale(_ initialSessionId: String?) -> Bool {
+        switch StartupClient.expectedClientType {
+        case .b2b:
+            return initialSessionId != sessionManager.memberSessionId?.rawValue
+        case .consumer:
+            return initialSessionId != sessionManager.sessionId?.rawValue
+        default:
+            return false
+        }
+    }
+
+    private func getExistingSessionIdAsString() -> String? {
+        switch StartupClient.expectedClientType {
+        case .b2b:
+            return sessionManager.memberSessionId?.rawValue
+        case .consumer:
+            return sessionManager.sessionId?.rawValue
+        default:
+            return nil
+        }
+    }
+
     private func performRequest(
         _ method: HTTPMethod,
         route: Route,
@@ -120,7 +142,7 @@ public extension NetworkingRouter {
         guard let configuration = getConfiguration() else {
             throw StytchSDKError.consumerSDKNotConfigured
         }
-
+        let initialSessionId = getExistingSessionIdAsString()
         var components = URLComponents(url: configuration.baseUrl, resolvingAgainstBaseURL: false)
         components?.path += path(for: route).rawValue
         components?.queryItems = queryItems
@@ -129,6 +151,11 @@ public extension NetworkingRouter {
         }
 
         let (data, response) = try await networkingClient.performRequest(method, url: url, useDFPPA: useDFPPA)
+
+        if isSessionStale(initialSessionId) {
+            // The session was updated out from under us while the request was in flight; discard the response and retry
+            return try await performRequest(method, route: route, queryItems: queryItems, useDFPPA: useDFPPA)
+        }
 
         do {
             try response.verifyStatusCode(data: data, jsonDecoder: jsonDecoder)
@@ -172,6 +199,10 @@ public extension NetworkingRouter {
             }
             return dataContainer.data
         } catch {
+            if isSessionStale(initialSessionId) {
+                // The session was updated out from under us while the request was in flight; discard the response and retry
+                return try await performRequest(method, route: route, queryItems: queryItems, useDFPPA: useDFPPA)
+            }
             throw error
         }
     }

--- a/Sources/StytchCore/ObjectStorage.swift
+++ b/Sources/StytchCore/ObjectStorage.swift
@@ -85,8 +85,14 @@ class ObjectStorage<WrapperType: ObjectStorageWrapper> {
             }
         } catch let error as EncryptedUserDefaultsError {
             _onChange.send(.unavailable(error))
+            Task {
+                try? await EventsClient.logEvent(parameters: .init(eventName: "persisted_data_was_unavailable", error: error))
+            }
         } catch {
             _onChange.send(.unavailable(nil))
+            Task {
+                try? await EventsClient.logEvent(parameters: .init(eventName: "persisted_data_was_unavailable", error: error))
+            }
         }
     }
 }

--- a/Sources/StytchCore/SessionManager.swift
+++ b/Sources/StytchCore/SessionManager.swift
@@ -173,6 +173,14 @@ extension SessionManager {
             }
         }
     }
+
+    var sessionId: Session.ID? {
+        try? userDefaultsClient.getObject(Session.self, for: .session)?.sessionId
+    }
+
+    var memberSessionId: MemberSession.ID? {
+        try? userDefaultsClient.getObject(MemberSession.self, for: .memberSession)?.memberSessionId
+    }
 }
 
 // Intermediate Session Token


### PR DESCRIPTION
Linear Ticket: No ticket

## Changes:

1. Adopt the session storm protection from JS SDK
2. Bubble up exact causes for info being unavailable, and attempt to determine if it's expected or not

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
