### PR TITLE
Fix passkeys update and register response models

### DIFF
--- a/Sources/StytchCore/Generated/StytchClient.Passkeys.register+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.Passkeys.register+AsyncVariants.generated.swift
@@ -7,7 +7,7 @@ import Foundation
 @available(macOS 12.0, iOS 16.0, tvOS 16.0, *)
 public extension StytchClient.Passkeys {
     /// Registers a passkey with the device and with Stytch's servers for the authenticated user.
-    func register(parameters: RegisterParameters, completion: @escaping Completion<BasicResponse>) {
+    func register(parameters: RegisterParameters, completion: @escaping Completion<RegisterResponse>) {
         Task {
             do {
                 completion(.success(try await register(parameters: parameters)))
@@ -18,7 +18,7 @@ public extension StytchClient.Passkeys {
     }
 
     /// Registers a passkey with the device and with Stytch's servers for the authenticated user.
-    func register(parameters: RegisterParameters) -> AnyPublisher<BasicResponse, Error> {
+    func register(parameters: RegisterParameters) -> AnyPublisher<RegisterResponse, Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/StytchClient/Models/User.swift
+++ b/Sources/StytchCore/StytchClient/Models/User.swift
@@ -283,14 +283,17 @@ public extension User {
         public let userAgent: String
         /// The verification status of the registration.
         public let verified: Bool
+        /// The user-provided name of the registration, if one has been set.
+        public let name: String?
         /// The id of the registration.
         public var id: ID { webauthnRegistrationId }
         let webauthnRegistrationId: ID
 
-        public init(domain: String, userAgent: String, verified: Bool, webauthnRegistrationId: Self.ID) {
+        public init(domain: String, userAgent: String, verified: Bool, name: String? = nil, webauthnRegistrationId: Self.ID) {
             self.domain = domain
             self.userAgent = userAgent
             self.verified = verified
+            self.name = name
             self.webauthnRegistrationId = webauthnRegistrationId
         }
 
@@ -298,6 +301,7 @@ public extension User {
             lhs.domain == rhs.domain &&
                 lhs.userAgent == rhs.userAgent &&
                 lhs.verified == rhs.verified &&
+                lhs.name == rhs.name &&
                 lhs.webauthnRegistrationId == rhs.webauthnRegistrationId
         }
     }

--- a/Sources/StytchCore/StytchClient/Models/User.swift
+++ b/Sources/StytchCore/StytchClient/Models/User.swift
@@ -279,29 +279,40 @@ public extension User {
         public typealias ID = Identifier<Self, String>
         /// The domain of the WebAuthN registration.
         public let domain: String
+        /// The requested authenticator type of the Passkey or WebAuthn device.
+        public let authenticatorType: String?
+        /// The user-friendly name of the Passkey or WebAuthn registration.
+        public let name: String?
         /// The user agent of the registration.
         public let userAgent: String
         /// The verification status of the registration.
         public let verified: Bool
-        /// The user-provided name of the registration, if one has been set.
-        public let name: String?
         /// The id of the registration.
         public var id: ID { webauthnRegistrationId }
         let webauthnRegistrationId: ID
 
-        public init(domain: String, userAgent: String, verified: Bool, name: String? = nil, webauthnRegistrationId: Self.ID) {
+        public init(
+            domain: String,
+            authenticatorType: String? = nil,
+            name: String? = nil,
+            userAgent: String,
+            verified: Bool,
+            webauthnRegistrationId: Self.ID
+        ) {
             self.domain = domain
+            self.authenticatorType = authenticatorType
+            self.name = name
             self.userAgent = userAgent
             self.verified = verified
-            self.name = name
             self.webauthnRegistrationId = webauthnRegistrationId
         }
 
         public static func == (lhs: Self, rhs: Self) -> Bool {
             lhs.domain == rhs.domain &&
+                lhs.authenticatorType == rhs.authenticatorType &&
+                lhs.name == rhs.name &&
                 lhs.userAgent == rhs.userAgent &&
                 lhs.verified == rhs.verified &&
-                lhs.name == rhs.name &&
                 lhs.webauthnRegistrationId == rhs.webauthnRegistrationId
         }
     }

--- a/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
+++ b/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
@@ -320,24 +320,11 @@ extension StytchClient.Passkeys {
 }
 
 public struct PasskeysUpdateResponseData: Codable, Sendable {
-    private enum CodingKeys: CodingKey {
-        case webauthnRegistrationId
-    }
+    /// The updated WebAuthN registration.
+    public let webauthnRegistration: User.WebAuthNRegistration
 
-    let webauthnRegistrationId: User.WebAuthNRegistration.ID
-
-    init(webauthnRegistrationId: User.WebAuthNRegistration.ID) {
-        self.webauthnRegistrationId = webauthnRegistrationId
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        webauthnRegistrationId = try container.decode(key: .webauthnRegistrationId)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(webauthnRegistrationId, forKey: .webauthnRegistrationId)
+    init(webauthnRegistration: User.WebAuthNRegistration) {
+        self.webauthnRegistration = webauthnRegistration
     }
 }
 

--- a/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
+++ b/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
@@ -21,7 +21,7 @@ public extension StytchClient {
         // If we use webauthn current web-backend implementation, this will only be allowed as a secondary factor, and mfa will be required
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
         /// Registers a passkey with the device and with Stytch's servers for the authenticated user.
-        public func register(parameters: RegisterParameters) async throws -> BasicResponse {
+        public func register(parameters: RegisterParameters) async throws -> RegisterResponse {
             let startResp: Response<RegisterStartResponseData> = try await router.post(
                 to: .registerStart,
                 parameters: parameters
@@ -36,7 +36,7 @@ public extension StytchClient {
 
             guard let attestationObject = credential.rawAttestationObject else { throw StytchSDKError.missingAttestationObject }
 
-            let response: BasicResponse = try await router.post(
+            let response: RegisterResponse = try await router.post(
                 to: .register,
                 parameters: Credential<AttestationResponse>(
                     id: credential.credentialID,
@@ -111,6 +111,8 @@ public extension StytchClient {
 
 @available(macOS 12.0, iOS 16.0, tvOS 16.0, *)
 public extension StytchClient.Passkeys {
+    typealias RegisterResponse = Response<RegisterResponseData>
+
     /// A dedicated parameters type for passkeys `register` calls.
     struct RegisterParameters: Encodable, Sendable {
         let domain: String
@@ -121,6 +123,16 @@ public extension StytchClient.Passkeys {
         public init(domain: String) {
             self.domain = domain
         }
+    }
+
+    struct RegisterResponseData: Codable, Sendable, AuthenticateResponseDataType {
+        public let userId: User.ID
+        public let webauthnRegistrationId: User.WebAuthNRegistration.ID
+        public let user: User
+        public let sessionToken: String
+        public let sessionJwt: String
+        public let session: Session
+        public let userDevice: DeviceHistory?
     }
 
     /// A dedicated parameters type for passkeys `authenticate` calls.

--- a/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
+++ b/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
@@ -334,10 +334,6 @@ extension StytchClient.Passkeys {
 public struct PasskeysUpdateResponseData: Codable, Sendable {
     /// The updated WebAuthN registration.
     public let webauthnRegistration: User.WebAuthNRegistration
-
-    init(webauthnRegistration: User.WebAuthNRegistration) {
-        self.webauthnRegistration = webauthnRegistration
-    }
 }
 
 public struct PasskeysUpdateRequest: Codable, Sendable {

--- a/Tests/StytchCoreTests/PasskeysTestCase.swift
+++ b/Tests/StytchCoreTests/PasskeysTestCase.swift
@@ -10,15 +10,53 @@ final class PasskeysTestCase: BaseTestCase {
     private typealias Base = StytchClient.Passkeys
 
     func testRegister() async throws {
+        let userId: User.ID = "user_id_123"
+        let webauthnRegistrationId: User.WebAuthNRegistration.ID = "webauthn-registration-id"
         let startResponse: Base.RegisterStartResponseData = .init(
-            userId: "user_id_123",
+            userId: userId,
             challenge: try Current.cryptoClient.dataWithRandomBytesOfCount(32),
             user: StytchClient.Passkeys.PasskeysUser(displayName: "My Stytch Username")
         )
         networkInterceptor.responses {
             Success {
                 Response(requestId: "", statusCode: 200, wrapped: startResponse)
-                BasicResponse(requestId: "request_id_123", statusCode: 200)
+                Base.RegisterResponse(
+                    requestId: "request_id_123",
+                    statusCode: 200,
+                    wrapped: .init(
+                        userId: userId,
+                        webauthnRegistrationId: webauthnRegistrationId,
+                        user: .init(
+                            createdAt: Current.date(),
+                            cryptoWallets: [],
+                            emails: [],
+                            userId: userId,
+                            name: .init(firstName: "first", lastName: "last", middleName: nil),
+                            password: nil,
+                            phoneNumbers: [],
+                            providers: [],
+                            status: .active,
+                            totps: [],
+                            webauthnRegistrations: [
+                                .init(
+                                    domain: "something.blah.com",
+                                    authenticatorType: "platform",
+                                    name: "My device passkey",
+                                    userAgent: "iOS",
+                                    verified: true,
+                                    webauthnRegistrationId: webauthnRegistrationId
+                                ),
+                            ],
+                            biometricRegistrations: [],
+                            untrustedMetadata: nil,
+                            trustedMetadata: nil
+                        ),
+                        sessionToken: "hello_session",
+                        sessionJwt: "jwt_for_me",
+                        session: .mock(userId: userId),
+                        userDevice: nil
+                    )
+                )
             }
         }
         Current.passkeysClient.registerCredential = { _, _, _, _ in
@@ -28,7 +66,11 @@ final class PasskeysTestCase: BaseTestCase {
                 credentialID: .init("fake_id".utf8)
             )
         }
-        _ = try await StytchClient.passkeys.register(parameters: .init(domain: "something.blah.com"))
+        let response = try await StytchClient.passkeys.register(parameters: .init(domain: "something.blah.com"))
+        XCTAssertEqual(response.userId, userId)
+        XCTAssertEqual(response.webauthnRegistrationId, webauthnRegistrationId)
+        XCTAssertEqual(response.user.webauthnRegistrations.first?.authenticatorType, "platform")
+        XCTAssertEqual(response.user.webauthnRegistrations.first?.name, "My device passkey")
         try XCTAssertRequest(
             networkInterceptor.requests[0],
             urlString: "https://api.stytch.com/sdk/v1/webauthn/register/start",
@@ -150,9 +192,9 @@ extension PasskeysUpdateResponse {
             wrapped: .init(
                 webauthnRegistration: .init(
                     domain: "example.com",
+                    name: "Cool new name",
                     userAgent: "",
                     verified: true,
-                    name: "Cool new name",
                     webauthnRegistrationId: "webauthn-registration-id"
                 )
             )

--- a/Tests/StytchCoreTests/PasskeysTestCase.swift
+++ b/Tests/StytchCoreTests/PasskeysTestCase.swift
@@ -86,15 +86,43 @@ final class PasskeysTestCase: BaseTestCase {
     }
 
     func testRegisterWithNameOverrides() async throws {
+        let userId: User.ID = "user_id_123"
         let startResponse: Base.RegisterStartResponseData = .init(
-            userId: "user_id_123",
+            userId: userId,
             challenge: try Current.cryptoClient.dataWithRandomBytesOfCount(32),
             user: StytchClient.Passkeys.PasskeysUser(displayName: "user@example.com")
         )
         networkInterceptor.responses {
             Success {
                 Response(requestId: "", statusCode: 200, wrapped: startResponse)
-                BasicResponse(requestId: "request_id_123", statusCode: 200)
+                Base.RegisterResponse(
+                    requestId: "request_id_123",
+                    statusCode: 200,
+                    wrapped: .init(
+                        userId: userId,
+                        webauthnRegistrationId: "webauthn-registration-id",
+                        user: .init(
+                            createdAt: Current.date(),
+                            cryptoWallets: [],
+                            emails: [],
+                            userId: userId,
+                            name: .init(firstName: "first", lastName: "last", middleName: nil),
+                            password: nil,
+                            phoneNumbers: [],
+                            providers: [],
+                            status: .active,
+                            totps: [],
+                            webauthnRegistrations: [],
+                            biometricRegistrations: [],
+                            untrustedMetadata: nil,
+                            trustedMetadata: nil
+                        ),
+                        sessionToken: "hello_session",
+                        sessionJwt: "jwt_for_me",
+                        session: .mock(userId: userId),
+                        userDevice: nil
+                    )
+                )
             }
         }
         var registeredUsername: String?

--- a/Tests/StytchCoreTests/PasskeysTestCase.swift
+++ b/Tests/StytchCoreTests/PasskeysTestCase.swift
@@ -101,23 +101,44 @@ final class PasskeysTestCase: BaseTestCase {
     }
 
     func testUpdate() async throws {
-        let updateResponse: PasskeysUpdateResponseData = .init(
-            webauthnRegistrationId: "webauthn-registration-id"
-        )
         networkInterceptor.responses {
-            Response(requestId: "", statusCode: 200, wrapped: updateResponse)
             PasskeysUpdateResponse.mock
         }
         let parameters: Base.UpdateParameters = .init(
             id: "webauthn-registration-id",
             name: "Cool new name"
         )
-        _ = try await StytchClient.passkeys.update(parameters: parameters)
+        let response = try await StytchClient.passkeys.update(parameters: parameters)
         try XCTAssertRequest(
             networkInterceptor.requests[0],
             urlString: "https://api.stytch.com/sdk/v1/webauthn/update/webauthn-registration-id",
             method: .put(["name": "Cool new name"])
         )
+        XCTAssertEqual(response.wrapped.webauthnRegistration.name, "Cool new name")
+    }
+
+    // Pins the live response shape: the updated registration is returned nested
+    // under `webauthn_registration`, not as a top-level `webauthn_registration_id`.
+    func testUpdateResponseDecoding() throws {
+        let json = """
+        {
+            "request_id": "request-id-test-1234",
+            "status_code": 200,
+            "webauthn_registration": {
+                "authenticator_type": "",
+                "domain": "example.com",
+                "name": "My passkey",
+                "user_agent": "",
+                "verified": true,
+                "webauthn_registration_id": "webauthn-registration-id"
+            }
+        }
+        """
+        let response = try Current.jsonDecoder.decode(PasskeysUpdateResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(response.wrapped.webauthnRegistration.id, "webauthn-registration-id")
+        XCTAssertEqual(response.wrapped.webauthnRegistration.name, "My passkey")
+        XCTAssertEqual(response.wrapped.webauthnRegistration.domain, "example.com")
+        XCTAssertTrue(response.wrapped.webauthnRegistration.verified)
     }
 }
 
@@ -127,7 +148,13 @@ extension PasskeysUpdateResponse {
             requestId: "1234",
             statusCode: 200,
             wrapped: .init(
-                webauthnRegistrationId: "webauthn-registration-id"
+                webauthnRegistration: .init(
+                    domain: "example.com",
+                    userAgent: "",
+                    verified: true,
+                    name: "Cool new name",
+                    webauthnRegistrationId: "webauthn-registration-id"
+                )
             )
         )
     }


### PR DESCRIPTION
## Problem

The passkeys SDK models were out of sync with the live API in two places:

1. StytchClient.passkeys.update threw on successful calls because the response returns the updated registration nested under webauthn_registration, while PasskeysUpdateResponseData expected a top-level webauthn_registration_id.
2. StytchClient.passkeys.register was typed as BasicResponse, even though the API returns a richer authentication payload including the user, session, and device details. The nested User.WebAuthNRegistration model also did not expose newer fields like authenticator_type and name.

Observed successful update response shape:

~~~json
{
  "data": {
    "request_id": "...",
    "status_code": 200,
    "webauthn_registration": {
      "authenticator_type": "",
      "domain": "example.com",
      "name": "My passkey",
      "user_agent": "",
      "verified": true,
      "webauthn_registration_id": "webauthn-registration-..."
    }
  }
}
~~~

## Fix

- PasskeysUpdateResponseData now models and publicly exposes the nested webauthnRegistration object returned by the update endpoint.
- StytchClient.passkeys.register now returns a dedicated RegisterResponse wrapping the richer authentication payload instead of BasicResponse.
- User.WebAuthNRegistration now exposes optional authenticatorType and name fields so those values are decoded when present.
- The generated async/register variants and passkeys tests were updated to match the new response shape.

## Testing

- Added coverage for decoding the live nested update response shape in testUpdateResponseDecoding.
- Updated register-path assertions in PasskeysTestCase to validate the richer register response and nested WebAuthn registration fields.
- Ran:
  - xcodebuild test -project Stytch/Stytch.xcodeproj -scheme StytchCoreTests -destination 'platform=macOS' -only-testing:StytchCoreTests/PasskeysTestCase

Note: I used the Xcode test target for verification because the repo's SwiftPM path is currently blocked by an unrelated existing package/platform mismatch.
