### PR TITLE
Honor excludeCredentials during passkey registration

### DIFF
--- a/Sources/StytchCore/PasskeysClient/PasskeysClient+Live.swift
+++ b/Sources/StytchCore/PasskeysClient/PasskeysClient+Live.swift
@@ -4,7 +4,7 @@ import AuthenticationServices
 @available(macOS 12.0, iOS 16.0, tvOS 16.0, *)
 extension PasskeysClient {
     static let live: Self = .init(
-        registerCredential: { domain, challenge, username, userId in
+        registerCredential: { domain, challenge, username, userId, excludedCredentialIds in
             let platformProvider: ASAuthorizationPlatformPublicKeyCredentialProvider = .init(relyingPartyIdentifier: domain)
 
             let request = platformProvider.createCredentialRegistrationRequest(
@@ -13,16 +13,39 @@ extension PasskeysClient {
                 userID: .init(userId.rawValue.utf8) // WebAuthN backend currently relies on session auth, so isn't a pending user id
             )
 
+            #if !os(tvOS)
+            // Honoring excludeCredentials prevents re-registering a credential this user already holds — without it,
+            // the platform authenticator silently replaces the local passkey (same rpId + user handle) while the
+            // server accumulates orphaned webauthn registrations.
+            if #available(iOS 17.4, macCatalyst 16.6, macOS 13.5, *), !excludedCredentialIds.isEmpty {
+                request.excludedCredentials = excludedCredentialIds.map { credentialId in
+                    ASAuthorizationPlatformPublicKeyCredentialDescriptor(credentialID: credentialId)
+                }
+            }
+            #endif
+
             let controller = ASAuthorizationController(authorizationRequests: [request])
             let delegate = await Delegate()
             controller.delegate = delegate
             // controller.presentationContextProvider = parameters.presentationContextProvider // TODO: consider passing this in as optional param
 
-            let credential: ASAuthorizationCredential = try await withCheckedThrowingContinuation { continuation in
-                Task { @MainActor in
-                    delegate.continuation = continuation
-                    controller.performRequests()
+            let credential: ASAuthorizationCredential
+            do {
+                credential = try await withCheckedThrowingContinuation { continuation in
+                    Task { @MainActor in
+                        delegate.continuation = continuation
+                        controller.performRequests()
+                    }
                 }
+            } catch {
+                #if !os(tvOS)
+                if #available(iOS 18.0, macOS 15.0, *),
+                   let authorizationError = error as? ASAuthorizationError,
+                   authorizationError.code == .matchedExcludedCredential {
+                    throw StytchSDKError.passkeyAlreadyRegistered
+                }
+                #endif
+                throw error
             }
 
             guard let credential = credential as? ASAuthorizationPublicKeyCredentialRegistration else {

--- a/Sources/StytchCore/PasskeysClient/PasskeysClient.swift
+++ b/Sources/StytchCore/PasskeysClient/PasskeysClient.swift
@@ -3,11 +3,11 @@ import AuthenticationServices
 #if !os(watchOS)
 @available(macOS 12.0, iOS 16.0, tvOS 16.0, *)
 struct PasskeysClient {
-    var registerCredential: (String, Data, String, User.ID) async throws -> ASAuthorizationPublicKeyCredentialRegistration
+    var registerCredential: (String, Data, String, User.ID, [Data]) async throws -> ASAuthorizationPublicKeyCredentialRegistration
     var assertCredential: (String, Data, StytchClient.Passkeys.AuthenticateParameters.RequestBehavior) async throws -> ASAuthorizationPublicKeyCredentialAssertion
 
-    func registerCredential(domain: String, challenge: Data, username: String, userId: User.ID) async throws -> ASAuthorizationPublicKeyCredentialRegistration {
-        try await registerCredential(domain, challenge, username, userId)
+    func registerCredential(domain: String, challenge: Data, username: String, userId: User.ID, excludedCredentialIds: [Data]) async throws -> ASAuthorizationPublicKeyCredentialRegistration {
+        try await registerCredential(domain, challenge, username, userId, excludedCredentialIds)
     }
 
     func assertCredential(

--- a/Sources/StytchCore/SharedModels/Errors/StytchSDKError.swift
+++ b/Sources/StytchCore/SharedModels/Errors/StytchSDKError.swift
@@ -93,6 +93,12 @@ public extension StytchSDKError {
             errorType: "passkeys_unsupported"
         )
     )
+    static let passkeyAlreadyRegistered = StytchSDKError(
+        message: "A passkey for this user already exists on this device.",
+        options: .init(
+            errorType: "passkey_already_registered"
+        )
+    )
     static let randomNumberGenerationFailed = StytchSDKError(
         message: "System unable to generate a random data. Typically used for PKCE.",
         options: .init(

--- a/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
+++ b/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
@@ -31,7 +31,8 @@ public extension StytchClient {
                 domain: parameters.domain,
                 challenge: startResp.challenge,
                 username: startResp.user.displayName,
-                userId: startResp.userId
+                userId: startResp.userId,
+                excludedCredentialIds: startResp.excludeCredentialIds
             )
 
             guard let attestationObject = credential.rawAttestationObject else { throw StytchSDKError.missingAttestationObject }
@@ -210,14 +211,17 @@ extension StytchClient.Passkeys {
         enum CodingKeys: CodingKey {
             case challenge
             case user
+            case excludeCredentials
         }
 
         let challenge: Data
         let user: PasskeysUser
+        let excludeCredentials: [CredentialDescriptor]
 
-        init(challenge: Data, user: PasskeysUser) {
+        init(challenge: Data, user: PasskeysUser, excludeCredentials: [CredentialDescriptor]) {
             self.challenge = challenge
             self.user = user
+            self.excludeCredentials = excludeCredentials
         }
 
         init(from decoder: Decoder) throws {
@@ -231,12 +235,50 @@ extension StytchClient.Passkeys {
             }
 
             self.challenge = challenge
+
+            let descriptors: [CredentialDescriptor]? = try container.optionalDecode(key: .excludeCredentials)
+            if let descriptors = descriptors {
+                excludeCredentials = descriptors
+            } else {
+                excludeCredentials = []
+            }
         }
 
         func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(challenge.base64UrlEncoded(), forKey: .challenge)
             try container.encode(user, forKey: .user)
+            try container.encode(excludeCredentials, forKey: .excludeCredentials)
+        }
+    }
+
+    private struct CredentialDescriptor: Codable, Sendable {
+        enum CodingKeys: CodingKey {
+            case type
+            case id
+        }
+
+        let id: Data
+
+        init(id: Data) {
+            self.id = id
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let idString: String = try container.decode(key: .id)
+
+            guard let id: Data = .init(base64UrlEncoded: idString) else {
+                throw DecodingError.dataCorruptedError(forKey: .id, in: container, debugDescription: "credential id not base64 url encoded")
+            }
+
+            self.id = id
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("public-key", forKey: .type)
+            try container.encode(id.base64UrlEncoded(), forKey: .id)
         }
     }
 
@@ -277,11 +319,13 @@ extension StytchClient.Passkeys {
         let userId: User.ID
         let challenge: Data
         let user: PasskeysUser
+        let excludeCredentialIds: [Data]
 
-        init(userId: User.ID, challenge: Data, user: PasskeysUser) {
+        init(userId: User.ID, challenge: Data, user: PasskeysUser, excludeCredentialIds: [Data] = []) {
             self.userId = userId
             self.challenge = challenge
             self.user = user
+            self.excludeCredentialIds = excludeCredentialIds
         }
 
         init(from decoder: Decoder) throws {
@@ -291,12 +335,14 @@ extension StytchClient.Passkeys {
             let options = try JSONDecoder().decode(CredentialCreationOptions.self, from: Data(optionsString.utf8))
             challenge = options.challenge
             user = options.user
+            excludeCredentialIds = options.excludeCredentials.map(\.id)
         }
 
         func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(userId, forKey: .userId)
-            let credentialOptions = try JSONEncoder().encode(CredentialCreationOptions(challenge: challenge, user: user))
+            let excludeCredentials = excludeCredentialIds.map(CredentialDescriptor.init(id:))
+            let credentialOptions = try JSONEncoder().encode(CredentialCreationOptions(challenge: challenge, user: user, excludeCredentials: excludeCredentials))
             try container.encode(String(data: credentialOptions, encoding: .utf8), forKey: .publicKeyCredentialCreationOptions)
         }
     }

--- a/Tests/StytchCoreTests/PasskeysTestCase.swift
+++ b/Tests/StytchCoreTests/PasskeysTestCase.swift
@@ -10,10 +10,12 @@ final class PasskeysTestCase: BaseTestCase {
     private typealias Base = StytchClient.Passkeys
 
     func testRegister() async throws {
+        let existingCredentialId = Data("existing_credential_id".utf8)
         let startResponse: Base.RegisterStartResponseData = .init(
             userId: "user_id_123",
             challenge: try Current.cryptoClient.dataWithRandomBytesOfCount(32),
-            user: StytchClient.Passkeys.PasskeysUser(displayName: "My Stytch Username")
+            user: StytchClient.Passkeys.PasskeysUser(displayName: "My Stytch Username"),
+            excludeCredentialIds: [existingCredentialId]
         )
         networkInterceptor.responses {
             Success {
@@ -21,14 +23,17 @@ final class PasskeysTestCase: BaseTestCase {
                 BasicResponse(requestId: "request_id_123", statusCode: 200)
             }
         }
-        Current.passkeysClient.registerCredential = { _, _, _, _ in
-            MockRegistration(
+        var receivedExcludedCredentialIds: [Data]?
+        Current.passkeysClient.registerCredential = { _, _, _, _, excludedCredentialIds in
+            receivedExcludedCredentialIds = excludedCredentialIds
+            return MockRegistration(
                 rawAttestationObject: .init("fake_attestation_data".utf8),
                 rawClientDataJSON: .init("fake_json".utf8),
                 credentialID: .init("fake_id".utf8)
             )
         }
         _ = try await StytchClient.passkeys.register(parameters: .init(domain: "something.blah.com"))
+        XCTAssertEqual(receivedExcludedCredentialIds, [existingCredentialId])
         try XCTAssertRequest(
             networkInterceptor.requests[0],
             urlString: "https://api.stytch.com/sdk/v1/webauthn/register/start",
@@ -56,7 +61,7 @@ final class PasskeysTestCase: BaseTestCase {
             }
         }
         var registeredUsername: String?
-        Current.passkeysClient.registerCredential = { _, _, username, _ in
+        Current.passkeysClient.registerCredential = { _, _, username, _, _ in
             registeredUsername = username
             return MockRegistration(
                 rawAttestationObject: .init("fake_attestation_data".utf8),
@@ -82,6 +87,32 @@ final class PasskeysTestCase: BaseTestCase {
                 "override_display_name": "user@example.com",
             ])
         )
+    }
+
+    // Pins the live response shape: `excludeCredentials` lives inside the JSON-string
+    // `public_key_credential_creation_options`, and the server encodes credential ids
+    // as padded standard base64 (unlike the base64url challenge).
+    func testRegisterStartResponseDecodesExcludeCredentials() throws {
+        let json = """
+        {
+            "user_id": "user-test-1234",
+            "public_key_credential_creation_options": "{\\"challenge\\":\\"KeCOE4Yt-JRCCTKqLHQL4pEIYvHThIB8fa65OuOFRFDD\\",\\"excludeCredentials\\":[{\\"id\\":\\"OddU8QGULlaQC9nCup3ZIYpaJOk=\\",\\"type\\":\\"public-key\\"}],\\"user\\":{\\"displayName\\":\\"user@example.com\\",\\"id\\":\\"dXNlcg==\\",\\"name\\":\\"user@example.com\\"}}"
+        }
+        """
+        let response = try Current.jsonDecoder.decode(Base.RegisterStartResponseData.self, from: Data(json.utf8))
+        XCTAssertEqual(response.excludeCredentialIds, [Data(base64Encoded: "OddU8QGULlaQC9nCup3ZIYpaJOk=")])
+    }
+
+    // The server omits `excludeCredentials` when the user has no existing registrations.
+    func testRegisterStartResponseDecodesMissingExcludeCredentials() throws {
+        let json = """
+        {
+            "user_id": "user-test-1234",
+            "public_key_credential_creation_options": "{\\"challenge\\":\\"KeCOE4Yt-JRCCTKqLHQL4pEIYvHThIB8fa65OuOFRFDD\\",\\"user\\":{\\"displayName\\":\\"user@example.com\\",\\"id\\":\\"dXNlcg==\\",\\"name\\":\\"user@example.com\\"}}"
+        }
+        """
+        let response = try Current.jsonDecoder.decode(Base.RegisterStartResponseData.self, from: Data(json.utf8))
+        XCTAssertEqual(response.excludeCredentialIds, [])
     }
 
     func testAuthenticate() async throws {


### PR DESCRIPTION
## Problem

The `webauthn/register/start` response includes an `excludeCredentials` list inside `public_key_credential_creation_options`, but the SDK's custom decoder only extracted `challenge` and `user` — the exclusion list was silently dropped, and nothing was ever set on the registration request's `excludedCredentials`.

Because Apple's platform authenticator stores one passkey per (relying party ID, user handle) pair, every repeat `register()` call for the same user silently **replaces** the local passkey while the server mints a brand-new `webauthn_registration`. The result is a user object that accumulates orphaned registrations that can never authenticate again — credentials the web SDK correctly refuses to duplicate (browsers honor `excludeCredentials` and throw `InvalidStateError`).

## Changes

- Decode `excludeCredentials` from `public_key_credential_creation_options` in the register/start response, and thread the credential IDs through `PasskeysClient.registerCredential`. The existing base64url helper already tolerates the padded standard-base64 IDs the API returns.
- On iOS 17.4+ / macCatalyst 16.6+ / macOS 13.5+, set `excludedCredentials` on `ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest` so the authenticator refuses to overwrite an existing passkey. The API is unavailable on tvOS, so the code is compiled out there.
- On iOS 18+ / macOS 15+, map the resulting `ASAuthorizationError.matchedExcludedCredential` to a new `StytchSDKError.passkeyAlreadyRegistered` (`error_type: passkey_already_registered`) so callers can present a friendly "you already have a passkey" message.

On runtimes older than iOS 17.4 the platform API doesn't exist, so the previous behavior remains there.

## Testing

- `testRegister` now asserts the excluded credential IDs flow through to the authenticator request.
- New `testRegisterStartResponseDecodesExcludeCredentials` pins the live wire format (JSON-string options payload, padded standard-base64 credential ID).
- New `testRegisterStartResponseDecodesMissingExcludeCredentials` covers the field being omitted for users with no registrations.
- Full `StytchCoreTests` suite passes on the iOS simulator; `StytchCore` builds for macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)