### PR TITLE
User-Member Device History

### DIFF
--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClient.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsClient.swift
@@ -26,6 +26,7 @@ extension EncryptedUserDefaultsClient {
         }
     }
 
+    // TODO: check if this is silencing an error here.
     func getStringValue(_ item: EncryptedUserDefaultsItem) throws -> String? {
         do {
             return try getItem(item: item)?.stringValue

--- a/Sources/StytchCore/Networking/NetworkingRouter.swift
+++ b/Sources/StytchCore/Networking/NetworkingRouter.swift
@@ -154,6 +154,7 @@ public extension NetworkingRouter {
 
         let (data, response) = try await networkingClient.performRequest(method, url: url, useDFPPA: useDFPPA)
 
+        // TODO: Make this logic only valid for sessions authenticate
         if isSessionStale(initialSessionId) {
             // The session was updated out from under us while the request was in flight; discard the response and retry
             return try await performRequest(method, route: route, queryItems: queryItems, useDFPPA: useDFPPA)
@@ -203,6 +204,7 @@ public extension NetworkingRouter {
             }
             return dataContainer.data
         } catch {
+            // TODO: Make this logic only valid for sessions authenticate
             if isSessionStale(initialSessionId) {
                 // The session was updated out from under us while the request was in flight; discard the response and retry
                 return try await performRequest(method, route: route, queryItems: queryItems, useDFPPA: useDFPPA)

--- a/Sources/StytchCore/SharedModels/DeviceHistory.swift
+++ b/Sources/StytchCore/SharedModels/DeviceHistory.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public struct DeviceHistory: Codable, Sendable {
+    let visitorId: String?
+    let visitorIdDetails: DeviceAttributeDetails?
+    let ipAddress: String?
+    let ipAddressDetails: DeviceAttributeDetails?
+    let ipGeoCountry: String?
+    let ipGeoCountryDetails: DeviceAttributeDetails?
+    let ipGeoCity: String?
+    let ipGeoRegion: String?
+}
+
+public struct DeviceAttributeDetails: Codable, Sendable {
+    let isNew: Bool?
+    let firstSeenAt: String?
+    let lastSeenAt: String?
+}

--- a/Sources/StytchCore/SharedModels/Response.swift
+++ b/Sources/StytchCore/SharedModels/Response.swift
@@ -76,6 +76,7 @@ extension Response: AuthenticateResponseDataType where Wrapped: AuthenticateResp
     public var sessionToken: String { wrapped.sessionToken }
     public var sessionJwt: String { wrapped.sessionJwt }
     public var session: Session { wrapped.session }
+    public var userDevice: DeviceHistory? { wrapped.userDevice }
 }
 
 extension Response: B2BAuthenticateResponseDataType where Wrapped: B2BAuthenticateResponseDataType {
@@ -84,6 +85,7 @@ extension Response: B2BAuthenticateResponseDataType where Wrapped: B2BAuthentica
     public var organization: Organization { wrapped.organization }
     public var sessionToken: String { wrapped.sessionToken }
     public var sessionJwt: String { wrapped.sessionJwt }
+    public var memberDevice: DeviceHistory? { wrapped.memberDevice }
 }
 
 extension Response: B2BMFAAuthenticateResponseDataType where Wrapped: B2BMFAAuthenticateResponseDataType {
@@ -97,6 +99,7 @@ extension Response: B2BMFAAuthenticateResponseDataType where Wrapped: B2BMFAAuth
     public var memberAuthenticated: Bool { wrapped.memberAuthenticated }
     public var mfaRequired: StytchB2BClient.MFARequired? { wrapped.mfaRequired }
     public var primaryRequired: StytchB2BClient.PrimaryRequired? { wrapped.primaryRequired }
+    public var memberDevice: DeviceHistory? { wrapped.memberDevice }
 }
 
 extension Response: DiscoveryIntermediateSessionTokenDataType where Wrapped: DiscoveryIntermediateSessionTokenDataType {

--- a/Sources/StytchCore/StytchB2BClient/Models/B2BAuthenticateResponse.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/B2BAuthenticateResponse.swift
@@ -18,6 +18,8 @@ public struct B2BAuthenticateResponseData: Codable, Sendable, B2BAuthenticateRes
     public let sessionToken: String
     /// The JWT for the session. Can be used by your server to verify the validity of your session either by checking the data included in the JWT, or by verifying with Stytch's servers as needed.
     public let sessionJwt: String
+    /// If a valid telemetry_id was passed in the request and the Fingerprint Lookup API returned results, the member_device response field will contain information about the member's device attributes.
+    public let memberDevice: DeviceHistory?
 }
 
 /// The interface which a data type must conform to for all underlying data in B2B `authenticate` responses.
@@ -32,4 +34,6 @@ public protocol B2BAuthenticateResponseDataType {
     var sessionToken: String { get }
     /// The JWT for the session. Can be used by your server to verify the validity of your session either by checking the data included in the JWT, or by verifying with Stytch's servers as needed.
     var sessionJwt: String { get }
+    /// If a valid telemetry_id was passed in the request and the Fingerprint Lookup API returned results, the member_device response field will contain information about the member's device attributes.
+    var memberDevice: DeviceHistory? { get }
 }

--- a/Sources/StytchCore/StytchB2BClient/Models/B2BMFAAuthenticateResponse.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/B2BMFAAuthenticateResponse.swift
@@ -28,6 +28,8 @@ public struct B2BMFAAuthenticateResponseData: Codable, Sendable, B2BMFAAuthentic
     public let mfaRequired: StytchB2BClient.MFARequired?
     /// Information about the primary authentication requirements of the Organization.
     public let primaryRequired: StytchB2BClient.PrimaryRequired?
+    /// If a valid telemetry_id was passed in the request and the Fingerprint Lookup API returned results, the member_device response field will contain information about the member's device attributes.
+    public let memberDevice: DeviceHistory?
 }
 
 /// The interface which a data type must conform to for all underlying data in B2B MFA `authenticate` responses.
@@ -52,6 +54,8 @@ public protocol B2BMFAAuthenticateResponseDataType {
     var mfaRequired: StytchB2BClient.MFARequired? { get }
     /// Information about the primary authentication requirements of the Organization.
     var primaryRequired: StytchB2BClient.PrimaryRequired? { get }
+    /// If a valid telemetry_id was passed in the request and the Fingerprint Lookup API returned results, the member_device response field will contain information about the member's device attributes.
+    var memberDevice: DeviceHistory? { get }
 }
 
 /// The interface which a data type must conform to for all discovery flows that return a non optional intermediate session token

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OAuth/StytchB2BClient+OAuth.swift
@@ -111,6 +111,8 @@ public extension StytchB2BClient.OAuth {
         public let mfaRequired: StytchB2BClient.MFARequired?
         /// Information about the primary authentication requirements of the Organization.
         public let primaryRequired: StytchB2BClient.PrimaryRequired?
+        /// If a valid telemetry_id was passed in the request and the Fingerprint Lookup API returned results, the member_device response field will contain information about the member's device attributes.
+        public let memberDevice: DeviceHistory?
         /// The provider_values object lists relevant identifiers, values, and scopes for a given OAuth provider.
         /// For example this object will include a provider's access_token that you can use to access the provider's API for a given user.
         /// Note that these values will vary based on the OAuth provider in question, e.g. id_token is only returned by OIDC compliant identity providers.

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP+Email.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+OTP/StytchB2BClient+OTP+Email.swift
@@ -88,6 +88,8 @@ public extension StytchB2BClient.OTP.Email {
         public let mfaRequired: StytchB2BClient.MFARequired?
         /// Information about the primary authentication requirements of the Organization.
         public let primaryRequired: StytchB2BClient.PrimaryRequired?
+        /// If a valid telemetry_id was passed in the request and the Fingerprint Lookup API returned results, the member_device response field will contain information about the member's device attributes.
+        public let memberDevice: DeviceHistory?
         /// The ID of the email used to send an OTP.
         public let methodId: String
     }

--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+RecoveryCodes.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+RecoveryCodes.swift
@@ -94,6 +94,8 @@ public extension StytchB2BClient.RecoveryCodes {
         public let sessionToken: String
         /// The JWT for the session. Can be used by your server to verify the validity of your session either by checking the data included in the JWT, or by verifying with Stytch's servers as needed.
         public let sessionJwt: String
+        /// If a valid telemetry_id was passed in the request and the Fingerprint Lookup API returned results, the member_device response field will contain information about the member's device attributes.
+        public let memberDevice: DeviceHistory?
         /// Number of recovery codes remaining for the member.
         public let recoveryCodesRemaining: Int
     }

--- a/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
@@ -282,6 +282,7 @@ public extension StytchClient.Biometrics {
         public let session: Session
         public let sessionToken: String
         public let sessionJwt: String
+        public let userDevice: DeviceHistory?
     }
 }
 

--- a/Sources/StytchCore/StytchClient/Models/AuthenticateResponse.swift
+++ b/Sources/StytchCore/StytchClient/Models/AuthenticateResponse.swift
@@ -14,6 +14,8 @@ public protocol AuthenticateResponseDataType {
     var sessionJwt: String { get }
     /// The ``Session`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
     var session: Session { get }
+    /// If a valid telemetry_id was passed in the request and the Fingerprint Lookup API returned results, the user_device response field will contain information about the user's device attributes.
+    var userDevice: DeviceHistory? { get }
 }
 
 /// The underlying data for `authenticate` calls.
@@ -26,4 +28,6 @@ public struct AuthenticateResponseData: Codable, Sendable, AuthenticateResponseD
     public let sessionJwt: String
     /// The ``Session`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
     public let session: Session
+    /// The visitor_id (a unique identifier) of the user's device. See the Device Fingerprinting documentation for more details on the visitor_id.
+    public let userDevice: DeviceHistory?
 }

--- a/Sources/StytchCore/StytchClient/OAuth/OAuth+Apple.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/OAuth+Apple.swift
@@ -72,6 +72,8 @@ public extension StytchClient.OAuth.Apple {
         public let sessionJwt: String
         /// The ``Session`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
         public let session: Session
+        /// The visitor_id (a unique identifier) of the user's device. See the Device Fingerprinting documentation for more details on the visitor_id.
+        public let userDevice: DeviceHistory?
         /// Indicates if this is a new or returning user
         public let userCreated: Bool
     }

--- a/Sources/StytchCore/StytchClient/OAuth/StytchClient+OAuth.swift
+++ b/Sources/StytchCore/StytchClient/OAuth/StytchClient+OAuth.swift
@@ -144,6 +144,8 @@ public extension StytchClient.OAuth {
         public let sessionJwt: String
         /// The ``Session`` object, which includes information about the session's validity, expiry, factors associated with this session, and more.
         public let session: Session
+        /// The visitor_id (a unique identifier) of the user's device. See the Device Fingerprinting documentation for more details on the visitor_id.
+        public let userDevice: DeviceHistory?
         /// The unique ID for an OAuth registration.
         public let oauthUserRegistrationId: String
         /// The unique identifier for the User within a given OAuth provider. Also commonly called the "sub" or "Subject field" in OAuth protocols.

--- a/Sources/StytchCore/StytchClient/Passwords/StytchClient+Passwords.swift
+++ b/Sources/StytchCore/StytchClient/Passwords/StytchClient+Passwords.swift
@@ -134,6 +134,7 @@ public extension StytchClient.Passwords {
         public let sessionToken: String
         public let sessionJwt: String
         public let session: Session
+        public let userDevice: DeviceHistory?
     }
 
     /// The dedicated parameters type for password `create` and `authenticate` calls.

--- a/Sources/StytchCore/StytchClient/TOTP/StytchClient+TOTP.swift
+++ b/Sources/StytchCore/StytchClient/TOTP/StytchClient+TOTP.swift
@@ -105,6 +105,7 @@ public extension StytchClient.TOTP {
         public let session: Session
         public let sessionToken: String
         public let sessionJwt: String
+        public let userDevice: DeviceHistory?
     }
 
     /// The underlying data for TOTP ``StytchClient/TOTP/recoveryCodes()-mbxc`` responses.

--- a/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
@@ -190,7 +190,8 @@ extension B2BAuthenticateResponse {
             member: .mock,
             organization: .mock,
             sessionToken: "xyzasdf",
-            sessionJwt: "i'mvalidjson"
+            sessionJwt: "i'mvalidjson",
+            memberDevice: nil
         )
     )
 }
@@ -209,7 +210,8 @@ extension B2BMFAAuthenticateResponse {
             intermediateSessionToken: "cccccbgkvlhvciffckuevcevtrkjfkeiklvulgrrgvke",
             memberAuthenticated: false,
             mfaRequired: nil,
-            primaryRequired: nil
+            primaryRequired: nil,
+            memberDevice: nil
         )
     )
 }

