### PR TITLE
ci: use depot macOS runners

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   analyze-stytch-core:
     name: Analyze (swift-StytchCore)
-    runs-on: osx
+    runs-on: depot-macos-15
     timeout-minutes: 120
     permissions:
       security-events: write
@@ -58,7 +58,7 @@ jobs:
 
   analyze-stytch-ui:
     name: Analyze (swift-StytchUI)
-    runs-on: osx
+    runs-on: depot-macos-15
     timeout-minutes: 120
     permissions:
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   analyze-stytch-core:
     name: Analyze (swift-StytchCore)
-    runs-on: macos-latest
+    runs-on: depot-macos-15
     timeout-minutes: 120
     permissions:
       security-events: write
@@ -58,7 +58,7 @@ jobs:
 
   analyze-stytch-ui:
     name: Analyze (swift-StytchUI)
-    runs-on: macos-latest
+    runs-on: depot-macos-15
     timeout-minutes: 120
     permissions:
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   analyze-stytch-core:
     name: Analyze (swift-StytchCore)
-    runs-on: depot-macos-15
+    runs-on: osx
     timeout-minutes: 120
     permissions:
       security-events: write
@@ -58,7 +58,7 @@ jobs:
 
   analyze-stytch-ui:
     name: Analyze (swift-StytchUI)
-    runs-on: depot-macos-15
+    runs-on: osx
     timeout-minutes: 120
     permissions:
       security-events: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
           echo "matrix={\"include\":[${matrix_values}]}" >> $GITHUB_OUTPUT
 
   generate-docs:
-    runs-on: depot-macos-15
+    runs-on: osx
 
     needs: set-matrix
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
           echo "matrix={\"include\":[${matrix_values}]}" >> $GITHUB_OUTPUT
 
   generate-docs:
-    runs-on: osx
+    runs-on: depot-macos-15
 
     needs: set-matrix
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
           echo "matrix={\"include\":[${matrix_values}]}" >> $GITHUB_OUTPUT
 
   generate-docs:
-    runs-on: macos-15
+    runs-on: depot-macos-15
 
     needs: set-matrix
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           echo "matrix={\"include\":[${matrix_values}]}" >> $GITHUB_OUTPUT
 
   test:
-    runs-on: osx
+    runs-on: depot-macos-15
 
     needs: set-matrix
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           echo "matrix={\"include\":[${matrix_values}]}" >> $GITHUB_OUTPUT
 
   test:
-    runs-on: depot-macos-15
+    runs-on: osx
 
     needs: set-matrix
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           echo "matrix={\"include\":[${matrix_values}]}" >> $GITHUB_OUTPUT
 
   test:
-    runs-on: macos-15
+    runs-on: depot-macos-15
 
     needs: set-matrix
 


### PR DESCRIPTION
## Summary
- Replaces `macos-15` and `macos-latest` GitHub-hosted runners with `depot-macos-15` in all three macOS workflow jobs
- Affects `test.yml`, `docs.yml`, and `codeql.yml`
- No token/action setup needed — depot runners are configured at the org level for `stytchauth`

## Test plan
- [ ] Verify CI jobs pick up depot runners on this PR