### PR TITLE
Return the raw attestation object from passkeys register

### DIFF
--- a/Sources/StytchCore/Generated/StytchClient.Passkeys.register+AsyncVariants.generated.swift
+++ b/Sources/StytchCore/Generated/StytchClient.Passkeys.register+AsyncVariants.generated.swift
@@ -6,8 +6,8 @@ import Foundation
 #if !os(watchOS)
 @available(macOS 12.0, iOS 16.0, tvOS 16.0, *)
 public extension StytchClient.Passkeys {
-    /// Registers a passkey with the device and with Stytch's servers for the authenticated user.
-    func register(parameters: RegisterParameters, completion: @escaping Completion<BasicResponse>) {
+    /// Registers a passkey with the device and with Stytch's servers for the authenticated user. Alongside the Stytch response, returns the ceremony's raw CBOR attestation object, whose attested credential data (e.g. the AAGUID identifying the passkey provider) exists only at registration time and is not stored by Stytch — callers may parse it to power passkey-management UIs.
+    func register(parameters: RegisterParameters, completion: @escaping Completion<(response: BasicResponse, attestationObject: Data)>) {
         Task {
             do {
                 completion(.success(try await register(parameters: parameters)))
@@ -17,8 +17,8 @@ public extension StytchClient.Passkeys {
         }
     }
 
-    /// Registers a passkey with the device and with Stytch's servers for the authenticated user.
-    func register(parameters: RegisterParameters) -> AnyPublisher<BasicResponse, Error> {
+    /// Registers a passkey with the device and with Stytch's servers for the authenticated user. Alongside the Stytch response, returns the ceremony's raw CBOR attestation object, whose attested credential data (e.g. the AAGUID identifying the passkey provider) exists only at registration time and is not stored by Stytch — callers may parse it to power passkey-management UIs.
+    func register(parameters: RegisterParameters) -> AnyPublisher<(response: BasicResponse, attestationObject: Data), Error> {
         return Deferred {
             Future({ promise in
                 Task {

--- a/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
+++ b/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
@@ -20,8 +20,8 @@ public extension StytchClient {
 
         // If we use webauthn current web-backend implementation, this will only be allowed as a secondary factor, and mfa will be required
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)
-        /// Registers a passkey with the device and with Stytch's servers for the authenticated user.
-        public func register(parameters: RegisterParameters) async throws -> BasicResponse {
+        /// Registers a passkey with the device and with Stytch's servers for the authenticated user. Alongside the Stytch response, returns the ceremony's raw CBOR attestation object, whose attested credential data (e.g. the AAGUID identifying the passkey provider) exists only at registration time and is not stored by Stytch — callers may parse it to power passkey-management UIs.
+        public func register(parameters: RegisterParameters) async throws -> (response: BasicResponse, attestationObject: Data) {
             let startResp: Response<RegisterStartResponseData> = try await router.post(
                 to: .registerStart,
                 parameters: parameters
@@ -47,7 +47,7 @@ public extension StytchClient {
                     )
                 ).wrapped()
             )
-            return response
+            return (response, attestationObject)
         }
 
         // sourcery: AsyncVariants, (NOTE: - must use /// doc comment styling)

--- a/Tests/StytchCoreTests/PasskeysTestCase.swift
+++ b/Tests/StytchCoreTests/PasskeysTestCase.swift
@@ -28,7 +28,8 @@ final class PasskeysTestCase: BaseTestCase {
                 credentialID: .init("fake_id".utf8)
             )
         }
-        _ = try await StytchClient.passkeys.register(parameters: .init(domain: "something.blah.com"))
+        let (_, attestationObject) = try await StytchClient.passkeys.register(parameters: .init(domain: "something.blah.com"))
+        XCTAssertEqual(attestationObject, Data("fake_attestation_data".utf8))
         try XCTAssertRequest(
             networkInterceptor.requests[0],
             urlString: "https://api.stytch.com/sdk/v1/webauthn/register/start",


### PR DESCRIPTION
## Motivation

Relying parties increasingly want to show users *where each passkey is stored* — "Apple Passwords", "1Password", "Google Password Manager" — in account-management UIs. Without that, users with multiple passkeys are guessing which is which, and the generic names that result are an industry-wide complaint.

The structured signal for this is the **AAGUID**: a 16-byte identifier of the credential manager, embedded in the *attested credential data* of the WebAuthn attestation object. The major passkey providers deliberately populate it (even with `none` attestation) precisely so apps can label credentials, and there's a community-maintained AAGUID → provider-name/icon mapping that GitHub and others use for exactly this.

Two properties make this a registration-time-only concern:

1. **The protocol only sends it once.** Attested credential data is present in the registration ceremony's authenticator data; sign-in assertions never include it (the AT flag is unset).
2. **Stytch doesn't store it.** The WebAuthn registration object exposes `domain`, `user_agent`, `authenticator_type`, `name`, `verified` — no AAGUID, and no way to retrieve the original attestation later.

Today the SDK receives the attestation object during `StytchClient.passkeys.register`, POSTs it to Stytch, and discards it — so the one moment this data exists is invisible to callers.

## Changes:

1. `register` now returns the raw attestation object alongside the response: `(response: BasicResponse, attestationObject: Data)`. It's the same value the SDK already holds from `credential.rawAttestationObject`; nothing changes on the wire or in the ceremony.
2. Sourcery async variants regenerated; `testRegister` asserts the passthrough.

Net diff is 9 lines across 3 files.

## Why raw, rather than parsed?

We considered the deeper version: parse the CBOR in the SDK and expose `aaguid`/backup-state fields, or go further and bundle the community AAGUID list so the SDK returns provider names directly. We deliberately kept this PR to the raw bytes:

- Returning the data **takes no opinion** — callers decide whether they want the AAGUID, the BE/BS backup flags, extensions, or nothing. That matches the SDK's general ethos of exposing the underlying information and letting the caller decide what to do with it.
- Bundling the community mapping would make SDK releases the refresh cadence for third-party display data that goes stale as new providers ship — a maintenance commitment that doesn't belong in an auth SDK.
- Parsing is a reasonable middle ground (spec-stable, no data file) — we're happy to follow up with an optional `aaguid`/backup-flags convenience if maintainers would take it, but it shouldn't gate the raw exposure.

## Real-world validation

We (Augment) run this change in production via our fork: parse the attestation object client-side (AAGUID at authenticator-data offset 37 per WebAuthn §6.1), resolve it against the community list, and immediately rename the passkey via `passkeys.update` — e.g. **"Apple Passwords — Jul 17, 2026"** — giving users a passkey list that says where each credential lives. Verified end-to-end with real Apple Passwords registrations on device.

## Note on API shape

As written this changes `register`'s return type, which is source-breaking for existing callers. If you'd prefer a non-breaking shape (an additive overload, or a field on a response wrapper), we're glad to rework it — the essential ask is just: don't discard the attestation object.

## Web parity

The JavaScript SDK's `webauthn.register` appears to have the same gap — the headless response carries only the registration ids, not the attestation response (callers driving `navigator.credentials.create()` themselves notwithstanding). For relying parties to build consistent passkey-management UIs across platforms, the JS SDK would need the equivalent change.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A — *running in production in our app via our fork; verified with real Apple Passwords registrations*
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A — *N/A*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
