### PR TITLE
Remove logic around isProtectedDataAvailable

### DIFF
--- a/Sources/StytchCore/KeychainClient/KeychainClient.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClient.swift
@@ -8,7 +8,6 @@ protocol KeychainClient: AnyObject {
     func valueExistsForItem(item: KeychainItem) -> Bool
     func setValueForItem(value: KeychainItem.Value, item: KeychainItem) throws
     func removeItem(item: KeychainItem) throws
-    func onProtectedDataDidBecomeAvailable()
 }
 
 extension KeychainClient {

--- a/Sources/StytchCore/KeychainClient/KeychainClientImplementation.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClientImplementation.swift
@@ -19,9 +19,10 @@ final class KeychainClientImplementation: KeychainClient {
     private init() {
         queue = DispatchQueue(label: "StytchKeychainClientQueue")
         queue.setSpecific(key: queueKey, value: ())
+        loadEncryptionKey()
     }
 
-    func onProtectedDataDidBecomeAvailable() {
+    func loadEncryptionKey() {
         try? safelyEnqueue {
             encryptionKey = try? getEncryptionKey()
         }

--- a/Sources/StytchCore/StytchClientType.swift
+++ b/Sources/StytchCore/StytchClientType.swift
@@ -82,18 +82,16 @@ extension StytchClientType {
                 }
             }
         }
-        if UIApplication.shared.isProtectedDataAvailable {
-            keychainClient.onProtectedDataDidBecomeAvailable()
-            defaultStartupFlow()
-        } else {
-            NotificationCenter.default.addObserver(forName: UIApplication.protectedDataDidBecomeAvailableNotification, object: nil, queue: nil) { _ in
-                keychainClient.onProtectedDataDidBecomeAvailable()
-                defaultStartupFlow()
+        #endif
+
+        Task {
+            do {
+                try await StartupClient.start(clientType: Self.clientType)
+                try? await EventsClient.logEvent(parameters: .init(eventName: "client_initialization_success"))
+            } catch {
+                try? await EventsClient.logEvent(parameters: .init(eventName: "client_initialization_failure"))
             }
         }
-        #else
-        defaultStartupFlow()
-        #endif
     }
 
     // swiftlint:disable:next identifier_name large_tuple
@@ -138,17 +136,6 @@ extension StytchClientType {
                 defaults.set(true, forKey: migrationName)
             } catch {
                 print(error)
-            }
-        }
-    }
-
-    private func defaultStartupFlow() {
-        Task {
-            do {
-                try await StartupClient.start(clientType: Self.clientType)
-                try? await EventsClient.logEvent(parameters: .init(eventName: "client_initialization_success"))
-            } catch {
-                try? await EventsClient.logEvent(parameters: .init(eventName: "client_initialization_failure"))
             }
         }
     }

--- a/Stytch/DemoApps/StytchBiometrics/ViewController.swift
+++ b/Stytch/DemoApps/StytchBiometrics/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        StytchClient.configure(configuration: .init(publicToken: ""))
+        StytchClient.configure(configuration: .init(publicToken: "public-token-test-81b5f118-b6d3-49ff-9f56-a037a6e65176"))
 
         StytchClient.sessions.onSessionChange
             .receive(on: DispatchQueue.main)

--- a/Stytch/DemoApps/StytchUIDemo/ContentView.swift
+++ b/Stytch/DemoApps/StytchUIDemo/ContentView.swift
@@ -109,7 +109,7 @@ class ContentViewModel: ObservableObject {
     }
 
     let configuration: StytchUIClient.Configuration = .init(
-        stytchClientConfiguration: .init(publicToken: "public-token-test-..."),
+        stytchClientConfiguration: .init(publicToken: "public-token-test-81b5f118-b6d3-49ff-9f56-a037a6e65176"),
         products: [.otp, .oauth, .passwords, .emailMagicLinks, .biometrics],
         navigation: Navigation(closeButtonStyle: .close(.right)),
         oauthProviders: [.apple, .thirdParty(.google)],

--- a/Tests/StytchCoreTests/KeychainClient+Mock.swift
+++ b/Tests/StytchCoreTests/KeychainClient+Mock.swift
@@ -6,8 +6,6 @@ import Foundation
 public var keychainDateCreatedOffsetInMinutes = 0
 
 class KeychainClientMock: KeychainClient {
-    func onProtectedDataDidBecomeAvailable() {}
-
     var encryptionKey: SymmetricKey? {
         do {
             return SymmetricKey(data: try Current.cryptoClient.dataWithRandomBytesOfCount(256))


### PR DESCRIPTION
[[iOS] Keychain migration 4 is failing with empty encryption key](https://linear.app/stytch/issue/SDK-2849/ios-keychain-migration-4-is-failing-with-empty-encryption-key)
[[iOS] Session token failing to write to the encrypted user defaults](https://linear.app/stytch/issue/SDK-2850/ios-session-token-failing-to-write-to-the-encrypted-user-defaults)

## Changes:

1. We are removing the UIApplication.shared.isProtectedDataAvailable check because it is not needed for the encryption key.
2. The encryption key uses AfterFirstUnlock accessibility, so it becomes available once the device is unlocked after reboot and remains accessible even if the device is later locked.
3. No user presence access control (biometric or passcode) is applied, which ensures the key can always be read silently.
4. Reads are configured with UI skipped, so the system will never display an authentication prompt and will simply return an error if the key is unavailable.
5. This guarantees the encryption key is accessible without user interaction after the first unlock, making the protected data check unnecessary.

## Checklist:
- [ ] I have verified that this change works in the relevant demo app, or N/A
- [ ] I have added or updated any tests relevant to this change, or N/A
- [ ] I have updated any relevant README files for this change, or N/A
