### PR TITLE
Convert SessionToken to a String typealias

### DIFF
--- a/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsItem.swift
+++ b/Sources/StytchCore/EncryptedUserDefaultsClient/EncryptedUserDefaultsItem.swift
@@ -18,8 +18,8 @@ extension EncryptedUserDefaultsItem {
 extension EncryptedUserDefaultsItem {
     static let biometricKeyRegistration: Self = .init(name: "stytch_biometric_key_registration")
 
-    static let sessionToken: Self = .init(name: SessionToken.Kind.opaque.name)
-    static let sessionJwt: Self = .init(name: SessionToken.Kind.jwt.name)
+    static let sessionToken: Self = .init(name: "stytch_session")
+    static let sessionJwt: Self = .init(name: "stytch_session_jwt")
     static let intermediateSessionToken: Self = .init(name: "stytch_intermediate_session_token")
 
     static let codeVerifierPKCE: Self = .init(name: "stytch_code_verifier_pkce")

--- a/Sources/StytchCore/KeychainClient/KeychainItem.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainItem.swift
@@ -122,8 +122,8 @@ extension KeychainItem {
 
     // The following key types are deprecated, but exist for backwards compatibility with migrations
     static let biometricKeyRegistration: Self = .init(kind: .deprecated, name: "stytch_biometric_key_registration")
-    static let sessionToken: Self = .init(kind: .deprecated, name: SessionToken.Kind.opaque.name)
-    static let sessionJwt: Self = .init(kind: .deprecated, name: SessionToken.Kind.jwt.name)
+    static let sessionToken: Self = .init(kind: .deprecated, name: "stytch_session")
+    static let sessionJwt: Self = .init(kind: .deprecated, name: "stytch_session_jwt")
     static let intermediateSessionToken: Self = .init(kind: .deprecated, name: "stytch_intermediate_session_token")
     static let codeVerifierPKCE: Self = .init(kind: .deprecated, name: "stytch_code_verifier_pkce")
     static let codeChallengePKCE: Self = .init(kind: .deprecated, name: "stytch_code_challenge_pkce")

--- a/Sources/StytchCore/Networking/NetworkingClient.swift
+++ b/Sources/StytchCore/Networking/NetworkingClient.swift
@@ -18,7 +18,7 @@ extension NetworkingClient {
         let publicToken = configuration.publicToken
 
         let authToken: String
-        if let sessionToken = Current.sessionManager.sessionToken?.value, sessionToken.isEmpty == false {
+        if let sessionToken = Current.sessionManager.sessionToken, sessionToken.isEmpty == false {
             authToken = "\(publicToken):\(sessionToken)".base64Encoded()
         } else {
             authToken = "\(publicToken):\(publicToken)".base64Encoded()

--- a/Sources/StytchCore/Networking/NetworkingRouter.swift
+++ b/Sources/StytchCore/Networking/NetworkingRouter.swift
@@ -215,7 +215,7 @@ extension NetworkingRouter {
 
             sessionManager.updateSession(
                 sessionType: .user(sessionResponse.session),
-                tokens: SessionTokens(jwt: .jwt(sessionResponse.sessionJwt), opaque: .opaque(sessionResponse.sessionToken))
+                tokens: SessionTokens(jwt: sessionResponse.sessionJwt, opaque: sessionResponse.sessionToken)
             )
 
             #if !os(tvOS) && !os(watchOS)
@@ -231,7 +231,7 @@ extension NetworkingRouter {
 
             sessionManager.updateSession(
                 sessionType: .member(sessionResponse.memberSession),
-                tokens: SessionTokens(jwt: .jwt(sessionResponse.sessionJwt), opaque: .opaque(sessionResponse.sessionToken))
+                tokens: SessionTokens(jwt: sessionResponse.sessionJwt, opaque: sessionResponse.sessionToken)
             )
         } else if let sessionResponse = dataContainer.data as? B2BMFAAuthenticateResponseType {
             // Update the member and organization so that all values are current when the session publisher fires
@@ -241,7 +241,7 @@ extension NetworkingRouter {
             if let memberSession = sessionResponse.memberSession {
                 sessionManager.updateSession(
                     sessionType: .member(memberSession),
-                    tokens: SessionTokens(jwt: .jwt(sessionResponse.sessionJwt), opaque: .opaque(sessionResponse.sessionToken))
+                    tokens: SessionTokens(jwt: sessionResponse.sessionJwt, opaque: sessionResponse.sessionToken)
                 )
             } else {
                 sessionManager.updateSession(

--- a/Sources/StytchCore/SessionManager.swift
+++ b/Sources/StytchCore/SessionManager.swift
@@ -28,11 +28,11 @@ class SessionManager {
     @Dependency(\.keychainClient) private var keychainClient
 
     var hasValidSessionToken: Bool {
-        sessionToken != nil && sessionToken?.value.isEmpty == false
+        sessionToken != nil && sessionToken?.isEmpty == false
     }
 
     var hasValidSessionJwt: Bool {
-        sessionJwt != nil && sessionJwt?.value.isEmpty == false
+        sessionJwt != nil && sessionJwt?.isEmpty == false
     }
 
     var hasValidIntermediateSessionToken: Bool {
@@ -95,10 +95,10 @@ class SessionManager {
 
     func clearEmptyTokens() {
         // Clear any successfully cached empty string on startup
-        if let value = sessionToken?.value, value.isEmpty == true {
+        if let value = sessionToken, value.isEmpty == true {
             sessionToken = nil
         }
-        if let value = sessionJwt?.value, value.isEmpty == true {
+        if let value = sessionJwt, value.isEmpty == true {
             sessionJwt = nil
         }
         if let value = intermediateSessionToken, value.isEmpty == true {
@@ -115,30 +115,18 @@ class SessionManager {
             resetSession()
         }
     }
-
-    @objc func cookiesDidUpdate(notification: Notification) {
-        let storage = (notification.object as? HTTPCookieStorage) ?? .shared
-
-        if let jwtCookieValue = storage.cookieValue(cookieName: SessionToken.Kind.jwt.name, date: date()) {
-            sessionJwt = .jwt(jwtCookieValue)
-        }
-
-        if let opaqueCookieValue = storage.cookieValue(cookieName: SessionToken.Kind.opaque.name, date: date()) {
-            sessionToken = .opaque(opaqueCookieValue)
-        }
-    }
 }
 
 // Session Tokens
 extension SessionManager {
     private(set) var sessionToken: SessionToken? {
         get {
-            try? userDefaultsClient.getStringValue(.sessionToken).map(SessionToken.opaque)
+            try? userDefaultsClient.getStringValue(.sessionToken)
         }
         set {
             let userDefaultsItem: EncryptedUserDefaultsItem = .sessionToken
             if let newValue = newValue {
-                try? userDefaultsClient.setStringValue(newValue.value, for: userDefaultsItem)
+                try? userDefaultsClient.setStringValue(newValue, for: userDefaultsItem)
             } else {
                 try? userDefaultsClient.removeItem(item: userDefaultsItem)
             }
@@ -147,12 +135,12 @@ extension SessionManager {
 
     private(set) var sessionJwt: SessionToken? {
         get {
-            try? userDefaultsClient.getStringValue(.sessionJwt).map(SessionToken.jwt)
+            try? userDefaultsClient.getStringValue(.sessionJwt)
         }
         set {
             let userDefaultsItem: EncryptedUserDefaultsItem = .sessionJwt
             if let newValue = newValue {
-                try? userDefaultsClient.setStringValue(newValue.value, for: userDefaultsItem)
+                try? userDefaultsClient.setStringValue(newValue, for: userDefaultsItem)
             } else {
                 try? userDefaultsClient.removeItem(item: userDefaultsItem)
             }

--- a/Sources/StytchCore/SharedModels/SessionToken.swift
+++ b/Sources/StytchCore/SharedModels/SessionToken.swift
@@ -1,67 +1,17 @@
 import Foundation
 
-// TODO: include optional expiration here
-/// Represents one of two kinds of tokens used to represent a session (see ``SessionToken/Kind-swift.enum``, for more info.) These tokens are used to authenticate the current user/member.
-public struct SessionToken: Equatable, Sendable {
-    /// A type representing the different kinds of session tokens available.
-    public enum Kind: CaseIterable, Sendable {
-        /// An token which is an opaque string, simply representing the session.
-        case opaque
-        /// A JWT representing the session, which contains signed and serialized information about the session.
-        case jwt
-
-        var name: String {
-            switch self {
-            case .opaque:
-                return "stytch_session"
-            case .jwt:
-                return "stytch_session_jwt"
-            }
-        }
-    }
-
-    /// The kind of session token.
-    public let kind: Kind
-
-    /// The string value of the session token.
-    public let value: String
-
-    var name: String { kind.name }
-
-    private init(kind: Kind, value: String) {
-        self.kind = kind
-        self.value = value
-    }
-
-    /// Initializes a new token and marks it as a JWT.
-    public static func jwt(_ value: String) -> Self {
-        .init(kind: .jwt, value: value)
-    }
-
-    /// Initializes a new token and marks it as an opaque token.
-    public static func opaque(_ value: String) -> Self {
-        .init(kind: .opaque, value: value)
-    }
-}
+public typealias SessionToken = String
 
 /// A public interface to require the caller to explicitly pass one of each type of non nil token in order to update a session.
 public struct SessionTokens: Sendable {
     internal let jwt: SessionToken?
     internal let opaque: SessionToken
 
-    /// A nullable initializer that requires the caller to pass at least one non-nil instance of each token type.
+    /// An  initializer that requires the caller to pass a non nil opaque SessionToken and an optional jwt.
     /// - Parameters:
     ///   - jwt: An instance of `SessionToken` with a `type` of `.jwt`
     ///   - opaque: An instance of `SessionToken` with a `type` of `.opaque`
-    public init?(jwt: SessionToken?, opaque: SessionToken) {
-        if let jwt = jwt, jwt.kind != .jwt, jwt.value.isEmpty == true {
-            return nil
-        }
-
-        if opaque.kind != .opaque, opaque.value.isEmpty == true {
-            return nil
-        }
-
+    public init(jwt: SessionToken? = nil, opaque: SessionToken) {
         self.jwt = jwt
         self.opaque = opaque
     }

--- a/Tests/StytchCoreTests/B2BSessionsTestCase.swift
+++ b/Tests/StytchCoreTests/B2BSessionsTestCase.swift
@@ -18,7 +18,7 @@ final class B2BSessionsTestCase: BaseTestCase {
 
         Current.sessionManager.updateSession(
             sessionType: .member(.mock),
-            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day"))
+            tokens: SessionTokens(jwt: "i'm_jwt", opaque: "opaque_all_day")
         )
 
         _ = try await StytchB2BClient.sessions.authenticate(parameters: parameters)
@@ -29,8 +29,8 @@ final class B2BSessionsTestCase: BaseTestCase {
             method: .post(["session_duration_minutes": 15])
         )
 
-        XCTAssertEqual(StytchB2BClient.sessions.sessionJwt, .jwt("i'mvalidjson"))
-        XCTAssertEqual(StytchB2BClient.sessions.sessionToken, .opaque("xyzasdf"))
+        XCTAssertEqual(StytchB2BClient.sessions.sessionJwt, "i'mvalidjson")
+        XCTAssertEqual(StytchB2BClient.sessions.sessionToken, "xyzasdf")
         XCTAssertNotNil(StytchB2BClient.sessions.memberSession)
     }
 
@@ -63,8 +63,8 @@ final class B2BSessionsTestCase: BaseTestCase {
             ])
         )
 
-        XCTAssertEqual(StytchB2BClient.sessions.sessionJwt, .jwt("i'mvalidjson"))
-        XCTAssertEqual(StytchB2BClient.sessions.sessionToken, .opaque("xyzasdf"))
+        XCTAssertEqual(StytchB2BClient.sessions.sessionJwt, "i'mvalidjson")
+        XCTAssertEqual(StytchB2BClient.sessions.sessionToken, "xyzasdf")
         XCTAssertNotNil(StytchB2BClient.sessions.memberSession)
     }
 
@@ -74,11 +74,11 @@ final class B2BSessionsTestCase: BaseTestCase {
 
         Current.sessionManager.updateSession(
             sessionType: .member(.mock),
-            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day"))
+            tokens: SessionTokens(jwt: "i'm_jwt", opaque: "opaque_all_day")
         )
 
-        XCTAssertEqual(StytchB2BClient.sessions.sessionToken, .opaque("opaque_all_day"))
-        XCTAssertEqual(StytchB2BClient.sessions.sessionJwt, .jwt("i'm_jwt"))
+        XCTAssertEqual(StytchB2BClient.sessions.sessionToken, "opaque_all_day")
+        XCTAssertEqual(StytchB2BClient.sessions.sessionJwt, "i'm_jwt")
 
         _ = try await StytchB2BClient.sessions.revoke()
 
@@ -94,13 +94,10 @@ final class B2BSessionsTestCase: BaseTestCase {
         XCTAssertNil(StytchB2BClient.sessions.sessionToken)
         XCTAssertNil(StytchB2BClient.sessions.sessionJwt)
 
-        if let tokens = SessionTokens(jwt: .jwt("jwt"), opaque: .opaque("token")) {
-            StytchB2BClient.sessions.update(sessionTokens: tokens)
-            XCTAssertEqual(StytchB2BClient.sessions.sessionToken, .opaque("token"))
-            XCTAssertEqual(StytchB2BClient.sessions.sessionJwt, .jwt("jwt"))
-        } else {
-            XCTFail("SessionTokens should not be nil")
-        }
+        let tokens = SessionTokens(jwt: "jwt", opaque: "token")
+        StytchB2BClient.sessions.update(sessionTokens: tokens)
+        XCTAssertEqual(StytchB2BClient.sessions.sessionToken, "token")
+        XCTAssertEqual(StytchB2BClient.sessions.sessionJwt, "jwt")
     }
 
     func testSessionExchange() async throws {
@@ -144,7 +141,7 @@ final class B2BSessionsTestCase: BaseTestCase {
         Current.timer = { _, _, _ in Self.mockTimer }
         Current.sessionManager.updateSession(
             sessionType: .member(.mock),
-            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day"))
+            tokens: SessionTokens(jwt: "i'm_jwt", opaque: "opaque_all_day")
         )
 
         wait(for: [expectation], timeout: 1.0)
@@ -167,7 +164,7 @@ final class B2BSessionsTestCase: BaseTestCase {
         Current.timer = { _, _, _ in Self.mockTimer }
         Current.sessionManager.updateSession(
             sessionType: nil,
-            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day"))
+            tokens: SessionTokens(jwt: "i'm_jwt", opaque: "opaque_all_day")
         )
 
         wait(for: [expectation], timeout: 1.0)
@@ -178,7 +175,7 @@ final class B2BSessionsTestCase: BaseTestCase {
         Current.timer = { _, _, _ in Self.mockTimer }
         Current.sessionManager.updateSession(
             sessionType: .member(.mockWithExpiredMemberSession),
-            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day"))
+            tokens: SessionTokens(jwt: "i'm_jwt", opaque: "opaque_all_day")
         )
 
         XCTAssertNil(StytchB2BClient.sessions.memberSession)

--- a/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
+++ b/Tests/StytchCoreTests/CryptoWalletsTestCase.swift
@@ -55,8 +55,8 @@ final class CryptoWalletsTestCase: BaseTestCase {
 
         _ = try await StytchClient.cryptoWallets.authenticate(parameters: .init(cryptoWalletType: .solana, cryptoWalletAddress: "mock-crypto-address", signature: "mock-signature"))
 
-        XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("hello_session"))
-        XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("jwt_for_me"))
+        XCTAssertEqual(StytchClient.sessions.sessionToken, "hello_session")
+        XCTAssertEqual(StytchClient.sessions.sessionJwt, "jwt_for_me")
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],

--- a/Tests/StytchCoreTests/OTPTestCase.swift
+++ b/Tests/StytchCoreTests/OTPTestCase.swift
@@ -158,8 +158,8 @@ final class OTPTestCase: BaseTestCase {
 
         _ = try await StytchClient.otps.authenticate(parameters: parameters)
 
-        XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("hello_session"))
-        XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("jwt_for_me"))
+        XCTAssertEqual(StytchClient.sessions.sessionToken, "hello_session")
+        XCTAssertEqual(StytchClient.sessions.sessionJwt, "jwt_for_me")
 
         try XCTAssertRequest(
             networkInterceptor.requests[0],

--- a/Tests/StytchCoreTests/SessionManagerTestCase.swift
+++ b/Tests/StytchCoreTests/SessionManagerTestCase.swift
@@ -26,7 +26,7 @@ final class SessionManagerTestCase: BaseTestCase {
 
         Current.sessionManager.updateSession(
             sessionType: .user(.mock(userId: "i_am_user")),
-            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day"))
+            tokens: SessionTokens(jwt: "i'm_jwt", opaque: "opaque_all_day")
         )
 
         _ = try await StytchClient.sessions.authenticate(parameters: parameters)
@@ -37,8 +37,8 @@ final class SessionManagerTestCase: BaseTestCase {
             method: .post(["session_duration_minutes": 15])
         )
 
-        XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("jwt_for_me"))
-        XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("hello_session"))
+        XCTAssertEqual(StytchClient.sessions.sessionJwt, "jwt_for_me")
+        XCTAssertEqual(StytchClient.sessions.sessionToken, "hello_session")
         XCTAssertNotNil(StytchClient.sessions.session)
     }
 
@@ -70,8 +70,8 @@ final class SessionManagerTestCase: BaseTestCase {
             ])
         )
 
-        XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("jwt_for_me"))
-        XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("hello_session"))
+        XCTAssertEqual(StytchClient.sessions.sessionJwt, "jwt_for_me")
+        XCTAssertEqual(StytchClient.sessions.sessionToken, "hello_session")
         XCTAssertNotNil(StytchClient.sessions.session)
     }
 
@@ -81,11 +81,11 @@ final class SessionManagerTestCase: BaseTestCase {
 
         Current.sessionManager.updateSession(
             sessionType: .user(.mock(userId: "i_am_user")),
-            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day"))
+            tokens: SessionTokens(jwt: "i'm_jwt", opaque: "opaque_all_day")
         )
 
-        XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("opaque_all_day"))
-        XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("i'm_jwt"))
+        XCTAssertEqual(StytchClient.sessions.sessionToken, "opaque_all_day")
+        XCTAssertEqual(StytchClient.sessions.sessionJwt, "i'm_jwt")
 
         _ = try await StytchClient.sessions.revoke()
 
@@ -104,11 +104,11 @@ final class SessionManagerTestCase: BaseTestCase {
 
         Current.sessionManager.updateSession(
             sessionType: .user(.mock(userId: "i_am_user")),
-            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day"))
+            tokens: SessionTokens(jwt: "i'm_jwt", opaque: "opaque_all_day")
         )
 
-        XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("opaque_all_day"))
-        XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("i'm_jwt"))
+        XCTAssertEqual(StytchClient.sessions.sessionToken, "opaque_all_day")
+        XCTAssertEqual(StytchClient.sessions.sessionJwt, "i'm_jwt")
 
         await XCTAssertThrowsErrorAsync(
             try await StytchClient.sessions.revoke(),
@@ -137,13 +137,10 @@ final class SessionManagerTestCase: BaseTestCase {
         XCTAssertNil(StytchClient.sessions.sessionToken)
         XCTAssertNil(StytchClient.sessions.sessionJwt)
 
-        if let tokens = SessionTokens(jwt: .jwt("jwt"), opaque: .opaque("token")) {
-            StytchClient.sessions.update(sessionTokens: tokens)
-            XCTAssertEqual(StytchClient.sessions.sessionToken, .opaque("token"))
-            XCTAssertEqual(StytchClient.sessions.sessionJwt, .jwt("jwt"))
-        } else {
-            XCTFail("SessionTokens should not be nil")
-        }
+        let tokens = SessionTokens(jwt: "jwt", opaque: "token")
+        StytchClient.sessions.update(sessionTokens: tokens)
+        XCTAssertEqual(StytchClient.sessions.sessionToken, "token")
+        XCTAssertEqual(StytchClient.sessions.sessionJwt, "jwt")
     }
 
     func testIntermediateSessionToken() {
@@ -152,7 +149,7 @@ final class SessionManagerTestCase: BaseTestCase {
         // Given we call update session with valid member session and tokens
         Current.sessionManager.updateSession(
             sessionType: .member(.mock),
-            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day"))
+            tokens: SessionTokens(jwt: "i'm_jwt", opaque: "opaque_all_day")
         )
 
         // And it correctly applies the values
@@ -190,7 +187,7 @@ final class SessionManagerTestCase: BaseTestCase {
         Current.timer = { _, _, _ in Self.mockTimer }
         Current.sessionManager.updateSession(
             sessionType: .user(.mock(userId: "i_am_user")),
-            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day"))
+            tokens: SessionTokens(jwt: "i'm_jwt", opaque: "opaque_all_day")
         )
 
         wait(for: [expectation], timeout: 1.0)
@@ -213,7 +210,7 @@ final class SessionManagerTestCase: BaseTestCase {
         Current.timer = { _, _, _ in Self.mockTimer }
         Current.sessionManager.updateSession(
             sessionType: nil,
-            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day"))
+            tokens: SessionTokens(jwt: "i'm_jwt", opaque: "opaque_all_day")
         )
 
         wait(for: [expectation], timeout: 1.0)
@@ -224,7 +221,7 @@ final class SessionManagerTestCase: BaseTestCase {
         Current.timer = { _, _, _ in Self.mockTimer }
         Current.sessionManager.updateSession(
             sessionType: .user(.mockWithExpiredSession(userId: "i_am_user")),
-            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day"))
+            tokens: SessionTokens(jwt: "i'm_jwt", opaque: "opaque_all_day")
         )
 
         XCTAssertNil(StytchClient.sessions.session)
@@ -241,7 +238,7 @@ final class SessionManagerTestCase: BaseTestCase {
 
         Current.sessionManager.updateSession(
             sessionType: .user(.mock(userId: "i_am_user")),
-            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day"))
+            tokens: SessionTokens(jwt: "i'm_jwt", opaque: "opaque_all_day")
         )
 
         XCTAssertNotNil(Current.sessionManager.sessionToken)
@@ -271,7 +268,7 @@ final class SessionManagerTestCase: BaseTestCase {
 
         Current.sessionManager.updateSession(
             sessionType: .user(.mock(userId: "i_am_user")),
-            tokens: SessionTokens(jwt: .jwt("i'm_jwt"), opaque: .opaque("opaque_all_day"))
+            tokens: SessionTokens(jwt: "i'm_jwt", opaque: "opaque_all_day")
         )
 
         XCTAssertNotNil(Current.sessionManager.sessionToken)


### PR DESCRIPTION
After interacting with the `SessionTokens` and `SessionToken` objects as an external consumer I felt that distinguishing between the token types internally was of zero value. The `SessionTokens` object store 2 tokens, one for each type that is named and that is all the differentiation we really need. Therefore I felt that the `SessionToken` could be made a simple String type alias and we would get all the same value from it.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