--- a/Tests/StytchCoreTests/B2BOAuthTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOAuthTestCase.swift
@@ -104,6 +104,7 @@ extension StytchB2BClient.OAuth.OAuthAuthenticateResponse {
             memberAuthenticated: false,
             mfaRequired: nil,
             primaryRequired: nil,
+            memberDevice: nil,
             providerValues: .mock
         )
     )

--- a/Tests/StytchCoreTests/B2BOTPTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOTPTestCase.swift
@@ -253,6 +253,7 @@ extension StytchB2BClient.OTP.Email.AuthenticateResponse {
             memberAuthenticated: false,
             mfaRequired: nil,
             primaryRequired: nil,
+            memberDevice: nil,
             methodId: ""
         )
     )

--- a/Tests/StytchCoreTests/B2BRecoveryCodesTestCase.swift
+++ b/Tests/StytchCoreTests/B2BRecoveryCodesTestCase.swift
@@ -91,6 +91,7 @@ extension StytchB2BClient.RecoveryCodes.RecoveryCodesRecoverResponseData {
             organization: .mock,
             sessionToken: "xyzasdf",
             sessionJwt: "i'mvalidjson",
+            memberDevice: nil,
             recoveryCodesRemaining: 99
         )
     }

--- a/Tests/StytchCoreTests/BaseTestCase.swift
+++ b/Tests/StytchCoreTests/BaseTestCase.swift
@@ -102,7 +102,8 @@ extension AuthenticateResponse {
                 user: .mock(userId: userId),
                 sessionToken: "hello_session",
                 sessionJwt: "jwt_for_me",
-                session: .mock(userId: userId)
+                session: .mock(userId: userId),
+                userDevice: nil
             )
         )
     }

