### PR TITLE
Fix spurious session unavailable on offline/locked launch

### DIFF
--- a/Sources/StytchCore/KeychainClient/KeychainClientImplementation.swift
+++ b/Sources/StytchCore/KeychainClient/KeychainClientImplementation.swift
@@ -21,18 +21,16 @@ final class KeychainClientImplementation: KeychainClient {
             if let cachedEncryptionKey {
                 return cachedEncryptionKey
             }
-            #if os(iOS)
-            if UIApplication.shared.isProtectedDataAvailable {
-                try? getEncryptionKey()
-                didInitializeKeychainData = true
-            } else {
-                // For some reason, we are trying to read the encryption key before protected data became available
-                // Log that this happened (which it hopefully won't?), but leave the behavior up to the caller (EncryptedUserDefaultsClient) to handle a missing key (throw an error)
-                StytchConsoleLogger.error(message: "Attempted to read encryption key but UIApplication.shared.isProtectedDataAvailable was false")
-            }
-            #else
+            // Don't gate this on UIApplication.shared.isProtectedDataAvailable - it is a main-thread-only
+            // API and this getter runs on the keychain queue, where it can spuriously return false and
+            // leave the key unread even though the keychain is accessible. The keychain read itself is
+            // the reliable availability check: while protected data is unavailable, reading the key fails
+            // with errSecInteractionNotAllowed (it does not report the key as missing), so getEncryptionKey()
+            // throws instead of creating a replacement key.
             try? getEncryptionKey()
-            #endif
+            if cachedEncryptionKey != nil {
+                didInitializeKeychainData = true
+            }
             return cachedEncryptionKey
         })
     }
@@ -67,7 +65,7 @@ final class KeychainClientImplementation: KeychainClient {
         try safelyEnqueue {
             let result = try getFirstQueryResult(KeychainItem.encryptionKey)
             guard let result else {
-                // At this point, we know that protected data IS available, so if the keychain returned nil, then it means the key TRULY doesn't exist, and so we should create a new one
+                // A nil result means the keychain answered errSecItemNotFound - a locked keychain would have thrown errSecInteractionNotAllowed above - so the key TRULY doesn't exist and we should create a new one
                 let data = SymmetricKey(size: .bits256).withUnsafeBytes {
                     Data(Array($0))
                 }

--- a/Sources/StytchCore/ObjectStorage.swift
+++ b/Sources/StytchCore/ObjectStorage.swift
@@ -1,5 +1,8 @@
 import Combine
 import Foundation
+#if os(iOS)
+import UIKit
+#endif
 
 // swiftlint:disable type_contents_order let_var_whitespace
 
@@ -45,6 +48,7 @@ extension ObjectStorageWrapper {
 class ObjectStorage<WrapperType: ObjectStorageWrapper> {
     private let objectWrapper: WrapperType
     private var cancellable: AnyCancellable?
+    private var protectedDataCancellable: AnyCancellable?
 
     private let _onChange = PassthroughSubject<StytchObjectInfo<WrapperType.ObjectType>, Never>()
     var onChange: AnyPublisher<StytchObjectInfo<WrapperType.ObjectType>, Never> {
@@ -58,6 +62,16 @@ class ObjectStorage<WrapperType: ObjectStorageWrapper> {
         cancellable = StartupClient.isInitialized.first().sink { [weak self] _ in
             self?.publish()
         }
+
+        #if os(iOS)
+        // If the encryption key was unreadable at startup (locked keychain / prewarming), publish again
+        // once protected data becomes available so the cached object can be recovered.
+        protectedDataCancellable = NotificationCenter.default
+            .publisher(for: UIApplication.protectedDataDidBecomeAvailableNotification)
+            .sink { [weak self] _ in
+                self?.publish()
+            }
+        #endif
     }
 
     var object: WrapperType.ObjectType? {
@@ -85,7 +99,12 @@ class ObjectStorage<WrapperType: ObjectStorageWrapper> {
                 }
             }
         } catch let error as EncryptedUserDefaultsError {
-            if error == .noDataFound {
+            if error == .encryptionKeyNotAvailable {
+                // The encryption key is transiently unreadable (locked keychain / prewarming) but the cached
+                // object may still be fully intact, so don't report it as unavailable - consumers treat that
+                // as a logout signal. We publish again when protected data becomes available.
+                logExceptionalUnavailableCase(error: error)
+            } else if error == .noDataFound {
                 // if the underlying error was that no data could be found, check if we were _expecting_ there to be data
                 if objectWrapper.dataWasExpected {
                     // if it was expected to exist, send the error that was encountered. This is an exceptional .unavailable case


### PR DESCRIPTION
## Summary

Fixes users being spuriously treated as logged out when the app is launched while the keychain is briefly unreadable (e.g. offline cold launch shortly after boot, or launch while the device is locked). In that window the SDK reads the session cache, hits `encryptionKeyNotAvailable`, and publishes `.unavailable` — which consuming apps reasonably treat as a terminal logout.

## Root cause

Two compounding issues:

1. **`KeychainClientImplementation.encryptionKey`** gates the key read on `UIApplication.shared.isProtectedDataAvailable`. That is a main-thread-only API, and this getter runs on the keychain queue, where it can spuriously return `false` and skip the read even though the keychain is accessible.
2. **`ObjectStorage.publish()`** treats the resulting `encryptionKeyNotAvailable` as a terminal state and emits `.unavailable`, signaling "logged out" for what is a transient condition.

## Fix (no public API changes)

- **`KeychainClientImplementation.swift`**
  - Remove the off-main-thread `isProtectedDataAvailable` gate; rely on the keychain's own error status instead. A locked keychain throws `errSecInteractionNotAllowed` (surfaced as `unhandledError`) rather than "not found".
  - `getEncryptionKey()` now only creates a fresh key when the keychain explicitly returns `errSecItemNotFound`, so a locked keychain can never trigger accidental key rotation (preserves the protection from #601).
- **`ObjectStorage.swift`**
  - When a read fails with `encryptionKeyNotAvailable`, log and skip the publish instead of emitting `.unavailable` (unknown ≠ logged out).
  - Observe `UIApplication.protectedDataDidBecomeAvailableNotification` and re-publish once protected data becomes available, so consumers receive the real session state after unlock.

## Behavioral trade-off

An app launched while the keychain is genuinely locked receives no session emission until unlock (instead of a fast `.unavailable`). For session consumers this is the correct semantics — the state is unknown, not logged out.

## Testing

- StytchCore builds clean on top of current `main` and the StytchCore test suites pass.
- Verified end-to-end in a consuming app: an offline cold launch no longer logs the user out, and `sessionUnavailable — error: encryptionKeyNotAvailable` no longer appears in the console.
