### PR TITLE
Fix the organization search member function

### DIFF
--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/StytchB2BClient+Organizations+SearchParameters.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Organizations/StytchB2BClient+Organizations+SearchParameters.swift
@@ -3,9 +3,9 @@ import Foundation
 
 public extension StytchB2BClient.Organizations {
     struct SearchParameters: Codable, Sendable {
-        let query: SearchQuery
+        let query: SearchQuery?
         let cursor: String?
-        let limit: String?
+        let limit: Int?
 
         /// * Data class used for wrapping the parameters necessary to search members
         /// - Parameters:
@@ -23,9 +23,9 @@ public extension StytchB2BClient.Organizations {
         ///   The default limit is 100. A maximum of 1000 results can be returned by a single search request.
         ///   If the total size of your result set is greater than one page size, you must paginate the response. See the cursor field.
         public init(
-            query: SearchQuery,
+            query: SearchQuery? = nil,
             cursor: String? = nil,
-            limit: String? = nil
+            limit: Int? = nil
         ) {
             self.query = query
             self.cursor = cursor
@@ -49,7 +49,8 @@ public extension StytchB2BClient.Organizations.SearchParameters {
         ///   - searchOperands: An array of SearchQueryOperand(s) created via 'SearchParameters.searchQueryOperand(...)'
         public init(searchOperator: SearchOperator, searchOperands: [any SearchQueryOperand]) {
             self.searchOperator = searchOperator
-            searchOperandsJSON = JSON(arrayLiteral: searchOperands.map(\.json))
+            let searchOperandsJSONArray = searchOperands.map(\.json)
+            searchOperandsJSON = JSON(searchOperandsJSONArray)
         }
     }
 }
@@ -80,11 +81,8 @@ public extension StytchB2BClient.Organizations.SearchParameters {
         let filterValue: [String]
 
         public var filterValueJSON: JSON {
-            var filterValueJSON = [JSON]()
-            for string in filterValue {
-                filterValueJSON.append(JSON(stringLiteral: string))
-            }
-            return JSON(arrayLiteral: filterValueJSON)
+            let filterValues = filterValue.map { JSON(stringLiteral: $0) }
+            return JSON(filterValues)
         }
 
         init(filterName: String, filterValue: [String]) {
@@ -132,7 +130,7 @@ public extension StytchB2BClient.Organizations.SearchParameters {
         case memberIsBreakglass = "member_is_breakglass"
         case statuses
         case memberMfaPhoneNumbers = "member_mfa_phone_numbers"
-        case memberMfaPhoneNumbeFuzzy = "member_mfa_phone_number_fuzzy"
+        case memberMfaPhoneNumberFuzzy = "member_mfa_phone_number_fuzzy"
         case memberPasswordExists = "member_password_exists"
         case memberRoles = "member_roles"
 
@@ -141,7 +139,7 @@ public extension StytchB2BClient.Organizations.SearchParameters {
         }
 
         var isSearchQueryOperandString: Bool {
-            self == .memberEmailFuzzy || self == .memberMfaPhoneNumbeFuzzy
+            self == .memberEmailFuzzy || self == .memberMfaPhoneNumberFuzzy
         }
 
         var isSearchQueryOperandBool: Bool {

--- a/Stytch/DemoApps/B2BWorkbench/ViewControllers/AuthMethodControllers/OrganizationMemberSearchViewController.swift
+++ b/Stytch/DemoApps/B2BWorkbench/ViewControllers/AuthMethodControllers/OrganizationMemberSearchViewController.swift
@@ -1,0 +1,227 @@
+import Combine
+import StytchCore
+import UIKit
+
+final class OrganizationMemberSearchViewController: UIViewController {
+    private let stackView = UIStackView.stytchB2BStackView()
+
+    private lazy var searchAllMembersButton: UIButton = .init(title: "Search all members", primaryAction: .init { [weak self] _ in
+        self?.searchAllMembers()
+    })
+
+    private lazy var searchBySingleEmailButton: UIButton = .init(title: "Search by single email", primaryAction: .init { [weak self] _ in
+        self?.searchBySingleEmail()
+    })
+    private lazy var searchByMultipleEmailsButton: UIButton = .init(title: "Search by multiple emails", primaryAction: .init { [weak self] _ in
+        self?.searchByMultipleEmails()
+    })
+    private lazy var searchByEmailFuzzyButton: UIButton = .init(title: "Search by email fuzzy", primaryAction: .init { [weak self] _ in
+        self?.searchByEmailFuzzy()
+    })
+    private lazy var searchByBreakglassTrueButton: UIButton = .init(title: "Search breakglass true", primaryAction: .init { [weak self] _ in
+        self?.searchByBreakglassTrue()
+    })
+    private lazy var searchByPasswordExistsFalseButton: UIButton = .init(title: "Search password exists false", primaryAction: .init { [weak self] _ in
+        self?.searchByPasswordExistsFalse()
+    })
+    private lazy var searchByStatusesButton: UIButton = .init(title: "Search by statuses", primaryAction: .init { [weak self] _ in
+        self?.searchByStatuses()
+    })
+    private lazy var searchByRolesButton: UIButton = .init(title: "Search by roles", primaryAction: .init { [weak self] _ in
+        self?.searchByRoles()
+    })
+    private lazy var searchAndEmailsAndPasswordButton: UIButton = .init(title: "Search AND emails and password", primaryAction: .init { [weak self] _ in
+        self?.searchAndEmailsAndPassword()
+    })
+    private lazy var searchOrFuzzyEmailOrFuzzyPhoneButton: UIButton = .init(title: "Search OR fuzzy email or fuzzy phone", primaryAction: .init { [weak self] _ in
+        self?.searchOrFuzzyEmailOrFuzzyPhone()
+    })
+    private lazy var searchWithPaginationSmallLimitButton: UIButton = .init(title: "Search with small limit for pagination", primaryAction: .init { [weak self] _ in
+        self?.searchWithPaginationSmallLimit()
+    })
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = "Organization Member Search"
+        view.backgroundColor = .systemBackground
+
+        view.addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+
+        // Buttons
+        stackView.addArrangedSubview(searchAllMembersButton)
+        stackView.addArrangedSubview(searchBySingleEmailButton)
+        stackView.addArrangedSubview(searchByMultipleEmailsButton)
+        stackView.addArrangedSubview(searchByEmailFuzzyButton)
+        stackView.addArrangedSubview(searchByBreakglassTrueButton)
+        stackView.addArrangedSubview(searchByPasswordExistsFalseButton)
+        stackView.addArrangedSubview(searchByStatusesButton)
+        stackView.addArrangedSubview(searchByRolesButton)
+        stackView.addArrangedSubview(searchAndEmailsAndPasswordButton)
+        stackView.addArrangedSubview(searchOrFuzzyEmailOrFuzzyPhoneButton)
+        stackView.addArrangedSubview(searchWithPaginationSmallLimitButton)
+    }
+
+    // MARK: - Demo search builders
+
+    private func searchAllMembers() {
+        Task {
+            let operands: [any SearchQueryOperand] = []
+            let queryOperator: StytchB2BClient.Organizations.SearchParameters.SearchOperator = .AND
+            await performSearch(operands: operands, operator: queryOperator, cursor: nil, limit: nil, label: "all members")
+        }
+    }
+
+    private func searchBySingleEmail() {
+        Task {
+            let operands = makeOperands([
+                (.memberEmails, ["foo@stytch.com"]),
+            ])
+            let queryOperator: StytchB2BClient.Organizations.SearchParameters.SearchOperator = .AND
+            await performSearch(operands: operands, operator: queryOperator, cursor: nil, limit: nil, label: "single email")
+        }
+    }
+
+    private func searchByMultipleEmails() {
+        Task {
+            let operands = makeOperands([
+                (.memberEmails, ["alpha@example.com", "beta@example.com"]),
+            ])
+            let queryOperator: StytchB2BClient.Organizations.SearchParameters.SearchOperator = .OR
+            await performSearch(operands: operands, operator: queryOperator, cursor: nil, limit: nil, label: "multiple emails OR")
+        }
+    }
+
+    private func searchByEmailFuzzy() {
+        Task {
+            let operands = makeOperands([
+                (.memberEmailFuzzy, "ali"),
+            ])
+            let queryOperator: StytchB2BClient.Organizations.SearchParameters.SearchOperator = .AND
+            await performSearch(operands: operands, operator: queryOperator, cursor: nil, limit: nil, label: "email fuzzy")
+        }
+    }
+
+    private func searchByBreakglassTrue() {
+        Task {
+            let operands = makeOperands([
+                (.memberIsBreakglass, true),
+            ])
+            let queryOperator: StytchB2BClient.Organizations.SearchParameters.SearchOperator = .AND
+            await performSearch(operands: operands, operator: queryOperator, cursor: nil, limit: nil, label: "breakglass true")
+        }
+    }
+
+    private func searchByPasswordExistsFalse() {
+        Task {
+            let operands = makeOperands([
+                (.memberPasswordExists, false),
+            ])
+            let queryOperator: StytchB2BClient.Organizations.SearchParameters.SearchOperator = .AND
+            await performSearch(operands: operands, operator: queryOperator, cursor: nil, limit: nil, label: "password exists false")
+        }
+    }
+
+    private func searchByStatuses() {
+        Task {
+            let operands = makeOperands([
+                (.statuses, ["active", "invited"]),
+            ])
+            let queryOperator: StytchB2BClient.Organizations.SearchParameters.SearchOperator = .OR
+            await performSearch(operands: operands, operator: queryOperator, cursor: nil, limit: nil, label: "statuses")
+        }
+    }
+
+    private func searchByRoles() {
+        Task {
+            let operands = makeOperands([
+                (.memberRoles, ["admin", "member"]),
+            ])
+            let queryOperator: StytchB2BClient.Organizations.SearchParameters.SearchOperator = .OR
+            await performSearch(operands: operands, operator: queryOperator, cursor: nil, limit: nil, label: "roles")
+        }
+    }
+
+    private func searchAndEmailsAndPassword() {
+        Task {
+            let operands = makeOperands([
+                (.memberEmails, ["alpha@example.com"]),
+                (.memberPasswordExists, true),
+            ])
+            let queryOperator: StytchB2BClient.Organizations.SearchParameters.SearchOperator = .AND
+            await performSearch(operands: operands, operator: queryOperator, cursor: nil, limit: nil, label: "AND emails and password")
+        }
+    }
+
+    private func searchOrFuzzyEmailOrFuzzyPhone() {
+        Task {
+            let operands = makeOperands([
+                (.memberEmailFuzzy, "ali"),
+                (.memberMfaPhoneNumberFuzzy, "401"),
+            ])
+            let queryOperator: StytchB2BClient.Organizations.SearchParameters.SearchOperator = .OR
+            await performSearch(operands: operands, operator: queryOperator, cursor: nil, limit: nil, label: "OR email fuzzy or phone fuzzy")
+        }
+    }
+
+    private func searchWithPaginationSmallLimit() {
+        Task {
+            let operands = makeOperands([
+                (.memberEmails, ["alpha@example.com", "beta@example.com", "gamma@example.com"]),
+            ])
+            let queryOperator: StytchB2BClient.Organizations.SearchParameters.SearchOperator = .OR
+            await performSearch(operands: operands, operator: queryOperator, cursor: nil, limit: 2, label: "pagination with small limit")
+        }
+    }
+
+    // MARK: - Common helpers
+
+    private func performSearch(
+        operands: [any SearchQueryOperand],
+        operator searchOperator: StytchB2BClient.Organizations.SearchParameters.SearchOperator,
+        cursor: String?,
+        limit: Int?,
+        label: String
+    ) async {
+        do {
+            let query = StytchB2BClient.Organizations.SearchParameters.SearchQuery(
+                searchOperator: searchOperator,
+                searchOperands: operands
+            )
+            let parameters = StytchB2BClient.Organizations.SearchParameters(
+                query: query,
+                cursor: cursor,
+                limit: limit
+            )
+            let response = try await StytchB2BClient.organizations.searchMembers(parameters: parameters)
+            print("search \(label) members count: \(response.members.count)")
+            if let nextCursor = response.resultsMetadata.nextCursor {
+                print("search \(label) next_cursor: \(nextCursor)")
+            }
+            presentAlertAndLogMessage(description: "search \(label) success", object: response)
+        } catch {
+            presentAlertAndLogMessage(description: "search \(label) error", object: error)
+        }
+    }
+
+    private func makeOperands(_ inputs: [(StytchB2BClient.Organizations.SearchParameters.SearchQueryOperandFilterNames, Any)]) -> [any SearchQueryOperand] {
+        var builtOperands = [any SearchQueryOperand]()
+        for input in inputs {
+            if let operand = StytchB2BClient.Organizations.SearchParameters.searchQueryOperand(
+                filterName: input.0,
+                filterValue: input.1
+            ) {
+                builtOperands.append(operand)
+            } else {
+                print("Invalid operand skipped for filter \(input.0.rawValue)")
+            }
+        }
+        return builtOperands
+    }
+}

--- a/Stytch/DemoApps/B2BWorkbench/ViewControllers/AuthMethodControllers/OrganizationViewController.swift
+++ b/Stytch/DemoApps/B2BWorkbench/ViewControllers/AuthMethodControllers/OrganizationViewController.swift
@@ -27,7 +27,7 @@ final class OrganizationViewController: UIViewController {
     })
 
     lazy var searchMembersButton: UIButton = .init(title: "Search Members", primaryAction: .init { [weak self] _ in
-        self?.searchMembers()
+        self?.navigationController?.pushViewController(OrganizationMemberSearchViewController(), animated: true)
     })
 
     override func viewDidLoad() {
@@ -124,36 +124,6 @@ final class OrganizationViewController: UIViewController {
                 presentAlertAndLogMessage(description: "update organization success", object: response)
             } catch {
                 presentAlertAndLogMessage(description: "update organization error", object: error)
-            }
-        }
-    }
-
-    func searchMembers() {
-        Task {
-            do {
-                var operands = [any SearchQueryOperand]()
-                if let operand = StytchB2BClient.Organizations.SearchParameters.searchQueryOperand(
-                    filterName: .memberEmails,
-                    filterValue: ["foo@stytch.com"]
-                ) {
-                    operands.append(operand)
-                }
-
-                let query = StytchB2BClient.Organizations.SearchParameters.SearchQuery(
-                    searchOperator: .AND,
-                    searchOperands: operands
-                )
-
-                let parameters = StytchB2BClient.Organizations.SearchParameters(
-                    query: query,
-                    cursor: nil,
-                    limit: nil
-                )
-
-                let response = try await StytchB2BClient.organizations.searchMembers(parameters: parameters)
-                presentAlertAndLogMessage(description: "search organization member success!", object: response)
-            } catch {
-                presentAlertAndLogMessage(description: "search organization members error", object: error)
             }
         }
     }

--- a/Stytch/Stytch.xcodeproj/project.pbxproj
+++ b/Stytch/Stytch.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		74BCCBDD2D2C2A97001A1C0A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 74BCCBD32D2C2A97001A1C0A /* Main.storyboard */; };
 		74BCCBDF2D2C2DE7001A1C0A /* StytchCore in Frameworks */ = {isa = PBXBuildFile; productRef = 74BCCBDE2D2C2DE7001A1C0A /* StytchCore */; };
 		74C427992C9A25E700EFA1A1 /* SCIMViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C427982C9A25E700EFA1A1 /* SCIMViewController.swift */; };
+		74DC4C7A2E6F5571008D0152 /* OrganizationMemberSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DC4C792E6F5570008D0152 /* OrganizationMemberSearchViewController.swift */; };
 		74DD38CB2C2A2ABA00BEB0DD /* OAuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DD38CA2C2A2ABA00BEB0DD /* OAuthViewController.swift */; };
 		74F0088D2C24C05100E0F863 /* RecoveryCodesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F0088C2C24C05000E0F863 /* RecoveryCodesViewController.swift */; };
 		74F3702A2C07B7F400AED9C9 /* OrganizationMemberViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F370292C07B7F400AED9C9 /* OrganizationMemberViewController.swift */; };
