### PR TITLE
SDK-2810 Timer fix forward

### DIFF
--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -137,9 +137,11 @@ struct Environment {
         $0.asyncAfter(deadline: $1, execute: $2)
     }
 
-    var timer: (TimeInterval, RunLoop, @escaping () -> Void) -> Timer = { interval, runloop, task in
-        let timer = Timer(timeInterval: interval, repeats: true) { _ in task() }
-        runloop.add(timer, forMode: .common)
+    var timer: (TimeInterval, DispatchQueue, @escaping () -> Void) -> DispatchSourceTimer = { interval, queue, task in
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + interval, repeating: interval)
+        timer.setEventHandler { task() }
+        timer.resume()
         return timer
     }
 }

--- a/Tests/StytchCoreTests/B2BDiscoveryTestCase.swift
+++ b/Tests/StytchCoreTests/B2BDiscoveryTestCase.swift
@@ -41,7 +41,7 @@ final class B2BDiscoveryTestCase: BaseTestCase {
 
     func testExchangeIntermediateSession() async throws {
         networkInterceptor.responses { B2BMFAAuthenticateResponse.mock }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         Current.sessionManager.updateSession(intermediateSessionToken: intermediateSessionToken)
         XCTAssertTrue(Current.sessionManager.hasValidIntermediateSessionToken)
@@ -62,7 +62,7 @@ final class B2BDiscoveryTestCase: BaseTestCase {
 
     func testCreateOrganization() async throws {
         networkInterceptor.responses { B2BMFAAuthenticateResponse.mock }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         Current.sessionManager.updateSession(intermediateSessionToken: intermediateSessionToken)
         XCTAssertTrue(Current.sessionManager.hasValidIntermediateSessionToken)

--- a/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
@@ -110,7 +110,7 @@ final class B2BMagicLinksTestCase: BaseTestCase {
 
         XCTAssertNotNil(try Current.userDefaultsClient.getStringValue(.codeVerifierPKCE))
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         Current.sessionManager.updateSession(intermediateSessionToken: intermediateSessionToken)
 
@@ -167,7 +167,7 @@ final class B2BMagicLinksTestCase: BaseTestCase {
 
         XCTAssertNotNil(try Current.userDefaultsClient.getStringValue(.codeVerifierPKCE))
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         _ = try await StytchB2BClient.magicLinks.discoveryAuthenticate(parameters: parameters)
 

--- a/Tests/StytchCoreTests/B2BOAuthTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOAuthTestCase.swift
@@ -9,7 +9,7 @@ final class B2BOAuthTestCase: BaseTestCase {
             StytchB2BClient.OAuth.OAuthAuthenticateResponse.mock
         }
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         Current.sessionManager.updateSession(intermediateSessionToken: intermediateSessionToken)
 
@@ -52,7 +52,7 @@ final class B2BOAuthTestCase: BaseTestCase {
             )
         }
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         _ = try Current.pkcePairManager.generateAndReturnPKCECodePair()
         XCTAssertNotNil(Current.pkcePairManager.getPKCECodePair())

--- a/Tests/StytchCoreTests/B2BOTPTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOTPTestCase.swift
@@ -79,7 +79,7 @@ final class B2BOTPTestCase: BaseTestCase {
             B2BAuthenticateResponse.mock
         }
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         let organizationId = "orgid1234"
         let memberId = "memberid1234"
@@ -148,7 +148,7 @@ final class B2BOTPTestCase: BaseTestCase {
             StytchB2BClient.OTP.Email.AuthenticateResponse.mock
         }
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         let code = "code1234"
         let organizationId = "orgid1234"

--- a/Tests/StytchCoreTests/B2BPasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BPasswordsTestCase.swift
@@ -16,7 +16,7 @@ final class B2BPasswordsTestCase: BaseTestCase {
             locale: .en
         )
         networkInterceptor.responses { B2BMFAAuthenticateResponse.mock }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         Current.sessionManager.updateSession(intermediateSessionToken: intermediateSessionToken)
 
@@ -112,7 +112,7 @@ final class B2BPasswordsTestCase: BaseTestCase {
             ])
         )
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
         XCTAssertNotNil(Current.pkcePairManager.getPKCECodePair())
 
         _ = try await client.resetByEmail(
@@ -143,7 +143,7 @@ final class B2BPasswordsTestCase: BaseTestCase {
 
     func testResetByExistingPassword() async throws {
         networkInterceptor.responses { B2BMFAAuthenticateResponse.mock }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         Current.sessionManager.updateSession(intermediateSessionToken: intermediateSessionToken)
 
@@ -182,7 +182,7 @@ final class B2BPasswordsTestCase: BaseTestCase {
                 wrapped: .init(memberSession: .mock, member: .mock, organization: .mock)
             )
         }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         _ = try await client.resetBySession(parameters: .init(organizationId: "org123", password: "hi, i'm Tom.", locale: .en))
 
@@ -241,7 +241,7 @@ final class B2BPasswordsTestCase: BaseTestCase {
             ])
         )
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
         XCTAssertNotNil(Current.pkcePairManager.getPKCECodePair())
 
         // Call resetByEmail

--- a/Tests/StytchCoreTests/B2BRecoveryCodesTestCase.swift
+++ b/Tests/StytchCoreTests/B2BRecoveryCodesTestCase.swift
@@ -46,7 +46,7 @@ final class B2BRecoveryCodesTestCase: BaseTestCase {
             )
         }
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         let organizationId = "orgid1234"
         let memberId = "memberid1234"

--- a/Tests/StytchCoreTests/B2BSSOTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSSOTestCase.swift
@@ -39,7 +39,7 @@ final class B2BSSOTestCase: BaseTestCase {
         networkInterceptor.responses {
             B2BMFAAuthenticateResponse.mock
         }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         await XCTAssertThrowsErrorAsync(
             try await StytchB2BClient.sso.authenticate(parameters: .init(ssoToken: "i-am-token", sessionDurationMinutes: 12, locale: .en)),

--- a/Tests/StytchCoreTests/B2BSessionsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSessionsTestCase.swift
@@ -12,7 +12,7 @@ final class B2BSessionsTestCase: BaseTestCase {
         networkInterceptor.responses { B2BAuthenticateResponse.mock }
         let parameters: StytchB2BClient.Sessions.AuthenticateParameters = .init(sessionDurationMinutes: 15)
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         XCTAssertNil(StytchB2BClient.sessions.memberSession)
 
@@ -37,7 +37,7 @@ final class B2BSessionsTestCase: BaseTestCase {
 
     func testSessionsRevoke() async throws {
         networkInterceptor.responses { BasicResponse(requestId: "request_id", statusCode: 200) }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         Current.sessionManager.updateSession(
             sessionType: .member(.mock),
@@ -76,7 +76,7 @@ final class B2BSessionsTestCase: BaseTestCase {
             B2BMFAAuthenticateResponse.mock
         }
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         let organizationID = "org_123"
         let parameters = StytchB2BClient.Sessions.ExchangeParameters(organizationID: organizationID)
@@ -109,7 +109,7 @@ final class B2BSessionsTestCase: BaseTestCase {
             }
         }.store(in: &subscriptions)
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
         Current.sessionManager.updateSession(
             sessionType: .member(.mock),
             tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day")),
@@ -133,7 +133,7 @@ final class B2BSessionsTestCase: BaseTestCase {
             }
         }.store(in: &subscriptions)
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
         Current.sessionManager.updateSession(
             sessionType: nil,
             tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day")),
@@ -145,7 +145,7 @@ final class B2BSessionsTestCase: BaseTestCase {
     }
 
     func testGetExpiredMemberSessionReturnsNil() throws {
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
         Current.sessionManager.updateSession(
             sessionType: .member(.mockWithExpiredMemberSession),
             tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day")),

--- a/Tests/StytchCoreTests/B2BTOTPTestCase.swift
+++ b/Tests/StytchCoreTests/B2BTOTPTestCase.swift
@@ -42,7 +42,7 @@ final class B2BTOTPTestCase: BaseTestCase {
             B2BAuthenticateResponse.mock
         }
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         let organizationId = "orgid1234"
         let memberId = "memberid1234"

--- a/Tests/StytchCoreTests/BaseTestCase.swift
+++ b/Tests/StytchCoreTests/BaseTestCase.swift
@@ -21,7 +21,7 @@ class BaseTestCase: XCTestCase {
         Current.localStorage = .init()
         Current.timer = { _, _, _ in
             XCTFail("Unexpected timer initialization")
-            return .init()
+            return Self.mockTimer
         }
         Current.asyncAfter = { _, _, _ in
             XCTFail("Unexpected asyncAfter run")
@@ -202,3 +202,7 @@ class MockLocalAuthenticationContext: LAContextEvaluating {
     }
 }
 #endif
+
+extension BaseTestCase {
+    static var mockTimer = DispatchSource.makeTimerSource(queue: .main)
+}

--- a/Tests/StytchCoreTests/BiometricsTestCase.swift
+++ b/Tests/StytchCoreTests/BiometricsTestCase.swift
@@ -33,7 +33,7 @@ final class BiometricsTestCase: BaseTestCase {
             )
         }
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         _ = try await StytchClient.biometrics.register(parameters: .init(identifier: email))
 
@@ -75,7 +75,7 @@ final class BiometricsTestCase: BaseTestCase {
             )
         }
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         _ = try await StytchClient.biometrics.authenticate(parameters: .init())
 

--- a/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
+++ b/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
@@ -51,7 +51,7 @@ final class CryptoWalletsTestCase: BaseTestCase {
         XCTAssertNil(StytchClient.sessions.sessionToken)
         XCTAssertNil(StytchClient.sessions.sessionJwt)
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         _ = try await StytchClient.cryptoWallets.authenticate(parameters: .init(cryptoWalletType: .solana, cryptoWalletAddress: "mock-crypto-address", signature: "mock-signature"))
 

--- a/Tests/StytchCoreTests/DeeplinkHandlerTestCase.swift
+++ b/Tests/StytchCoreTests/DeeplinkHandlerTestCase.swift
@@ -24,7 +24,7 @@ final class DeeplinkHandlerTestCase: BaseTestCase {
         try Current.userDefaultsClient.setStringValue(String.mockPKCECodeVerifier, for: .codeVerifierPKCE)
         try Current.userDefaultsClient.setStringValue(String.mockPKCECodeChallenge, for: .codeChallengePKCE)
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         switch try await StytchClient.handle(url: handledUrl, sessionDurationMinutes: 30) {
         case let .handled(response):

--- a/Tests/StytchCoreTests/MagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/MagicLinksTestCase.swift
@@ -129,7 +129,7 @@ final class MagicLinksTestCase: BaseTestCase {
 
         XCTAssertNotNil(try Current.userDefaultsClient.getStringValue(.codeVerifierPKCE))
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         let response = try await StytchClient.magicLinks.authenticate(parameters: parameters)
         XCTAssertEqual(response.statusCode, 200)

--- a/Tests/StytchCoreTests/OAuthTestCase.swift
+++ b/Tests/StytchCoreTests/OAuthTestCase.swift
@@ -12,7 +12,7 @@ final class OAuthTestCase: BaseTestCase {
             UserResponse(requestId: "", statusCode: 200, wrapped: .mock(userId: ""))
         }
         Current.appleOAuthClient = .init { _, _ in .init(idToken: "id_token_123", name: .init(firstName: "user", lastName: nil)) }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
         _ = try await StytchClient.oauth.apple.start(parameters: .init())
 
         try XCTAssertRequest(
@@ -38,7 +38,7 @@ final class OAuthTestCase: BaseTestCase {
 
     func testAuthenticate() async throws {
         networkInterceptor.responses { StytchClient.OAuth.OAuthAuthenticateResponse.mock }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         await XCTAssertThrowsErrorAsync(
             try await StytchClient.oauth.authenticate(parameters: .init(token: "i-am-token", sessionDurationMinutes: 12)),

--- a/Tests/StytchCoreTests/OTPTestCase.swift
+++ b/Tests/StytchCoreTests/OTPTestCase.swift
@@ -154,7 +154,7 @@ final class OTPTestCase: BaseTestCase {
         XCTAssertNil(StytchClient.sessions.sessionToken)
         XCTAssertNil(StytchClient.sessions.sessionJwt)
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         _ = try await StytchClient.otps.authenticate(parameters: parameters)
 

--- a/Tests/StytchCoreTests/PasskeysTestCase.swift
+++ b/Tests/StytchCoreTests/PasskeysTestCase.swift
@@ -67,7 +67,7 @@ final class PasskeysTestCase: BaseTestCase {
                 credentialID: .init("fake_id".utf8)
             )
         }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
         #if os(iOS)
         let parameters: Base.AuthenticateParameters = .init(domain: "something.blah.com", requestBehavior: .autoFill)
         #else

--- a/Tests/StytchCoreTests/PasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/PasswordsTestCase.swift
@@ -11,7 +11,7 @@ final class PasswordsTestCase: BaseTestCase {
         networkInterceptor.responses {
             StytchClient.Passwords.CreateResponse(requestId: "321", statusCode: 200, wrapped: .init(emailId: "email_id_that's_what_i_am", userId: userId, user: .mock(userId: userId), sessionToken: "session_token_431", sessionJwt: "jwt_8534", session: .mock(userId: userId)))
         }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
         _ = try await StytchClient.passwords.create(parameters: passwordParams)
 
         try XCTAssertRequest(
@@ -27,7 +27,7 @@ final class PasswordsTestCase: BaseTestCase {
 
     func testAuthenticate() async throws {
         networkInterceptor.responses { AuthenticateResponse.mock }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
         _ = try await StytchClient.passwords.authenticate(parameters: passwordParams)
 
         try XCTAssertRequest(
@@ -106,7 +106,7 @@ final class PasswordsTestCase: BaseTestCase {
             ])
         )
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         XCTAssertNotNil(Current.pkcePairManager.getPKCECodePair())
 
@@ -130,7 +130,7 @@ final class PasswordsTestCase: BaseTestCase {
 
     func testResetBySession() async throws {
         networkInterceptor.responses { AuthenticateResponse.mock }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
         _ = try await StytchClient.passwords.resetBySession(parameters: passwordResetBySessionParams)
 
         try XCTAssertRequest(
@@ -147,7 +147,7 @@ final class PasswordsTestCase: BaseTestCase {
 
     func testResetByExistingPassword() async throws {
         networkInterceptor.responses { AuthenticateResponse.mock }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         _ = try await StytchClient.passwords.resetByExistingPassword(parameters: passwordResetByExistingPasswordParams)
 

--- a/Tests/StytchCoreTests/PollingClientTestCase.swift
+++ b/Tests/StytchCoreTests/PollingClientTestCase.swift
@@ -5,20 +5,24 @@ final class PollingClientTestCase: BaseTestCase {
     func testDefault() {
         let expectation = XCTestExpectation()
         let dispatchQueue = DispatchQueue(label: "test")
-        var timer: Timer?
-        Current.timer = { timeInterval, _, task in
-            let newTimer = Timer(fire: .distantFuture, interval: timeInterval, repeats: true) { _ in task() }
-            timer = newTimer
-            return newTimer
+        let interval = 0.5
+        var timer: DispatchSourceTimer?
+        Current.timer = { interval, queue, task in
+            let dst = DispatchSource.makeTimerSource(queue: queue)
+            dst.schedule(deadline: .now() + interval, repeating: interval)
+            dst.setEventHandler { task() }
+            dst.resume()
+            timer = dst
+            return dst
         }
-        var fireCount = 0
+        var timestamps: [Date] = []
         var error: Error?
         let pollingClient: PollingClient = .init(
-            interval: 5,
+            interval: interval,
             maxRetries: 5,
             queue: dispatchQueue
         ) { _, onFailure in
-            fireCount += 1
+            timestamps.append(Date.now)
             if let theError = error {
                 // Clear the error so the RetryClient doesn't continue to retry
                 error = nil
@@ -26,35 +30,20 @@ final class PollingClientTestCase: BaseTestCase {
             }
         }
 
-        XCTAssertEqual(fireCount, 0)
+        XCTAssertEqual(timestamps.count, 0)
         XCTAssertNil(timer)
 
         pollingClient.start()
+        // wait for it to fire a few times
+        let secondsToRun = 3.0
+        let expectedFires = secondsToRun / interval
+        dispatchQueue.asyncAfter(deadline: .now() + secondsToRun, execute: { expectation.fulfill() })
+        wait(for: [expectation], timeout: secondsToRun * 2)
 
-        dispatchQueue.asyncAfter(deadline: .now() + 1, execute: { expectation.fulfill() })
-        wait(for: [expectation], timeout: 10)
+        // did it fire the expected number of times?
+        XCTAssertEqual(timestamps.count, Int(expectedFires))
 
-        XCTAssertEqual(fireCount, 0)
-
-        timer?.fire()
-
-        XCTAssertEqual(fireCount, 1)
-
-        timer?.fire()
-
-        XCTAssertEqual(fireCount, 2)
-
-        timer?.fire()
-        timer?.fire()
-
-        XCTAssertEqual(fireCount, 4)
-
-        // Test default RetryClient, executing the task immediately
-        Current.asyncAfter = { $2() }
-        error = StytchSDKError.consumerSDKNotConfigured
-
-        timer?.fire()
-
-        XCTAssertEqual(fireCount, 6)
+        // was each fire _roughly_ one second apart?
+        XCTAssertIntervalsClose(to: interval, in: timestamps, tolerance: 0.1)
     }
 }

--- a/Tests/StytchCoreTests/SessionManagerTestCase.swift
+++ b/Tests/StytchCoreTests/SessionManagerTestCase.swift
@@ -20,7 +20,7 @@ final class SessionManagerTestCase: BaseTestCase {
         networkInterceptor.responses { AuthenticateResponse.mock }
         let parameters: StytchClient.Sessions.AuthenticateParameters = .init(sessionDurationMinutes: 15)
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         XCTAssertNil(StytchClient.sessions.session)
 
@@ -45,7 +45,7 @@ final class SessionManagerTestCase: BaseTestCase {
 
     func testSessionsRevoke() async throws {
         networkInterceptor.responses { BasicResponse(requestId: "request_id", statusCode: 200) }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         Current.sessionManager.updateSession(
             sessionType: .user(.mock(userId: "i_am_user")),
@@ -69,7 +69,7 @@ final class SessionManagerTestCase: BaseTestCase {
             StytchError(name: "fake_error", message: "I'm a mock error")
             StytchError(name: "fake_error", message: "I'm a mock error")
         }
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         Current.sessionManager.updateSession(
             sessionType: .user(.mock(userId: "i_am_user")),
@@ -117,7 +117,7 @@ final class SessionManagerTestCase: BaseTestCase {
     }
 
     func testIntermediateSessionToken() {
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         // Given we call update session with valid member session and tokens
         Current.sessionManager.updateSession(
@@ -158,7 +158,7 @@ final class SessionManagerTestCase: BaseTestCase {
             }
         }.store(in: &subscriptions)
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
         Current.sessionManager.updateSession(
             sessionType: .user(.mock(userId: "i_am_user")),
             tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day")),
@@ -182,7 +182,7 @@ final class SessionManagerTestCase: BaseTestCase {
             }
         }.store(in: &subscriptions)
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
         Current.sessionManager.updateSession(
             sessionType: nil,
             tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day")),
@@ -194,7 +194,7 @@ final class SessionManagerTestCase: BaseTestCase {
     }
 
     func testGetExpiredSessionReturnsNil() throws {
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
         Current.sessionManager.updateSession(
             sessionType: .user(.mockWithExpiredSession(userId: "i_am_user")),
             tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day")),
@@ -211,7 +211,7 @@ final class SessionManagerTestCase: BaseTestCase {
             error
         }
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         Current.sessionManager.updateSession(
             sessionType: .user(.mock(userId: "i_am_user")),
@@ -242,7 +242,7 @@ final class SessionManagerTestCase: BaseTestCase {
             error
         }
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         Current.sessionManager.updateSession(
             sessionType: .user(.mock(userId: "i_am_user")),

--- a/Tests/StytchCoreTests/TOTPTestCase.swift
+++ b/Tests/StytchCoreTests/TOTPTestCase.swift
@@ -15,7 +15,7 @@ final class TOTPTestCase: BaseTestCase {
     func testAuthenticate() async throws {
         networkInterceptor.responses { AuthenticateResponse.mock }
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         _ = try await StytchClient.totps.authenticate(parameters: .init(totpCode: "test-code"))
 
@@ -29,7 +29,7 @@ final class TOTPTestCase: BaseTestCase {
             StytchClient.TOTP.RecoverResponse(requestId: "", statusCode: 200, wrapped: .init(userId: "", totpId: "", user: .mock(userId: ""), session: .mock(userId: ""), sessionToken: "", sessionJwt: ""))
         }
 
-        Current.timer = { _, _, _ in .init() }
+        Current.timer = { _, _, _ in Self.mockTimer }
 
         _ = try await StytchClient.totps.recover(parameters: .init(recoveryCode: "recover-edoc"))
 

--- a/Tests/StytchCoreTests/XCTestHelpers.swift
+++ b/Tests/StytchCoreTests/XCTestHelpers.swift
@@ -244,3 +244,22 @@ private extension CollectionDifference.Change {
         }
     }
 }
+
+func XCTAssertIntervalsClose(to expected: TimeInterval, in timestamps: [Date], tolerance: TimeInterval = 0.1, file: StaticString = #file, line: UInt = #line) {
+    guard timestamps.count > 1 else {
+        XCTFail("Not enough timestamps to compare", file: file, line: line)
+        return
+    }
+
+    for i in 1..<timestamps.count {
+        let delta = timestamps[i].timeIntervalSince(timestamps[i - 1])
+        let diff = abs(delta - expected)
+        XCTAssertLessThanOrEqual(
+            diff,
+            tolerance,
+            "Interval \(i) was \(delta)s, expected ~\(expected)s (tolerance \(tolerance)s)",
+            file: file,
+            line: line
+        )
+    }
+}


### PR DESCRIPTION
Linear Ticket: [SDK-2810](https://linear.app/stytch/issue/SDK-2810)

## Changes:

1. Ports the fix from #516 into current releases

## Notes
- Linting is reenabled for this branch, so if you were squicked out about the other PR, let this one put your mind at ease

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
