### PR TITLE
Honor allowCredentials during passkey authentication

### DIFF
--- a/Sources/StytchCore/PasskeysClient/PasskeysClient+Live.swift
+++ b/Sources/StytchCore/PasskeysClient/PasskeysClient+Live.swift
@@ -31,10 +31,19 @@ extension PasskeysClient {
 
             return credential
         },
-        assertCredential: { domain, challenge, requestBehavior in
+        assertCredential: { domain, challenge, allowedCredentialIds, requestBehavior in
             let platformProvider: ASAuthorizationPlatformPublicKeyCredentialProvider = .init(relyingPartyIdentifier: domain)
 
             let request = platformProvider.createCredentialAssertionRequest(challenge: challenge)
+
+            // Honoring allowCredentials restricts the sheet to the credentials the server issued the
+            // challenge for — without it, a second-factor prompt offers every passkey on the device
+            // for this domain, including ones belonging to other accounts.
+            if !allowedCredentialIds.isEmpty {
+                request.allowedCredentials = allowedCredentialIds.map { credentialId in
+                    ASAuthorizationPlatformPublicKeyCredentialDescriptor(credentialID: credentialId)
+                }
+            }
 
             let controller = ASAuthorizationController(authorizationRequests: [request])
             let delegate = await Delegate()

--- a/Sources/StytchCore/PasskeysClient/PasskeysClient.swift
+++ b/Sources/StytchCore/PasskeysClient/PasskeysClient.swift
@@ -4,7 +4,7 @@ import AuthenticationServices
 @available(macOS 12.0, iOS 16.0, tvOS 16.0, *)
 struct PasskeysClient {
     var registerCredential: (String, Data, String, User.ID) async throws -> ASAuthorizationPublicKeyCredentialRegistration
-    var assertCredential: (String, Data, StytchClient.Passkeys.AuthenticateParameters.RequestBehavior) async throws -> ASAuthorizationPublicKeyCredentialAssertion
+    var assertCredential: (String, Data, [Data], StytchClient.Passkeys.AuthenticateParameters.RequestBehavior) async throws -> ASAuthorizationPublicKeyCredentialAssertion
 
     func registerCredential(domain: String, challenge: Data, username: String, userId: User.ID) async throws -> ASAuthorizationPublicKeyCredentialRegistration {
         try await registerCredential(domain, challenge, username, userId)
@@ -13,9 +13,10 @@ struct PasskeysClient {
     func assertCredential(
         domain: String,
         challenge: Data,
+        allowedCredentialIds: [Data],
         requestBehavior: StytchClient.Passkeys.AuthenticateParameters.RequestBehavior
     ) async throws -> ASAuthorizationPublicKeyCredentialAssertion {
-        try await assertCredential(domain, challenge, requestBehavior)
+        try await assertCredential(domain, challenge, allowedCredentialIds, requestBehavior)
     }
 }
 #endif

--- a/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
+++ b/Sources/StytchCore/StytchClient/Passkeys/StytchClient+Passkeys.swift
@@ -67,6 +67,7 @@ public extension StytchClient {
             let credential = try await passkeysClient.assertCredential(
                 domain: parameters.domain,
                 challenge: startResp.challenge,
+                allowedCredentialIds: startResp.allowCredentialIds,
                 requestBehavior: parameters.requestBehavior
             )
 
@@ -240,15 +241,48 @@ extension StytchClient.Passkeys {
         }
     }
 
+    private struct CredentialDescriptor: Codable, Sendable {
+        enum CodingKeys: CodingKey {
+            case type
+            case id
+        }
+
+        let id: Data
+
+        init(id: Data) {
+            self.id = id
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let idString: String = try container.decode(key: .id)
+
+            guard let id: Data = .init(base64UrlEncoded: idString) else {
+                throw DecodingError.dataCorruptedError(forKey: .id, in: container, debugDescription: "credential id not base64 url encoded")
+            }
+
+            self.id = id
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("public-key", forKey: .type)
+            try container.encode(id.base64UrlEncoded(), forKey: .id)
+        }
+    }
+
     private struct CredentialOptions: Codable, Sendable {
         enum CodingKeys: CodingKey {
             case challenge
+            case allowCredentials
         }
 
         let challenge: Data
+        let allowCredentials: [CredentialDescriptor]
 
-        init(challenge: Data) {
+        init(challenge: Data, allowCredentials: [CredentialDescriptor]) {
             self.challenge = challenge
+            self.allowCredentials = allowCredentials
         }
 
         init(from decoder: Decoder) throws {
@@ -260,11 +294,19 @@ extension StytchClient.Passkeys {
             }
 
             self.challenge = challenge
+
+            let descriptors: [CredentialDescriptor]? = try container.optionalDecode(key: .allowCredentials)
+            if let descriptors = descriptors {
+                allowCredentials = descriptors
+            } else {
+                allowCredentials = []
+            }
         }
 
         func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(challenge.base64UrlEncoded(), forKey: .challenge)
+            try container.encode(allowCredentials, forKey: .allowCredentials)
         }
     }
 
@@ -309,10 +351,12 @@ extension StytchClient.Passkeys {
 
         let userId: User.ID
         let challenge: Data
+        let allowCredentialIds: [Data]
 
-        init(userId: User.ID, challenge: Data) {
+        init(userId: User.ID, challenge: Data, allowCredentialIds: [Data] = []) {
             self.userId = userId
             self.challenge = challenge
+            self.allowCredentialIds = allowCredentialIds
         }
 
         init(from decoder: Decoder) throws {
@@ -321,12 +365,14 @@ extension StytchClient.Passkeys {
             let optionsString: String = try container.decode(key: .publicKeyCredentialRequestOptions)
             let options = try JSONDecoder().decode(CredentialOptions.self, from: Data(optionsString.utf8))
             challenge = options.challenge
+            allowCredentialIds = options.allowCredentials.map(\.id)
         }
 
         func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(userId, forKey: .userId)
-            let credentialOptions = try JSONEncoder().encode(CredentialOptions(challenge: challenge))
+            let allowCredentials = allowCredentialIds.map(CredentialDescriptor.init(id:))
+            let credentialOptions = try JSONEncoder().encode(CredentialOptions(challenge: challenge, allowCredentials: allowCredentials))
             try container.encode(String(data: credentialOptions, encoding: .utf8), forKey: .publicKeyCredentialRequestOptions)
         }
     }

--- a/Tests/StytchCoreTests/PasskeysTestCase.swift
+++ b/Tests/StytchCoreTests/PasskeysTestCase.swift
@@ -84,6 +84,32 @@ final class PasskeysTestCase: BaseTestCase {
         )
     }
 
+    // Pins the live response shape: `allowCredentials` lives inside the JSON-string
+    // `public_key_credential_request_options`, and the server encodes credential ids
+    // as padded standard base64 (unlike the base64url challenge).
+    func testAuthenticateStartResponseDecodesAllowCredentials() throws {
+        let json = """
+        {
+            "user_id": "user-test-1234",
+            "public_key_credential_request_options": "{\\"challenge\\":\\"KeCOE4Yt-JRCCTKqLHQL4pEIYvHThIB8fa65OuOFRFDD\\",\\"allowCredentials\\":[{\\"id\\":\\"OddU8QGULlaQC9nCup3ZIYpaJOk=\\",\\"type\\":\\"public-key\\"}]}"
+        }
+        """
+        let response = try Current.jsonDecoder.decode(Base.AuthenticateStartResponseData.self, from: Data(json.utf8))
+        XCTAssertEqual(response.allowCredentialIds, [Data(base64Encoded: "OddU8QGULlaQC9nCup3ZIYpaJOk=")])
+    }
+
+    // The server omits `allowCredentials` when the user isn't yet known (primary authentication).
+    func testAuthenticateStartResponseDecodesMissingAllowCredentials() throws {
+        let json = """
+        {
+            "user_id": "user-test-1234",
+            "public_key_credential_request_options": "{\\"challenge\\":\\"KeCOE4Yt-JRCCTKqLHQL4pEIYvHThIB8fa65OuOFRFDD\\"}"
+        }
+        """
+        let response = try Current.jsonDecoder.decode(Base.AuthenticateStartResponseData.self, from: Data(json.utf8))
+        XCTAssertEqual(response.allowCredentialIds, [])
+    }
+
     func testAuthenticate() async throws {
         let startResponse: Base.AuthenticateStartResponseData = .init(
             userId: "user_id_123",
@@ -95,7 +121,8 @@ final class PasskeysTestCase: BaseTestCase {
         }
         var requestBehaviorIsAutoFill = false
         var requestBehaviorIsPreferLocallyAvailableCredentials = false
-        Current.passkeysClient.assertCredential = { _, _, requestBehavior in
+        Current.passkeysClient.assertCredential = { _, _, allowedCredentialIds, requestBehavior in
+            XCTAssertEqual(allowedCredentialIds, [])
             #if os(iOS)
             if case .autoFill = requestBehavior {
                 requestBehaviorIsAutoFill = true


### PR DESCRIPTION
## Problem

The `webauthn/authenticate/start` response's `public_key_credential_request_options` includes an `allowCredentials` list when the user is known (e.g. the secondary/MFA route), but the SDK's `CredentialOptions` decoder only kept the challenge, so the list was silently dropped. The assertion request was then built without `allowedCredentials`, making it fully discoverable: the system sheet offers every passkey on the device for the RP domain. During second-factor authentication this lets a user pick a passkey belonging to a *different* account than the partially authenticated session, which then fails server-side (or worse, confuses users with multiple accounts on one device).

## Fix

- Decode `allowCredentials` (base64url credential ids) from `public_key_credential_request_options` in `AuthenticateStartResponseData`
- Thread the ids through `PasskeysClient.assertCredential`
- Set them as `allowedCredentials` on the `ASAuthorizationPlatformPublicKeyCredentialAssertionRequest` when non-empty

Primary (pre-identification) authentication is unaffected: the server has no user context there and omits `allowCredentials`, so the request stays fully discoverable, matching current behavior.

Includes decode-pinning tests for both the present and omitted `allowCredentials` cases (note the server encodes credential ids as padded standard base64, unlike the base64url challenge — the existing `Data(base64UrlEncoded:)` helper handles both).

We've been running this patch in our fork (augmentcorp/stytch-ios) and are upstreaming it as a courtesy.

---
*This pull request was prepared with AI assistance.*