@@ -152,6 +153,7 @@
 		74BF2AFB2CF4EF7200798DCE /* Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigation.swift; sourceTree = "<group>"; };
 		74C427982C9A25E700EFA1A1 /* SCIMViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SCIMViewController.swift; sourceTree = "<group>"; };
 		74D1157E2BFBDFFD002EAB79 /* B2BWorkbench-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "B2BWorkbench-Bridging-Header.h"; sourceTree = "<group>"; };
+		74DC4C792E6F5570008D0152 /* OrganizationMemberSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationMemberSearchViewController.swift; sourceTree = "<group>"; };
 		74DD38CA2C2A2ABA00BEB0DD /* OAuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthViewController.swift; sourceTree = "<group>"; };
 		74F0088C2C24C05000E0F863 /* RecoveryCodesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryCodesViewController.swift; sourceTree = "<group>"; };
 		74F370292C07B7F400AED9C9 /* OrganizationMemberViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationMemberViewController.swift; sourceTree = "<group>"; };
@@ -236,6 +238,7 @@
 				2254779729A05D08003DF229 /* MemberViewController.swift */,
 				74DD38CA2C2A2ABA00BEB0DD /* OAuthViewController.swift */,
 				2254779929A05D37003DF229 /* OrganizationViewController.swift */,
