### PR TITLE
Fix orangization member update path

### DIFF
--- a/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
+++ b/Sources/StytchCore/StytchB2BClient/StytchB2BClient+Routes.swift
@@ -222,7 +222,7 @@ extension StytchB2BClient {
                 case .create:
                     return Path(rawValue: "")
                 case let .update(memberId):
-                    return Path(rawValue: "update/\(memberId)")
+                    return Path(rawValue: "\(memberId)")
                 case let .delete(memberId):
                     return Path(rawValue: "\(memberId)")
                 case let .reactivate(memberId):

--- a/Tests/StytchCoreTests/B2BOrganizationsMembersTestCase.swift
+++ b/Tests/StytchCoreTests/B2BOrganizationsMembersTestCase.swift
@@ -47,7 +47,7 @@ final class B2BOrganizationsMembersTestCase: BaseTestCase {
         XCTAssertEqual(updateOrganizationMemberResponse.member.name, name)
         try XCTAssertRequest(
             networkInterceptor.requests[0],
-            urlString: "https://api.stytch.com/sdk/v1/b2b/organizations/members/update/\(memberId)",
+            urlString: "https://api.stytch.com/sdk/v1/b2b/organizations/members/\(memberId)",
             method: .put(["member_id": JSON(stringLiteral: memberId), "name": JSON(stringLiteral: name)])
         )
     }


### PR DESCRIPTION
[[iOS] Bug in organization member update path](https://linear.app/stytch/issue/SDK-2871/ios-bug-in-organization-member-update-path)

## Changes:

1. Remove unneeded "update/" from `organizations/members/memberid` call used to be `organizations/members/update/memberid` which matched the update member self path that is just `organizations/members/update`

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
