### PR TITLE
Create StytchConsoleLogger

### DIFF
--- a/Sources/StytchCore/StartupClient.swift
+++ b/Sources/StytchCore/StartupClient.swift
@@ -40,6 +40,8 @@ struct StartupClient {
         _ = try await (auth, bootstrap)
 
         isInitializedPublisher.send(true)
+
+        StytchConsoleLogger.log(message: "Stytch SDK initialized for client type: \(clientType)")
     }
 
     private static func authenticateSessionIfNeeded(for clientType: ClientType) async {

--- a/Sources/StytchCore/StytchConsoleLogger.swift
+++ b/Sources/StytchCore/StytchConsoleLogger.swift
@@ -1,0 +1,47 @@
+import Foundation
+import os.log
+
+@objc
+public final class StytchConsoleLogger: NSObject {
+    // Create a logger with subsystem and category for filtering in Console
+    // In Console.app you can filter using:
+    //   subsystem:com.stytch.sdk
+    //   category:console
+    // You can also combine filters, for example:
+    //   subsystem:com.stytch.sdk level:error
+    private static let logger = Logger(subsystem: "com.stytch.sdk", category: "console")
+}
+
+// These map directly to OSLogType levels and are easy to call.
+// Note: error and warning messages always appear in Console by default.
+// Info messages do NOT appear unless you enable "Action->Include Info Messages" in Console
+// or change log settings via `log config` in Terminal. This is an Apple logging behavior
+// designed to reduce noise, not a limitation of this class.
+public extension StytchConsoleLogger {
+    /// Log an informational message
+    @objc static func log(message: String) {
+        logger.info("\(message, privacy: .public)")
+    }
+
+    /// Log a warning message
+    @objc static func warn(message: String) {
+        logger.warning("\(message, privacy: .public)")
+    }
+
+    /// Log an error message
+    @objc static func error(message: String) {
+        logger.error("\(message, privacy: .public)")
+    }
+}
+
+// Use this if you want one entry point with a configurable log level.
+// Callers pass in an OSLogType (.debug, .info, .error, etc).
+// Example:
+//   StytchConsoleLogger.log(message: "debugging", type: .debug)
+//   StytchConsoleLogger.log(message: "problem!", type: .error)
+public extension StytchConsoleLogger {
+    /// Log a message with a custom log level
+    @objc static func log(message: String, type: OSLogType = .default) {
+        logger.log(level: type, "\(message, privacy: .public)")
+    }
+}


### PR DESCRIPTION
Based on some recent changes made to react native around console logging I decided to create a `StytchConsoleLogger` for the iOS sdk and make it public so that other developers can choose to use it and we can then filter those messages in the console log as a group to isolate potential issues with our SDK.