--- a/Tests/StytchCoreTests/BiometricsTestCase.swift
+++ b/Tests/StytchCoreTests/BiometricsTestCase.swift
@@ -28,7 +28,8 @@ final class BiometricsTestCase: BaseTestCase {
                     user: .mock(userId: userId),
                     session: .mock(userId: userId),
                     sessionToken: sessionToken,
-                    sessionJwt: "session_jwt"
+                    sessionJwt: "session_jwt",
+                    userDevice: nil
                 )
             )
         }
@@ -71,7 +72,13 @@ final class BiometricsTestCase: BaseTestCase {
             AuthenticateResponse(
                 requestId: "req_123",
                 statusCode: 200,
-                wrapped: .init(user: .mock(userId: userId), sessionToken: "session_token_123", sessionJwt: "session_jwt_123", session: .mock(userId: userId))
+                wrapped: .init(
+                    user: .mock(userId: userId),
+                    sessionToken: "session_token_123",
+                    sessionJwt: "session_jwt_123",
+                    session: .mock(userId: userId),
+                    userDevice: nil
+                )
             )
         }
 

--- a/Tests/StytchCoreTests/OAuthTestCase.swift
+++ b/Tests/StytchCoreTests/OAuthTestCase.swift
@@ -7,7 +7,14 @@ final class OAuthTestCase: BaseTestCase {
             StytchClient.OAuth.Apple.AuthenticateResponse(
                 requestId: "",
                 statusCode: 200,
-                wrapped: .init(user: .mock(userId: ""), sessionToken: "", sessionJwt: "", session: .mock(userId: ""), userCreated: false)
+                wrapped: .init(
+                    user: .mock(userId: ""),
+                    sessionToken: "",
+                    sessionJwt: "",
+                    session: .mock(userId: ""),
+                    userDevice: nil,
+                    userCreated: false
+                )
             )
             UserResponse(requestId: "", statusCode: 200, wrapped: .mock(userId: ""))
         }