+				74DC4C792E6F5570008D0152 /* OrganizationMemberSearchViewController.swift */,
 				74F370292C07B7F400AED9C9 /* OrganizationMemberViewController.swift */,
 				74A2D1902C21FDF8007F8F20 /* OTPViewController.swift */,
 				224E6F2429E8CAEB0031D37A /* PasswordsViewController.swift */,
@@ -654,6 +657,7 @@
 				2254779A29A05D37003DF229 /* OrganizationViewController.swift in Sources */,
 				2254779C29A05D4E003DF229 /* SessionsViewController.swift in Sources */,
 				22ABFABB29F7690100927518 /* SSOViewController.swift in Sources */,
+				74DC4C7A2E6F5571008D0152 /* OrganizationMemberSearchViewController.swift in Sources */,
 				74A2D1912C21FDF8007F8F20 /* OTPViewController.swift in Sources */,
 				22ABFAB929F7628E00927518 /* DiscoveryViewController.swift in Sources */,
 				2254779829A05D08003DF229 /* MemberViewController.swift in Sources */,

--- a/Tests/StytchCoreTests/B2BOrganizationsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOrganizationsTestCase.swift
@@ -70,40 +70,6 @@ final class B2BOrganizationsTestCase: BaseTestCase {
         )
     }
 
