### PR TITLE
Make biometrics prompt strings more customizable

### DIFF
--- a/Sources/StytchCore/Environment.swift
+++ b/Sources/StytchCore/Environment.swift
@@ -5,10 +5,6 @@ import AppKit
 import UIKit
 #endif
 
-#if !os(tvOS) && !os(watchOS)
-import LocalAuthentication
-#endif
-
 // swiftlint:disable identifier_name
 #if DEBUG
 var Current: Environment = .init()
@@ -116,10 +112,6 @@ struct Environment {
     #if canImport(StytchDFP)
     var dfpClient: DFPProvider = DFPClient()
     var captcha: CaptchaProvider = CaptchaClient()
-    #endif
-
-    #if !os(tvOS) && !os(watchOS)
-    var localAuthenticationContext: LAContextEvaluating = LAContext()
     #endif
 
     var pkcePairManager: PKCEPairManager {

--- a/Sources/StytchCore/KeychainClient/KeychainClientImplementation.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClientImplementation.swift
@@ -56,7 +56,7 @@ final class KeychainClientImplementation: KeychainClient {
         try safelyEnqueue {
             var result: CFTypeRef?
             var query = item.getQuery
-            #if !os(tvOS)
+            #if !os(tvOS) && !os(watchOS)
             try updateQueryWithLAContext(&query)
             #endif
             var status: OSStatus?
@@ -134,7 +134,7 @@ final class KeychainClientImplementation: KeychainClient {
         let exists = try? safelyEnqueue {
             var result: CFTypeRef?
             var query = item.getQuery
-            #if !os(tvOS)
+            #if !os(tvOS) && !os(watchOS)
             let context = try updateQueryWithLAContext(&query)
             context.interactionNotAllowed = true
             #endif
@@ -148,7 +148,7 @@ final class KeychainClientImplementation: KeychainClient {
         try safelyEnqueue {
             let status: OSStatus
             var query = item.baseQuery
-            #if !os(tvOS)
+            #if !os(tvOS) && !os(watchOS)
             _ = try updateQueryWithLAContext(&query)
             #endif
             if valueExistsForItem(item: item) {
@@ -206,19 +206,12 @@ final class KeychainClientImplementation: KeychainClient {
 }
 
 extension KeychainClientImplementation {
-    #if !os(tvOS)
+    #if !os(tvOS) && !os(watchOS)
     @discardableResult
     func updateQueryWithLAContext(_ query: inout [CFString: Any]) throws -> LAContext {
         try safelyEnqueue {
-            let context = LAContext()
-            #if !os(watchOS)
-            context.localizedReason = NSLocalizedString(
-                "keychain_client.la_context_reason",
-                value: "Authenticate with biometrics",
-                comment: "The user-presented reason for biometric authentication prompts"
-            )
-            #endif
             // This could potentially cause prompting for secured items, so we'll pass in a reusable authentication context to minimize prompting
+            let context = LocalAuthenticationContextManager.laContext
             query[kSecUseAuthenticationContext] = context
             return context
         }

--- a/Sources/StytchCore/StytchClient/Biometrics/LAContextEvaluating.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/LAContextEvaluating.swift
@@ -7,7 +7,7 @@ import LocalAuthentication
 /// and `evaluatePolicy` depend on actual device hardware and biometric configuration.
 /// By conforming `LAContext` to this protocol and providing a mock implementation,
 /// we can inject a controllable context into our biometric flow for reliable testing.
-protocol LAContextEvaluating {
+public protocol LAContextEvaluating {
     var biometryType: LABiometryType { get }
 
     func canEvaluatePolicy(_ policy: LAPolicy, error: NSErrorPointer) -> Bool

--- a/Sources/StytchCore/StytchClient/Biometrics/LocalAuthenticationContextManager.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/LocalAuthenticationContextManager.swift
@@ -1,0 +1,55 @@
+#if !os(tvOS) && !os(watchOS)
+import Foundation
+import LocalAuthentication
+
+// swiftlint:disable type_contents_order prefer_self_in_static_references
+
+public enum LocalAuthenticationContextManager {
+    /// The shared instance of `LAContext` used by default.
+    public static var laContext = LAContext()
+
+    /// The current local authentication context, exposed as `LAContextEvaluating` for easier unit testing.
+    /// Defaults to the shared `laContext` unless explicitly overridden.
+    public static var localAuthenticationContext: LAContextEvaluating = laContext
+
+    /// Replaces the current `localAuthenticationContext` with a custom context.
+    /// Primarily intended for use in unit tests.
+    public static func setLocalAuthenticationContext(context: LAContextEvaluating) {
+        localAuthenticationContext = context
+    }
+
+    /// Updates the localized strings on the shared `laContext` instance.
+    /// Note that this does not update the `localAuthenticationContext` if it has been overridden.
+    public static func updateLaContextStrings(strings: LAContextPromptStrings) {
+        laContext.localizedReason = strings.localizedReason
+        laContext.localizedFallbackTitle = strings.localizedFallbackTitle
+        laContext.localizedCancelTitle = strings.localizedCancelTitle
+    }
+}
+
+/// A type that encapsulates localized prompt strings for an `LAContext`.
+public struct LAContextPromptStrings: Codable, Sendable {
+    public let localizedReason: String
+    public let localizedFallbackTitle: String?
+    public let localizedCancelTitle: String?
+
+    public init(
+        localizedReason: String,
+        localizedFallbackTitle: String? = nil,
+        localizedCancelTitle: String? = nil
+    ) {
+        self.localizedReason = localizedReason
+        self.localizedFallbackTitle = localizedFallbackTitle
+        self.localizedCancelTitle = localizedCancelTitle
+    }
+
+    public static var defaultPromptStrings: LAContextPromptStrings {
+        let localizedReason = NSLocalizedString(
+            "keychain_client.la_context_reason",
+            value: "Authenticate with biometrics",
+            comment: "The user-presented reason for biometric authentication prompts"
+        )
+        return LAContextPromptStrings(localizedReason: localizedReason)
+    }
+}
+#endif

--- a/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
@@ -49,8 +49,6 @@ public extension StytchClient {
 
         @Dependency(\.jsonDecoder) private var jsonDecoder
 
-        @Dependency(\.localAuthenticationContext) private var localAuthenticationContext
-
         /// Indicates if there is an existing biometric registration on device.
         public var registrationAvailable: Bool {
             keychainClient.valueExistsForItem(item: .privateKeyRegistration)
@@ -63,7 +61,7 @@ public extension StytchClient {
         /// Indicates if biometrics are available
         public var availability: Availability {
             var error: NSError?
-            switch (localAuthenticationContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error), registrationAvailable) {
+            switch (LocalAuthenticationContextManager.localAuthenticationContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error), registrationAvailable) {
             case (false, _):
                 return .systemUnavailable((error as? LAError)?.code)
             case (true, false):
@@ -75,8 +73,8 @@ public extension StytchClient {
 
         /// Returns the type of biometric authentication available on the device. touchID or faceID
         public var biometryType: LABiometryType {
-            _ = localAuthenticationContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
-            return localAuthenticationContext.biometryType
+            _ = LocalAuthenticationContextManager.localAuthenticationContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
+            return LocalAuthenticationContextManager.localAuthenticationContext.biometryType
         }
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
@@ -110,11 +108,13 @@ public extension StytchClient {
                 throw StytchSDKError.biometricsAlreadyEnrolled
             }
 
-            guard localAuthenticationContext.canEvaluatePolicy(parameters.accessPolicy, error: nil) else {
+            LocalAuthenticationContextManager.updateLaContextStrings(strings: parameters.promptStrings)
+
+            guard LocalAuthenticationContextManager.localAuthenticationContext.canEvaluatePolicy(parameters.accessPolicy, error: nil) else {
                 throw StytchSDKError.biometricsUnavailable
             }
 
-            guard try await localAuthenticationContext.evaluatePolicy(parameters.accessPolicy, localizedReason: "Authenticate to register biometrics") else {
+            guard try await LocalAuthenticationContextManager.localAuthenticationContext.evaluatePolicy(parameters.accessPolicy, localizedReason: parameters.promptStrings.localizedReason) else {
                 throw StytchSDKError.biometricAuthenticationFailed
             }
 
@@ -162,6 +162,8 @@ public extension StytchClient {
             guard let privateKeyRegistrationQueryResult: KeychainQueryResult = try keychainClient.getQueryResults(item: .privateKeyRegistration).first else {
                 throw StytchSDKError.noBiometricRegistration
             }
+
+            LocalAuthenticationContextManager.updateLaContextStrings(strings: parameters.promptStrings)
 
             try copyBiometricRegistrationIDToKeychainIfNeeded(privateKeyRegistrationQueryResult)
 
@@ -246,11 +248,18 @@ public extension StytchClient.Biometrics {
     /// A dedicated parameters type for biometrics `authenticate` calls.
     struct AuthenticateParameters: Sendable {
         let sessionDurationMinutes: Minutes
+        let promptStrings: LAContextPromptStrings
 
         /// Initializes the parameters struct
-        /// - Parameter sessionDurationMinutes: The duration, in minutes, for the requested session. Defaults to 5 minutes.
-        public init(sessionDurationMinutes: Minutes = StytchClient.defaultSessionDuration) {
+        /// - Parameters:
+        ///   - sessionDurationMinutes: The duration, in minutes, for the requested session. Defaults to 5 minutes.
+        ///   - promptStrings: The localized prompt strings for an `LAContext`.
+        public init(
+            sessionDurationMinutes: Minutes = StytchClient.defaultSessionDuration,
+            promptStrings: LAContextPromptStrings = .defaultPromptStrings
+        ) {
             self.sessionDurationMinutes = sessionDurationMinutes
+            self.promptStrings = promptStrings
         }
     }
 
@@ -259,20 +268,24 @@ public extension StytchClient.Biometrics {
         let identifier: String
         let accessPolicy: LAPolicy
         let sessionDurationMinutes: Minutes
+        let promptStrings: LAContextPromptStrings
 
         /// Initializes the parameters struct
         /// - Parameters:
         ///   - identifier: An id used to easily identify the account associated with the biometric registration, generally an email or phone number.
         ///   - accessPolicy: Defines the policy as to how the user must confirm their ownership.
         ///   - sessionDurationMinutes: The duration, in minutes, for the requested session. Defaults to 5 minutes.
+        ///   - promptStrings: The localized prompt strings for an `LAContext`.
         public init(
             identifier: String,
             accessPolicy: LAPolicy = .deviceOwnerAuthenticationWithBiometrics,
-            sessionDurationMinutes: Minutes = StytchClient.defaultSessionDuration
+            sessionDurationMinutes: Minutes = StytchClient.defaultSessionDuration,
+            promptStrings: LAContextPromptStrings = .defaultPromptStrings
         ) {
             self.identifier = identifier
             self.accessPolicy = accessPolicy
             self.sessionDurationMinutes = sessionDurationMinutes
+            self.promptStrings = promptStrings
         }
     }
 

--- a/Tests/StytchCoreTests/BaseTestCase.swift
+++ b/Tests/StytchCoreTests/BaseTestCase.swift
@@ -48,10 +48,6 @@ class BaseTestCase: XCTestCase {
 
         Current.sessionManager.consumerLastAuthMethodUsed = StytchClient.ConsumerAuthMethod.unknown
         Current.sessionManager.b2bLastAuthMethodUsed = StytchB2BClient.B2BAuthMethod.unknown
-
-        #if !os(tvOS) && !os(watchOS)
-        Current.localAuthenticationContext = MockLocalAuthenticationContext()
-        #endif
     }
 }
 

--- a/Tests/StytchCoreTests/BiometricsTestCase.swift
+++ b/Tests/StytchCoreTests/BiometricsTestCase.swift
@@ -4,6 +4,11 @@ import XCTest
 
 #if !os(tvOS) && !os(watchOS)
 final class BiometricsTestCase: BaseTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        LocalAuthenticationContextManager.setLocalAuthenticationContext(context: MockLocalAuthenticationContext())
+    }
+
     func testRegistration() async throws {
         XCTAssertFalse(StytchClient.biometrics.registrationAvailable)
 


### PR DESCRIPTION
[[iOS] Make biometric prompts customizable.](https://linear.app/stytch/issue/SDK-2904/ios-make-biometric-prompts-customizable)

## Changes:

1. Moved the management of the shared  `LAContext` to the `LocalAuthenticationContextManager`.
2. Create `LAContextPromptStrings` so that the calling developer can configure the strings for an `LAContext`.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