@@ -171,6 +178,7 @@ extension StytchClient.OAuth.OAuthAuthenticateResponse {
             sessionToken: "123",
             sessionJwt: "123",
             session: .mock(userId: "123"),
+            userDevice: nil,
             oauthUserRegistrationId: "123",
             providerSubject: "123",
             providerType: "123",

--- a/Tests/StytchCoreTests/PasswordsTestCase.swift
+++ b/Tests/StytchCoreTests/PasswordsTestCase.swift
@@ -9,7 +9,19 @@ final class PasswordsTestCase: BaseTestCase {
     func testCreate() async throws {
         let userId: User.ID = ""
         networkInterceptor.responses {
-            StytchClient.Passwords.CreateResponse(requestId: "321", statusCode: 200, wrapped: .init(emailId: "email_id_that's_what_i_am", userId: userId, user: .mock(userId: userId), sessionToken: "session_token_431", sessionJwt: "jwt_8534", session: .mock(userId: userId)))
+            StytchClient.Passwords.CreateResponse(
+                requestId: "321",
+                statusCode: 200,
+                wrapped: .init(
+                    emailId: "email_id_that's_what_i_am",
+                    userId: userId,
+                    user: .mock(userId: userId),
+                    sessionToken: "session_token_431",
+                    sessionJwt: "jwt_8534",
+                    session: .mock(userId: userId),
+                    userDevice: nil
+                )
+            )
         }
         Current.timer = { _, _, _ in .init() }
         _ = try await StytchClient.passwords.create(parameters: passwordParams)

--- a/Tests/StytchCoreTests/TOTPTestCase.swift
+++ b/Tests/StytchCoreTests/TOTPTestCase.swift
@@ -26,7 +26,19 @@ final class TOTPTestCase: BaseTestCase {
 
     func testRecover() async throws {
         networkInterceptor.responses {
-            StytchClient.TOTP.RecoverResponse(requestId: "", statusCode: 200, wrapped: .init(userId: "", totpId: "", user: .mock(userId: ""), session: .mock(userId: ""), sessionToken: "", sessionJwt: ""))
+            StytchClient.TOTP.RecoverResponse(
+                requestId: "",
+                statusCode: 200,
+                wrapped: .init(
+                    userId: "",
+                    totpId: "",
+                    user: .mock(userId: ""),
+                    session: .mock(userId: ""),
+                    sessionToken: "",
+                    sessionJwt: "",
+                    userDevice: nil
+                )
+            )
         }
 
         Current.timer = { _, _, _ in .init() }

--- a/Tests/StytchUIUnitTests/StytchUIClientTests/BaseTestCase.swift
+++ b/Tests/StytchUIUnitTests/StytchUIClientTests/BaseTestCase.swift
@@ -65,7 +65,8 @@ extension AuthenticateResponse {
                 user: .mock(userId: userId),
                 sessionToken: "hello_session",
                 sessionJwt: "jwt_for_me",
-                session: .mock(userId: userId)
+                session: .mock(userId: userId),
+                userDevice: nil
             )
         )
     }
@@ -90,7 +91,8 @@ extension StytchClient.Passwords.CreateResponse {
                 user: mockUser,
                 sessionToken: "mock-session-token",
                 sessionJwt: "mock-session-jwt",
-                session: mockSession
+                session: mockSession,
+                userDevice: nil
             )
         )
     }
@@ -128,6 +130,7 @@ extension StytchClient.OAuth.Apple.AuthenticateResponse {
                 sessionToken: "session-token",
                 sessionJwt: "session-jwt",
                 session: mockSession,
+                userDevice: nil,
                 userCreated: true
             )
         )
