### PR TITLE
Remove extraneous guard

### DIFF
--- a/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
+++ b/Sources/StytchCore/StytchClient/Biometrics/StytchClient+Biometrics.swift
@@ -168,9 +168,6 @@ public extension StytchClient {
             }
             LocalAuthenticationContextManager.laContext = LAContext()
             LocalAuthenticationContextManager.updateLaContextStrings(strings: parameters.promptStrings)
-            guard try await LocalAuthenticationContextManager.localAuthenticationContext.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: parameters.promptStrings.localizedReason) else {
-                throw StytchSDKError.biometricAuthenticationFailed
-            }
 
             try copyBiometricRegistrationIDToKeychainIfNeeded(privateKeyRegistrationQueryResult)
 

--- a/Stytch/Stytch.xcodeproj/project.pbxproj
+++ b/Stytch/Stytch.xcodeproj/project.pbxproj
@@ -1682,7 +1682,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1718,7 +1718,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Changes:

1. Removes extraneous policy evaluation that could potentially trigger duplicate face ID prompts. Crucially, it still forces the use of a new LAContext for each authentication; without that, the Face ID prompt would _only_ show on the _first_ attempt of a session; additional requests would bypass the prompt at the platform's discretion.
2. Drops the minimum target for the biometrics demo app so I could test it on my old phone, haha

## Additional Context
#591 & #595 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A
