### PR TITLE
Configureable session extension

### DIFF
--- a/Sources/StytchCore/PollingClient/PollingClient+Live.swift
+++ b/Sources/StytchCore/PollingClient/PollingClient+Live.swift
@@ -3,7 +3,14 @@ import Foundation
 extension PollingClient {
     // A polling client which tries to complete every 3 minutes, and will retry w/ exponential backoff upon errors, for up to a total of approximately 124 seconds.
     static let sessions: PollingClient = .init(interval: 180, maxRetries: 5, queue: .sessionsPolling) { onSuccess, onFailure in
-        StytchClient.sessions.authenticate(parameters: .init()) { result in
+        let authenticateParameters: StytchClient.Sessions.AuthenticateParameters
+        if StytchClient.stytchClientConfiguration?.enableAutomaticSessionExtension == true {
+            authenticateParameters = .init(sessionDurationMinutes: StytchClient.defaultSessionDuration)
+        } else {
+            authenticateParameters = .init(sessionDurationMinutes: nil)
+        }
+
+        StytchClient.sessions.authenticate(parameters: authenticateParameters) { result in
             switch result {
             case .success:
                 onSuccess()
@@ -15,7 +22,14 @@ extension PollingClient {
 
     // A polling client which tries to complete every 3 minutes, and will retry w/ exponential backoff upon errors, for up to a total of approximately 124 seconds.
     static let memberSessions: PollingClient = .init(interval: 180, maxRetries: 5, queue: .sessionsPolling) { onSuccess, onFailure in
-        StytchB2BClient.sessions.authenticate(parameters: .init()) { result in
+        let authenticateParameters: StytchB2BClient.Sessions.AuthenticateParameters
+        if StytchB2BClient.stytchClientConfiguration?.enableAutomaticSessionExtension == true {
+            authenticateParameters = .init(sessionDurationMinutes: StytchB2BClient.defaultSessionDuration)
+        } else {
+            authenticateParameters = .init(sessionDurationMinutes: nil)
+        }
+
+        StytchB2BClient.sessions.authenticate(parameters: authenticateParameters) { result in
             switch result {
             case .success:
                 onSuccess()

--- a/Sources/StytchCore/SharedModels/StytchClientConfiguration.swift
+++ b/Sources/StytchCore/SharedModels/StytchClientConfiguration.swift
@@ -6,6 +6,7 @@ public struct StytchClientConfiguration: Equatable, Codable {
     private enum CodingKeys: String, CodingKey {
         case publicToken = "StytchPublicToken"
         case defaultSessionDuration
+        case enableAutomaticSessionExtension
         case hostUrl = "StytchHostURL"
         case dfppaDomain = "StytchDfppaDomain"
         case testDomain = "StytchTestDomain"
@@ -14,6 +15,7 @@ public struct StytchClientConfiguration: Equatable, Codable {
 
     public let publicToken: String
     public let defaultSessionDuration: Minutes
+    public let enableAutomaticSessionExtension: Bool
     public let hostUrl: URL?
     public let dfppaDomain: String?
     public let testDomain: String
@@ -26,6 +28,7 @@ public struct StytchClientConfiguration: Equatable, Codable {
        - defaultSessionDuration: The defaultSessionDuration must be configured to start the client.
          This value must be less than or equal to the session duration set in the Stytch Dashboard under `Frontend SDKs -> Session duration`.
          `defaultSessionDuration` will be applied to all authentication calls unless explicitly overridden per call.
+       - enableAutomaticSessionExtension: If true, the session heartbeat will attempt to extend the session duration instead of only checking the validity.
        - hostUrl: Generally this is your backend's base url, where your apple-app-site-association file is hosted.
          This is an https url which will be used as the domain for setting session-token cookies to be sent to your servers on subsequent requests.
          If not passed here, no cookies will be set on your behalf.
@@ -36,6 +39,7 @@ public struct StytchClientConfiguration: Equatable, Codable {
     public init(
         publicToken: String,
         defaultSessionDuration: Minutes = 5,
+        enableAutomaticSessionExtension: Bool = false,
         hostUrl: URL? = nil,
         dfppaDomain: String? = nil,
         testDomain: String = "test.stytch.com",
@@ -43,6 +47,7 @@ public struct StytchClientConfiguration: Equatable, Codable {
     ) {
         self.publicToken = publicToken
         self.defaultSessionDuration = defaultSessionDuration
+        self.enableAutomaticSessionExtension = enableAutomaticSessionExtension
         self.hostUrl = hostUrl
         self.dfppaDomain = dfppaDomain
         self.testDomain = testDomain
@@ -71,10 +76,11 @@ public extension StytchClientConfiguration {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         publicToken = try container.decode(key: .publicToken)
+        defaultSessionDuration = try container.decode(key: .defaultSessionDuration)
+        enableAutomaticSessionExtension = try container.decode(key: .enableAutomaticSessionExtension)
         dfppaDomain = try container.decode(key: .dfppaDomain)
         testDomain = try container.decode(key: .testDomain)
         liveDomain = try container.decode(key: .liveDomain)
-        defaultSessionDuration = try container.decode(key: .defaultSessionDuration)
         do {
             hostUrl = try container.decode(key: .hostUrl)
         } catch {


### PR DESCRIPTION
[[iOS] Optionally extend the session with the heartbeat via the client config](https://linear.app/stytch/issue/SDK-2909/ios-optionally-extend-the-session-with-the-heartbeat-via-the-client)

## Changes:

1. Now the developer can configure if they want the heartbeat to extend the session and by how much rather than just validating the session.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
