### PR TITLE
Update Recaptcha

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/marmelroy/PhoneNumberKit", .exact("3.8.0")),
-        .package(url: "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk", .exact("18.7.0")),
+        .package(url: "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk", .upToNextMajor(from: "18.8.0-beta01")),
         .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", from: "5.0.2"),
         .package(url: "https://github.com/stytchauth/stytch-ios-dfp.git", from: "1.0.4"),
     ],

--- a/Stytch/Stytch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stytch/Stytch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",
         "state": {
           "branch": null,
-          "revision": "5ec74256124faa7e7814c574509723f49e1fccfb",
-          "version": "18.7.0"
+          "revision": "b5c630a14acf1c8c4284015858e02377bfc99d63",
+          "version": "18.8.0-beta01"
         }
       },
       {


### PR DESCRIPTION
[[iOS] Investigate issues with Swift6/OS26](https://linear.app/stytch/issue/SDK-2745/ios-investigate-issues-with-swift6os26)

## Changes:

1. Bump google recaptcha to the version that supports Swift 6.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
