### PR TITLE
Add org slug to member session

### DIFF
--- a/Sources/StytchCore/StytchB2BClient/Models/MemberSession.swift
+++ b/Sources/StytchCore/StytchB2BClient/Models/MemberSession.swift
@@ -23,6 +23,8 @@ public struct MemberSession: Codable, Sendable {
     public let customClaims: JSON?
     /// A list of the Roles explicitly or implicitly assigned to this Member that are valid for this Member Session. This may differ from the Roles you see on the Member object - Roles that are implicitly assigned by SSO connection or SSO group will only be valid for a Member Session if there is at least one authentication factor on the Member Session from the specified SSO connection.
     public let roles: [String]?
+    /// The unique URL slug of the Organization. The slug only accepts alphanumeric characters and the following reserved characters: - . _ ~. Must be between 2 and 128 characters in length.
+    public let organizationSlug: String?
 
     let memberSessionId: ID
 }

--- a/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
+++ b/Tests/StytchCoreTests/B2BMagicLinksTestCase.swift
@@ -260,6 +260,7 @@ extension MemberSession {
             authenticationFactors: [],
             customClaims: nil,
             roles: ["reader"],
+            organizationSlug: "org_slug_123",
             memberSessionId: "mem_session_123"
         )
     }()
@@ -275,6 +276,7 @@ extension MemberSession {
             authenticationFactors: [],
             customClaims: nil,
             roles: ["organization_admin"],
+            organizationSlug: "org_slug_123",
             memberSessionId: "mem_session_123"
         )
     }()
@@ -289,6 +291,7 @@ extension MemberSession {
             authenticationFactors: [],
             customClaims: nil,
             roles: ["organization_admin"],
+            organizationSlug: "org_slug_123",
             memberSessionId: "mem_session_123"
         )
     }()


### PR DESCRIPTION
[Add organization slug to member session type](https://linear.app/stytch/issue/SDK-2836/add-organization-slug-to-member-session-type)

## Changes:

1. Add org slug to member session.
2. Clean up the B2B UI sample app.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