-    func testSearchMembers() async throws {
-        networkInterceptor.responses {
-            StytchB2BClient.Organizations.SearchMembersResponse(
-                requestId: "123",
-                statusCode: 200,
-                wrapped: .mock
-            )
-        }
-
-        let filterName = StytchB2BClient.Organizations.SearchParameters.SearchQueryOperandFilterNames.memberIsBreakglass.rawValue
-        let searchOperand = StytchB2BClient.Organizations.SearchParameters.SearchQueryOperandBool(filterName: filterName, filterValue: true)
-        let query = StytchB2BClient.Organizations.SearchParameters.SearchQuery(
-            searchOperator: .AND,
-            searchOperands: [searchOperand]
-        )
-
-        let parameters = StytchB2BClient.Organizations.SearchParameters(
-            query: query,
-            cursor: nil,
-            limit: nil
-        )
-
-        _ = try await StytchB2BClient.organizations.searchMembers(parameters: parameters)
-        try XCTAssertRequest(
-            networkInterceptor.requests[0],
-            urlString: "https://api.stytch.com/sdk/v1/b2b/organizations/me/members/search",
-            method: .post([
-                "query": JSON(dictionaryLiteral:
-                    ("operator", JSON(stringLiteral: "AND").rawValue),
-                    ("operands", JSON(arrayLiteral: [searchOperand.json]).rawValue)),
-            ])
-        )
-    }
-
     func testOrganizationPublisherAvailable() throws {
         let expectation = XCTestExpectation(description: "onOrganizationChange completes")
         var receivedOrganization: Organization?
@@ -143,6 +109,261 @@ final class B2BOrganizationsTestCase: BaseTestCase {
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertNil(StytchB2BClient.organizations.getSync())
+    }
+}
+
+// These tests cover the search members functionality for organizations.
+// Specifically, they validate that:
+// - Different operand types (boolean, string, string array) are encoded and sent correctly in requests.
+// - Query operators (AND, OR) are properly handled.
+// - Nil and empty values for query parameters are encoded as expected (e.g., JSON null).
+// - The operand factory rejects operands with mismatched types.
+// The tests ensure robust encoding and correct request construction for searching organization members.
+extension B2BOrganizationsTestCase {
+    // Verifies that a boolean operand search with AND operator is encoded and sent correctly.
+    func testSearchMembers() async throws {
+        networkInterceptor.responses {
+            StytchB2BClient.Organizations.SearchMembersResponse(
+                requestId: "123",
+                statusCode: 200,
+                wrapped: .mock
+            )
+        }
+
+        let filterName = StytchB2BClient.Organizations.SearchParameters.SearchQueryOperandFilterNames.memberIsBreakglass.rawValue
+        let boolOperand = StytchB2BClient.Organizations.SearchParameters.SearchQueryOperandBool(
+            filterName: filterName,
+            filterValue: true
+        )
+        let query = StytchB2BClient.Organizations.SearchParameters.SearchQuery(
+            searchOperator: .AND,
+            searchOperands: [boolOperand]
+        )
+
+        let parameters = StytchB2BClient.Organizations.SearchParameters(
+            query: query,
+            cursor: nil,
+            limit: nil
+        )
+
+        _ = try await StytchB2BClient.organizations.searchMembers(parameters: parameters)
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://api.stytch.com/sdk/v1/b2b/organizations/me/members/search",
+            method: .post([
+                "query": JSON(dictionaryLiteral:
+                    ("operator", JSON(stringLiteral: "AND").rawValue),
+                    ("operands", JSON(arrayLiteral: boolOperand.json).rawValue)),
+            ])
+        )
+    }
+
+    // Verifies that a boolean operand with value true is encoded and sent correctly.
+    func testSearchMembersBoolOperandTrue() async throws {
+        networkInterceptor.responses {
+            StytchB2BClient.Organizations.SearchMembersResponse(
+                requestId: "id",
+                statusCode: 200,
+                wrapped: .mock
+            )
+        }
+
+        let boolOperand = StytchB2BClient.Organizations.SearchParameters.SearchQueryOperandBool(
+            filterName: "member_is_breakglass",
+            filterValue: true
+        )
+        let searchQuery = StytchB2BClient.Organizations.SearchParameters.SearchQuery(
+            searchOperator: .AND,
+            searchOperands: [boolOperand]
+        )
+        let searchParameters = StytchB2BClient.Organizations.SearchParameters(query: searchQuery)
+
+        _ = try await StytchB2BClient.organizations.searchMembers(parameters: searchParameters)
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://api.stytch.com/sdk/v1/b2b/organizations/me/members/search",
+            method: .post([
+                "query": JSON(dictionaryLiteral:
+                    ("operator", JSON(stringLiteral: "AND").rawValue),
+                    ("operands", JSON(arrayLiteral: boolOperand.json).rawValue)),
+            ])
+        )
+    }
+
+    // Verifies that an empty array operand for member_emails is encoded and sent correctly.
+    func testSearchMembersMemberEmailsEmptyArray() async throws {
+        networkInterceptor.responses {
+            StytchB2BClient.Organizations.SearchMembersResponse(
+                requestId: "id",
+                statusCode: 200,
+                wrapped: .mock
+            )
+        }
+        let stringArrayOperand = StytchB2BClient.Organizations.SearchParameters.SearchQueryOperandStringArray(
+            filterName: "member_emails",
+            filterValue: []
+        )
+        let searchQuery = StytchB2BClient.Organizations.SearchParameters.SearchQuery(
+            searchOperator: .AND,
+            searchOperands: [stringArrayOperand]
+        )
+        let searchParameters = StytchB2BClient.Organizations.SearchParameters(query: searchQuery)
+
+        _ = try await StytchB2BClient.organizations.searchMembers(parameters: searchParameters)
+
+        let expected = JSON(dictionaryLiteral:
+            ("operator", JSON(stringLiteral: "AND").rawValue),
+            ("operands", JSON(arrayLiteral: stringArrayOperand.json).rawValue))
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://api.stytch.com/sdk/v1/b2b/organizations/me/members/search",
+            method: .post(["query": expected])
+        )
+    }
+
+    // Verifies that a non-empty array operand for member_emails is encoded and sent correctly.
+    func testSearchMembersMemberEmailsNonEmpty() async throws {
+        networkInterceptor.responses {
+            StytchB2BClient.Organizations.SearchMembersResponse(
+                requestId: "id",
+                statusCode: 200,
+                wrapped: .mock
+            )
+        }
+        let stringArrayOperand = StytchB2BClient.Organizations.SearchParameters.SearchQueryOperandStringArray(
+            filterName: "member_emails",
+            filterValue: ["a@x.com", "b@x.com"]
+        )
+        let searchQuery = StytchB2BClient.Organizations.SearchParameters.SearchQuery(
+            searchOperator: .AND,
+            searchOperands: [stringArrayOperand]
+        )
+        let searchParameters = StytchB2BClient.Organizations.SearchParameters(query: searchQuery)
+
+        _ = try await StytchB2BClient.organizations.searchMembers(parameters: searchParameters)
+
+        let expected = JSON(dictionaryLiteral:
+            ("operator", JSON(stringLiteral: "AND").rawValue),
+            ("operands", JSON(arrayLiteral: stringArrayOperand.json).rawValue))
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://api.stytch.com/sdk/v1/b2b/organizations/me/members/search",
+            method: .post(["query": expected])
+        )
+    }
+
+    // Verifies that a single string operand for member_email_fuzzy is encoded and sent correctly.
+    func testSearchMembersMemberEmailFuzzySingleString() async throws {
+        networkInterceptor.responses {
+            StytchB2BClient.Organizations.SearchMembersResponse(
+                requestId: "id",
+                statusCode: 200,
+                wrapped: .mock
+            )
+        }
+        let stringOperand = StytchB2BClient.Organizations.SearchParameters.SearchQueryOperandString(
+            filterName: "member_email_fuzzy",
+            filterValue: "alice"
+        )
+        let searchQuery = StytchB2BClient.Organizations.SearchParameters.SearchQuery(
+            searchOperator: .OR,
+            searchOperands: [stringOperand]
+        )
+        let searchParameters = StytchB2BClient.Organizations.SearchParameters(query: searchQuery)
+
+        _ = try await StytchB2BClient.organizations.searchMembers(parameters: searchParameters)
+
+        let expected = JSON(dictionaryLiteral:
+            ("operator", JSON(stringLiteral: "OR").rawValue),
+            ("operands", JSON(arrayLiteral: stringOperand.json).rawValue))
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://api.stytch.com/sdk/v1/b2b/organizations/me/members/search",
+            method: .post(["query": expected])
+        )
+    }
+
+    // Verifies that multiple operands (string array and bool) with AND operator, cursor, and limit are encoded and sent correctly.
+    func testSearchMembersMultipleOperandsAnd() async throws {
+        networkInterceptor.responses {
+            StytchB2BClient.Organizations.SearchMembersResponse(
+                requestId: "id",
+                statusCode: 200,
+                wrapped: .mock
+            )
+        }
+        let stringArrayOperand = StytchB2BClient.Organizations.SearchParameters.SearchQueryOperandStringArray(
+            filterName: "member_emails",
+            filterValue: ["a@x.com"]
+        )
+        let boolOperand = StytchB2BClient.Organizations.SearchParameters.SearchQueryOperandBool(
+            filterName: "member_password_exists",
+            filterValue: true
+        )
+        let searchQuery = StytchB2BClient.Organizations.SearchParameters.SearchQuery(
+            searchOperator: .AND,
+            searchOperands: [stringArrayOperand, boolOperand]
+        )
+        let searchParameters = StytchB2BClient.Organizations.SearchParameters(
+            query: searchQuery,
+            cursor: "c123",
+            limit: 50
+        )
+
+        _ = try await StytchB2BClient.organizations.searchMembers(parameters: searchParameters)
+
+        let expectedQuery = JSON(dictionaryLiteral:
+            ("operator", JSON(stringLiteral: "AND").rawValue),
+            ("operands", JSON(arrayLiteral: stringArrayOperand.json, boolOperand.json).rawValue))
+
+        try XCTAssertRequest(
+            networkInterceptor.requests[0],
+            urlString: "https://api.stytch.com/sdk/v1/b2b/organizations/me/members/search",
+            method: .post([
+                "query": expectedQuery,
+                "cursor": JSON(stringLiteral: "c123").rawValue,
+                "limit": JSON(integerLiteral: 50).rawValue,
+            ])
+        )
+    }
+
+    // Verifies that a nil query parameter is encoded as a JSON null value.
+    func testSearchMembersNilQueryEncodesAsNull() async throws {
+        networkInterceptor.responses {
+            StytchB2BClient.Organizations.SearchMembersResponse(
+                requestId: "id",
+                statusCode: 200,
+                wrapped: .mock
+            )
+        }
+        let searchParameters = StytchB2BClient.Organizations.SearchParameters(
+            query: nil,
+            cursor: nil,
+            limit: nil
+        )
+
+        _ = try await StytchB2BClient.organizations.searchMembers(parameters: searchParameters)
+
+        let body = try XCTUnwrap(networkInterceptor.requests.first?.httpBody)
+        let json = try JSON(data: body)
+        XCTAssertEqual(json["query"].type, .null)
+    }
+
+    // Verifies that the factory rejects operands with mismatched types.
+    func testSearchMembersFactoryRejectsMismatchedTypes() {
+        let invalidStringArrayOperand = StytchB2BClient.Organizations.SearchParameters.searchQueryOperand(
+            filterName: .memberEmailFuzzy,
+            filterValue: ["not single string"]
+        )
+        XCTAssertNil(invalidStringArrayOperand)
+
+        let invalidBoolOperand = StytchB2BClient.Organizations.SearchParameters.searchQueryOperand(
+            filterName: .memberIsBreakglass,
+            filterValue: "not bool"
+        )
+        XCTAssertNil(invalidBoolOperand)
     }
 }
 