@@ -143,6 +146,7 @@ extension StytchClient.OAuth.OAuthAuthenticateResponse {
             sessionToken: "123",
             sessionJwt: "123",
             session: .mock(userId: "123"),
+            userDevice: nil,
             oauthUserRegistrationId: "123",
             providerSubject: "123",
             providerType: "123",


### PR DESCRIPTION
[User Device History changes for iOS](https://linear.app/stytch/issue/SDK-2823/user-device-history-changes-for-ios)

Android PR: https://github.com/stytchauth/stytch-android/pull/363

## Changes:

1. Create `DeviceHistory` and `DeviceAttributeDetails` objects.
2. Add `DeviceHistory` to the B2C `AuthenticateResponseDataType` as `userDevice`
3. Add `DeviceHistory` to the B2B `B2BAuthenticateResponseDataType` and `B2BMFAAuthenticateResponseDataType` as `memberDevice`

I decided to go with the approach of adding these as optionals to the generic response types rather than bifurcating all response types to accommodate the reality that only certain response types have `DeviceHistory` in their response type. I decided to do this to avoid unnecessary complexity in the code for a feature that mobile users are unlikely to use. So therefore I decided to make it optional on all response types since even the ones where `DeviceHistory` can return a value will only do so when bot protection is enabled.

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A