### PR DESCRIPTION
[[iOS] Bugs organization member search in iOS SDK.](https://linear.app/stytch/issue/SDK-2870/ios-bugs-organization-member-search-in-ios-sdk)

## Summary
This PR fixes several bugs in the **Search Members** request encoding and adds a comprehensive suite of tests in `B2BOrganizationsTestCase` to prevent regressions.

## Changes

### Bug Fixes
- Removed nested operand arrays: operands are now encoded as `[ {…} ]` instead of `[ [ {…} ] ]`.
- Corrected `limit` type: fixed from `String` to `Int` so values serialize as numbers.
- Fixed enum typo: corrected `memberMfaPhoneNumbeFuzzy` to `memberMfaPhoneNumberFuzzy`.
- Nil query handling: `query` now encodes as `null` when not provided.

**Before (incorrect):**
```json
{
  "query": {
    "operator": "AND",
    "operands": [
      [
        { "filter_name": "member_emails", "filter_value": ["foo@stytch.com"] }
      ]
    ]
  }
}
```

**After (correct):**
```json
{
  "query": {
    "operator": "AND",
    "operands": [
      { "filter_name": "member_emails", "filter_value": ["foo@stytch.com"] }
    ]
  }
}
```

## New Tests
- Boolean operand encoding (`member_is_breakglass`, `member_password_exists`).
- String array operand encoding (`member_emails`), both empty and non-empty.
- String operand encoding (`member_email_fuzzy`).
- Multiple operands with `AND`, including `cursor` and `limit`.
- Nil queries encoded as `null`.
- Factory rejecting mismatched types.